### PR TITLE
Add llms-full.txt to sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2533,6 +2533,11 @@
           "anchor": "llms.txt",
           "href": "https://docs.chainstack.com/llms.txt",
           "icon": "sparkle"
+        },
+        {
+          "anchor": "llms-full.txt",
+          "href": "https://docs.chainstack.com/llms-full.txt",
+          "icon": "brain"
         }
       ]
     }


### PR DESCRIPTION
I was testing o3-pro on docs and noticed that it does crawl llms.txt. So adding llms-full.txt to make it easier for LLM agents to notice and scrape.