### PR TITLE
Add a notification on mempool & pending txs to Avalanche API ref

### DIFF
--- a/reference/avalanche-native-subscribe-newheads.mdx
+++ b/reference/avalanche-native-subscribe-newheads.mdx
@@ -3,6 +3,8 @@ title: 'eth_subscribe ("newHeads") | Avalanche'
 description: "Avalanche API method allowing developers to receive real-time notifications regarding new block headers on the Avalanche blockchain; it sends notifications whenever a new block is added."
 ---
 
+Note that because the Avalanche mempool is [only accessible to validators](/docs/mempool-configuration), this method will only return transactions that were submitted through the same node you are connected to.
+
 <Check>
   ### Get you own node endpoint today
 

--- a/reference/avalanche-native-subscribe-newpendingtransactions.mdx
+++ b/reference/avalanche-native-subscribe-newpendingtransactions.mdx
@@ -3,6 +3,8 @@ title: 'eth_subscribe ("newPendingTransactions") | Avalanche'
 description: "Avalanche API method that allows developers to receive real-time notifications regarding new pending transactions on the Avalanche blockchain. The application will receive notifications whenever new pending transactions are identified."
 ---
 
+Note that because the Avalanche mempool is [only accessible to validators](/docs/mempool-configuration), this method will only return transactions that were submitted through the same node you are connected to.
+
 <Check>
   ### Get you own node endpoint today
 

--- a/reference/avalanche-newpendingtransactionfilter.mdx
+++ b/reference/avalanche-newpendingtransactionfilter.mdx
@@ -4,6 +4,8 @@ openapi: /openapi/avalanche_node_api/transactions_info/eth_newPendingTransaction
   POST /8763cb5a211e1d4345acd51bde484c00/ext/bc/C/rpc
 ---
 
+Note that because the Avalanche mempool is [only accessible to validators](/docs/mempool-configuration), this method will only return transactions that were submitted through the same node you are connected to.
+
 Avalanche API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the [eth\_getFilterChanges](/reference/avalanche-getfilterchanges) method. The `eth_newBlockFilter` method is useful for developers who must be notified of new blocks on the blockchain in real time.
 
 <Check>

--- a/reference/avalanche-subscribependingtransactions.mdx
+++ b/reference/avalanche-subscribependingtransactions.mdx
@@ -2,6 +2,8 @@
 title: 'subscribe ("pendingTransactions") | Avalanche'
 ---
 
+Note that because the Avalanche mempool is [only accessible to validators](/docs/mempool-configuration), this method will only return transactions that were submitted through the same node you are connected to.
+
 web3.js subscription equivalent to [eth\_newPendingTransactionFilter](/reference/avalanche-newpendingtransactionfilter). `subscribe("pendingTransactions")` allows developers to subscribe to real-time updates about pending transactions on the Avalanche blockchain; the application will receive notifications whenever a pending transaction appears on the blockchain.
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added clarifying notes to multiple Avalanche method references, explaining that mempool access is limited to validator nodes. As a result, subscription and filter methods for pending transactions and new heads will only return transactions submitted through the same node the client is connected to. This provides important context about transaction visibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->