### PR TITLE
Add concurrent filters to Solana Geyser

### DIFF
--- a/docs/yellowstone-grpc-geyser-plugin.mdx
+++ b/docs/yellowstone-grpc-geyser-plugin.mdx
@@ -46,6 +46,15 @@ $449/month:
 * 25 concurrent streams available per platform account
 * Up to 50 Solana accounts per stream
 
+Regardless of the plan: 5 concurrent filters of the same type in a single connection for all types:
+* `accounts`
+* `slots`
+* `transactions`
+* `transactions_status`
+* `blocks`
+* `blocks_meta`
+* `entries`
+
 Note that on a dedicated Solana node with Yellowstone gRPC Geyser plugin limit customization is available.
 
 The following Solana accounts are unavailable for streaming:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin documentation to clarify a new concurrency limit: a maximum of 5 concurrent filters of the same type can be used per connection, regardless of subscription plan. Applies to accounts, slots, transactions, transactions_status, blocks, blocks_meta, and entries filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->