### PR TITLE
docs: add release notes for Linea (June 9, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,13 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 9, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Linea Mainnet.
+
+<Button href="/changelog/chainstack-updates-june-9-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: June 3, 2025" description=" by Vladimir">
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Berachain Mainnet. See also [Berachain tooling](/docs/berachain-tooling) and a [tutorial](/docs/berachain-on-chain-data-quickstart-with-python).

--- a/changelog/chainstack-updates-june-9-2025.mdx
+++ b/changelog/chainstack-updates-june-9-2025.mdx
@@ -1,0 +1,4 @@
+---
+title: "Chainstack updates: June 9, 2025"
+---
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Linea Mainnet.

--- a/docs.json
+++ b/docs.json
@@ -2404,6 +2404,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-9-2025",
           "changelog/chainstack-updates-june-3-2025",
           "changelog/chainstack-updates-may-28-2025",
           "changelog/chainstack-updates-may-16-2025",


### PR DESCRIPTION
### Summary

Adds release notes for the support of Linea Mainnet on GEN as of June 9, 2025.

### Changes
- **changelog.mdx**: Added new entry with summary and button link.
- **changelog/chainstack-updates-june-9-2025.mdx**: New file with full content of the update.
- **docs.json**: Registered new release note page under `"Release notes"` tab.

### Verification
✅ Previewed locally with `mintlify dev`  
✅ Checked for broken links with `mint broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new changelog entry announcing support for deploying Global Nodes on the Linea Mainnet protocol.
  - Updated the release notes navigation to include the June 9, 2025 Chainstack update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->