### PR TITLE
docs: add release notes for Polkadot (June 11, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,15 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
+
+<Update label="Chainstack updates: June 11, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Polkadot Mainnet.
+
+<Button href="/changelog/chainstack-updates-june-11-2025">Read more</Button>
+</Update>
+
+
 <Update label="Chainstack updates: June 10, 2025" description=" by Ake" >
 
 **Protocols**:

--- a/changelog/chainstack-updates-june-11-2025.mdx
+++ b/changelog/chainstack-updates-june-11-2025.mdx
@@ -1,0 +1,5 @@
+---
+title: "Chainstack updates: June 11, 2025"
+---
+**Protocols**:
+* Polkadot — You can now deploy [Global Nodes](/docs/global-elastic-node) for Polkadot Mainnet. 

--- a/docs.json
+++ b/docs.json
@@ -2342,6 +2342,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-11-2025",
           "changelog/chainstack-updates-june-10-2025",
           "changelog/chainstack-updates-june-9-2025",
           "changelog/chainstack-updates-june-3-2025",


### PR DESCRIPTION
### Summary

Adds release notes for the support of Global Nodes deployment on Polkadot Mainnet as of June 11, 2025.

### Changes
- `changelog.mdx`: New top-level update entry
- `changelog/chainstack-updates-june-11-2025.mdx`: Full content
- `docs.json`: Entry added for new changelog file

✅ Verified locally with `mintlify dev`  
✅ Links passed via `mint broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new release note announcing support for deploying Global Nodes for the Polkadot Mainnet protocol.
- **Documentation**
	- Updated the release notes section to include the June 11, 2025 Chainstack update for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->