### PR TITLE
Add release notes for Berachain – June 3, 2025

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,13 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 3, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Berachain Mainnet. See also [Berachain tooling](/docs/berachain-tooling) and a [tutorial](/docs/berachain-track-defi-flows).
+
+<Button href="/changelog/chainstack-updates-june-3-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: May 30, 2025" description=" by Ake" >
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Unichain Mainnet. See also [Unichain tooling](/docs/unichain-tooling) and a [tutorial](/docs/unichain-collecting-uniswapv4-eth-usdc-trades).

--- a/changelog/chainstack-updates-june-3-2025.mdx
+++ b/changelog/chainstack-updates-june-3-2025.mdx
@@ -1,0 +1,3 @@
+title: "Chainstack updates: June 3 , 2025"
+---
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Berachain Mainnet. See also [tooling](/docs/berachain-tooling) and a [tutorial](/docs/berachain-dapp-tutorial).

--- a/docs.json
+++ b/docs.json
@@ -2402,6 +2402,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-3-2025",
           "changelog/chainstack-updates-may-28-2025",
           "changelog/chainstack-updates-may-16-2025",
           "changelog/chainstack-updates-may-14-2025",


### PR DESCRIPTION
### Summary

- Added release notes for Berachain support on June 3, 2025
- Added new changelog entry file
- Updated changelog.mdx and docs.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new changelog entry for June 3, 2025, highlighting the ability to deploy Global Nodes for the Berachain Mainnet.
	- Included links to Berachain tooling documentation and a tutorial on tracking DeFi flows.
	- Updated the documentation to display this new release note in the Release notes section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->