### PR TITLE
Aurora deprecation relnotes

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,13 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 10, 2025" description=" by Ake" >
+
+**Protocols**. All Aurora nodes are now deprecated.
+
+<Button href="/changelog/chainstack-updates-june-10-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: June 9, 2025" description=" by Vladimir">
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Linea Mainnet.

--- a/changelog/chainstack-updates-june-10-2025.mdx
+++ b/changelog/chainstack-updates-june-10-2025.mdx
@@ -1,0 +1,4 @@
+---
+title: "Chainstack updates: June 10, 2025"
+---
+**Protocols**. All Aurora nodes are now deprecated.

--- a/docs.json
+++ b/docs.json
@@ -2338,6 +2338,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-10-2025",
           "changelog/chainstack-updates-june-9-2025",
           "changelog/chainstack-updates-june-3-2025",
           "changelog/chainstack-updates-may-28-2025",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new changelog entry for June 10, 2025, announcing the deprecation of all Aurora nodes.
	- Updated the release notes navigation to include the latest changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->