### PR TITLE
docs: add release notes for Mantle (June 10, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,7 +6,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: June 10, 2025" description=" by Ake" >
 
-**Protocols**. All Aurora nodes are now deprecated.
+**Protocols**. All Aurora nodes are now deprecated. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Mantle Mainnet.
 
 <Button href="/changelog/chainstack-updates-june-10-2025">Read more</Button>
 </Update>

--- a/changelog/chainstack-updates-june-10-2025.mdx
+++ b/changelog/chainstack-updates-june-10-2025.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Chainstack updates: June 10, 2025"
 ---
-**Protocols**. All Aurora nodes are now deprecated.
+**Protocols**. All Aurora nodes are now deprecated. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Mantle Mainnet.


### PR DESCRIPTION
### Summary

Adds release notes for the support of Global Nodes deployment on Mantle Mainnet as of June 10, 2025.

### Changes
- `changelog.mdx`: New top-level update entry
- `changelog/chainstack-updates-june-10-2025.mdx`: Full content
- `docs.json`: Entry added for new changelog file

✅ Verified locally with `mintlify dev`  
✅ Links passed via `mint broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to clarify that users can now deploy Global Nodes for Mantle Mainnet, in addition to the deprecation of all Aurora nodes. Added a link to relevant documentation for Mantle Mainnet deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->