### PR TITLE
docs: add release notes for Zora (June 12, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,14 @@ title: "Release notes"
 import { Button } from '/snippets/button.mdx';
 
 
+<Update label="Chainstack updates: June 12, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Zora Mainnet.
+
+<Button href="/changelog/chainstack-updates-june-12-2025">Read more</Button>
+</Update>
+
+
 <Update label="Chainstack updates: June 11, 2025" description=" by Vladimir">
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Polkadot Mainnet. See also [Polkadot tooling](/docs/polkadot-tooling) and a [tutorial](/docs/polkadot-network-health-monitoring).

--- a/changelog/chainstack-updates-june-12-2025.mdx
+++ b/changelog/chainstack-updates-june-12-2025.mdx
@@ -1,0 +1,4 @@
+---
+title: "Chainstack updates: June 12, 2025"
+---
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Zora Mainnet.

--- a/docs.json
+++ b/docs.json
@@ -2352,6 +2352,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-12-2025",
           "changelog/chainstack-updates-june-11-2025",
           "changelog/chainstack-updates-june-10-2025",
           "changelog/chainstack-updates-june-9-2025",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new changelog entry for June 12, 2025, announcing support for deploying Global Nodes on the Zora Mainnet protocol.
  - Updated the documentation navigation to include this new changelog entry with a direct link to detailed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->