### PR TITLE
Remove Merkle as MEV partner

### DIFF
--- a/docs/mev-protection.mdx
+++ b/docs/mev-protection.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MEV protection"
-description: "With  on, your mainnet transaction is redirected to the Blink Labs partner network that works directly with block builders. This approach bypasses the public mempool, helping protect against front-running attacks."
+description: "With MEV protection on, your mainnet transaction is redirected to the Blink Labs partner network that works directly with block builders. This approach bypasses the public mempool, helping protect against front-running attacks."
 ---
 
 This currently applies to:

--- a/docs/mev-protection.mdx
+++ b/docs/mev-protection.mdx
@@ -1,17 +1,11 @@
 ---
 title: "MEV protection"
-description: "With  on, your mainnet transaction is redirected to a partner network that works directly with block builders. This approach bypasses the public mempool, helping protect against front-running attacks."
+description: "With  on, your mainnet transaction is redirected to the Blink Labs partner network that works directly with block builders. This approach bypasses the public mempool, helping protect against front-running attacks."
 ---
 
 This currently applies to:
-<CardGroup>
-  <Card title="Ethereum mainnet" icon="angle-right" iconType="solid" horizontal>
-    Blink Labs as a partner
-  </Card>
-  <Card title="Binance Smart Chain" icon="angle-right" iconType="solid" horizontal>
-    Merkle as a partner
-  </Card>
-</CardGroup>
+* Ethereum mainnet
+* BNB Smart Chain mainnet
 
 ### How it works
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the description to specify "Blink Labs" as the partner network.
	- Simplified the supported networks section to a bulleted list, removing partner names and card visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->