### PR TITLE
Fix ReadMe mentions

### DIFF
--- a/reference/arbitrum-gettransactionreceipt.mdx
+++ b/reference/arbitrum-gettransactionreceipt.mdx
@@ -5,7 +5,7 @@ title: eth_getTransactionReceipt | Arbitrum
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/aurora-gettransactionreceipt.mdx
+++ b/reference/aurora-gettransactionreceipt.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/aurora_node_api/eth_getTransactionReceipt.json POST /6df1a1b30
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/avalanche-gettransactionreceipt.mdx
+++ b/reference/avalanche-gettransactionreceipt.mdx
@@ -7,7 +7,7 @@ openapi: /openapi/avalanche_node_api/transactions_info/eth_getTransactionReceipt
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/bnb-gettransactionreceipt.mdx
+++ b/reference/bnb-gettransactionreceipt.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/bnb_node_api/eth_getTransactionReceipt.json POST /35848e183f3e
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/ethereum-gettransactionreceipt.mdx
+++ b/reference/ethereum-gettransactionreceipt.mdx
@@ -5,7 +5,7 @@ title: eth_getTransactionReceipt | Ethereum
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/fantom-gettransactionreceipt.mdx
+++ b/reference/fantom-gettransactionreceipt.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/fantom_node_api/eth_getTransactionReceipt.json POST /4ab982aa7
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/getcommitteesbystateidepochindexandslot.mdx
+++ b/reference/getcommitteesbystateidepochindexandslot.mdx
@@ -7,7 +7,7 @@ openapi: /openapi/ethereum_beacon_chain_api/state/getCommitteesByStateIdEpochInd
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/gettransactionreceipt.mdx
+++ b/reference/gettransactionreceipt.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/cronos_node_api/eth_getTransactionReceipt.json POST /b9b0fb920
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/gnosis-gettransactionreceipt.mdx
+++ b/reference/gnosis-gettransactionreceipt.mdx
@@ -5,7 +5,7 @@ title: eth_getTransactionReceipt | Gnosis
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/polygon-gettransactionreceipt.mdx
+++ b/reference/polygon-gettransactionreceipt.mdx
@@ -5,7 +5,7 @@ title: eth_getTransactionReceipt | Polygon
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 

--- a/reference/zkevm-gettransactionreceipt.mdx
+++ b/reference/zkevm-gettransactionreceipt.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/polygon_zkevm_node_api/eth_getTransactionReceipt.json POST /94
 <Note>
 **No response in the interactive API**
 
-The response to the call might be too big for ReadMe to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
+The response to the call might be too big for the web app to handle, so if you are not getting it here, copy the CURL example and run in your terminal—this will work.
 </Note>
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated notes across multiple API documentation pages to clarify that large responses may be too big for the web app to handle, instead of specifically referencing "ReadMe". No other content changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->