### PR TITLE
Add MCP servers to docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -912,6 +912,15 @@
             ]
           },
           {
+            "group": "MCP servers",
+            "pages": [
+              "docs/mcp-servers-introduction",
+              "docs/developer-portal-mcp-server",
+              "docs/evm-mcp-server",
+              "docs/solana-mcp-server"
+            ]
+          },
+          {
             "group": "IPFS storage",
             "pages": [
               "docs/ipfs-storage-introduction",

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -1,0 +1,87 @@
+---
+title: "Developer Portal MCP server"
+description: "Access Chainstack's documentation and development resources through the Developer Portal MCP server"
+---
+
+# Developer Portal MCP server
+
+The **Developer Portal MCP server** is integrated with Chainstack's documentation platform powered by Mintlify. This MCP server provides AI models with comprehensive access to Chainstack's blockchain development resources, documentation, and guides.
+
+## Installation
+
+Install the Developer Portal MCP server using the Mintlify MCP CLI:
+
+```bash
+npx mint-mcp add chainstack
+```
+
+This command automatically configures the MCP server to work with your AI application, providing access to all of Chainstack's developer resources.
+
+## Capabilities
+
+The Developer Portal MCP server gives AI models access to:
+
+### Documentation, guides, and best practices
+- **Getting started guides** for all supported blockchain protocols
+- **Step-by-step tutorials** for common blockchain development tasks
+- **Best practices** for blockchain application development
+- **Integration examples** and code snippets
+
+### API references
+- **Complete API documentation** for all Chainstack services
+- **Method references** for supported blockchain protocols
+- **Request and response examples** for all API endpoints
+- **Authentication and authorization** guidelines
+
+### Protocol information
+- **Network configurations** for all supported blockchains
+- **Node types and modes** available on Chainstack
+- **Supported methods** for each blockchain protocol
+- **Regional availability** and performance characteristics
+
+### Tooling and development resources
+- **SDK documentation** and usage examples
+- **Development tools** and utilities
+- **Recipes** for common development tasks
+
+## Integration with AI models
+
+The Developer Portal MCP server seamlessly integrates with popular AI development environments:
+
+### Cursor
+Configure the server in your [Cursor settings](https://docs.cursor.com/context/model-context-protocol) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Desktop
+Configure the server in your [Claude Desktop settings](https://modelcontextprotocol.io/quickstart/user) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Code
+Configure the server in your [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/mcp) to access Chainstack's knowledge base directly within your conversations.
+
+### Custom AI applications
+Use the MCP protocol to integrate Chainstack's documentation into your own AI-powered development tools and assistants.
+
+## Benefits
+
+Using the Developer Portal MCP server provides several advantages:
+
+- **Up-to-date information**: Always access the latest Chainstack documentation and features
+- **Consistent guidance**: Receive answers based on official Chainstack best practices
+- **Comprehensive coverage**: Access information about all supported protocols and services
+- **Structured knowledge**: Benefit from professionally curated and organized content
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="EVM MCP server" href="/docs/evm-mcp-server">
+    Combine with live blockchain interactions
+  </Card>
+  <Card title="Solana MCP server" href="/docs/solana-mcp-server">
+    Add Solana blockchain capabilities
+  </Card>
+  <Card title="Mintlify MCP documentation" href="https://mintlify.com/docs/mcp" icon="external-link">
+    Learn more about MCP integration
+  </Card>
+  <Card title="Chainstack API documentation" href="/reference/blockchain-apis">
+    Explore available APIs and methods
+  </Card>
+</CardGroup> 

--- a/docs/evm-mcp-server.mdx
+++ b/docs/evm-mcp-server.mdx
@@ -1,0 +1,129 @@
+---
+title: "EVM MCP server"
+description: "Interact with Ethereum and EVM-compatible networks through the EVM MCP server"
+---
+
+# EVM MCP server
+
+The **EVM MCP server** is part of Chainstack's RPC Nodes MCP server suite, providing AI models with direct access to Ethereum and EVM-compatible blockchain networks. This server enables real-time blockchain interactions, smart contract calls, and comprehensive blockchain data queries.
+
+## Repository
+
+The EVM MCP server is available in the [chainstacklabs/rpc-nodes-mcp](https://github.com/chainstacklabs/rpc-nodes-mcp) repository, which contains both EVM and Solana blockchain interaction capabilities.
+
+## Supported networks
+
+The EVM MCP server supports all EVM-compatible networks available on Chainstack, including:
+
+- **Ethereum** (Mainnet, Sepolia, Holesky)
+- **Polygon** (Mainnet, Amoy testnet)
+- **BNB Smart Chain** (Mainnet, testnet)
+- **Arbitrum** (One, Sepolia)
+- **Optimism** (Mainnet, Sepolia)
+- **Base** (Mainnet, Sepolia)
+- **Avalanche** C-Chain
+- **And many more** EVM-compatible networks
+
+## Available functions
+
+The EVM MCP server provides comprehensive blockchain interaction capabilities:
+
+### Network information
+- **Get supported blockchains** - Retrieve list of available networks
+- **Get client version** - Check node client information
+- **Get network version** - Retrieve network ID
+- **Get chain ID** - Fetch the chain identifier
+
+### Block operations
+- **Get latest block number** - Retrieve current block height
+- **Get block by number/hash** - Fetch complete block information
+- **Get block transaction count** - Count transactions in a block
+- **Get block receipts** - Retrieve all transaction receipts for a block
+
+### Account and balance queries
+- **Get account balance** - Check ETH/native token balance
+- **Get transaction count** - Retrieve account nonce
+- **Get contract code** - Fetch smart contract bytecode
+- **Get storage values** - Read contract storage slots
+
+### Transaction operations
+- **Get transaction by hash** - Retrieve transaction details
+- **Get transaction receipt** - Fetch transaction execution results
+- **Estimate gas** - Calculate gas requirements for transactions
+- **Get gas price** - Retrieve current gas pricing
+- **Get fee history** - Analyze historical fee data
+
+### Smart contract interactions
+- **Call contract methods** - Execute read-only contract calls
+- **Simulate transactions** - Test transactions without execution
+- **Get event logs** - Query contract event emissions
+- **Get proofs** - Retrieve Merkle proofs for accounts and storage
+
+### Advanced features
+- **Debug transaction traces** - Detailed execution analysis
+- **Trace calls and blocks** - Comprehensive execution tracing
+- **State overrides** - Simulate with modified blockchain state
+- **Batch requests** - Execute multiple calls efficiently
+
+## Use cases
+
+The EVM MCP server enables AI applications to:
+
+### DeFi and trading analysis
+- **Monitor token balances** and portfolio values
+- **Track transaction flows** and trading patterns
+- **Analyze gas usage** and optimization opportunities
+- **Query DeFi protocol states** and liquidity metrics
+
+### Smart contract development
+- **Test contract interactions** before deployment
+- **Debug transaction failures** with detailed traces
+- **Simulate complex scenarios** with state overrides
+- **Validate contract behavior** across different conditions
+
+### Blockchain analytics
+- **Extract event data** from smart contracts
+- **Analyze block composition** and network activity
+- **Track address interactions** and transaction patterns
+- **Generate reports** on blockchain metrics
+
+### Real-time monitoring
+- **Watch for specific events** or transactions
+- **Monitor contract state changes** in real-time
+- **Track network congestion** and gas price trends
+- **Alert on important blockchain events**
+
+## Integration with AI models
+
+See the [RPC nodes MCP README file](https://github.com/chainstacklabs/rpc-nodes-mcp/blob/main/README.md) for more information on how to integrate the EVM MCP server with AI models.
+
+The EVM MCP server seamlessly integrates with popular AI development environments:
+
+### Cursor
+Configure the server in your [Cursor settings](https://docs.cursor.com/context/model-context-protocol) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Desktop
+Configure the server in your [Claude Desktop settings](https://modelcontextprotocol.io/quickstart/user) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Code
+Configure the server in your [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/mcp) to access Chainstack's knowledge base directly within your conversations.
+
+### Custom AI applications
+Use the MCP protocol to integrate Chainstack's documentation into your own AI-powered development tools and assistants.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Solana MCP server" href="/docs/solana-mcp-server">
+    Add Solana blockchain capabilities
+  </Card>
+  <Card title="Developer Portal MCP server" href="/docs/developer-portal-mcp-server">
+    Access documentation and guides
+  </Card>
+  <Card title="GitHub Repository" href="https://github.com/chainstacklabs/rpc-nodes-mcp" icon="external-link">
+    View source code and installation instructions
+  </Card>
+  <Card title="Ethereum API Reference" href="/reference/ethereum-getting-started">
+    Explore available Ethereum methods
+  </Card>
+</CardGroup> 

--- a/docs/mcp-servers-introduction.mdx
+++ b/docs/mcp-servers-introduction.mdx
@@ -1,0 +1,73 @@
+---
+title: "MCP servers"
+description: "Learn about Chainstack's Model Context Protocol (MCP) servers for AI-driven blockchain development"
+---
+
+# MCP servers
+
+Chainstack provides [Model Context Protocol (MCP) servers](https://modelcontextprotocol.io/) to enhance AI-driven blockchain development workflows. MCP is an open protocol that enables AI applications to securely connect to external data sources and tools.
+
+## What is MCP?
+
+The Model Context Protocol (MCP) is an open standard that provides a unified way for AI applications to connect to external data sources, tools, and services. MCP servers act as intermediaries that expose specific capabilities to AI models in a secure and controlled manner.
+
+What this means in practice is you can run locally the Chainstack MCP servers and enable access to them in your AI applications like Claude Desktop, Claude Code, Cursor, VS Code, etc. Your AI applications will then call MCP servers whenever they deem necessary and get immediate access to the Chainstack Developer Portal or the supported chains via the Chainstack RPC nodes with the JSON-RPC method calls.
+
+## Chainstack MCP servers
+
+Chainstack ships **two distinct MCP servers** to support different blockchain development needs:
+
+### 1. Developer Portal MCP server
+
+The **Developer Portal MCP server** is built into Chainstack's documentation platform and provides AI models with access to Chainstack's comprehensive blockchain development resources.
+
+**Installation:**
+```bash
+npx mint-mcp add chainstack
+```
+
+This MCP server gives AI models access to:
+- Chainstack's documentation and guides
+- API references and examples
+- Best practices for blockchain development
+- Protocol-specific information and tooling guidance
+
+### 2. RPC Nodes MCP server
+
+The **RPC Nodes MCP server** provides direct blockchain interaction capabilities for Solana and EVM-compatible networks through Chainstack's infrastructure.
+
+**Repository:** [chainstacklabs/rpc-nodes-mcp](https://github.com/chainstacklabs/rpc-nodes-mcp)
+
+This MCP server enables AI models to:
+- Execute blockchain RPC calls
+- Query account balances and transaction data
+- Interact with smart contracts
+- Access real-time blockchain information
+- Perform cross-chain operations
+
+The RPC Nodes MCP server is split into specialized components:
+- **EVM MCP server** - For Ethereum and EVM-compatible networks
+- **Solana MCP server** - For the Solana blockchain
+
+## Getting started
+
+Choose the MCP server that best fits your AI application needs:
+
+- **Use the Developer Portal MCP server** when you need AI models to access Chainstack's documentation, guides, and development resources
+- **Use the RPC Nodes MCP server** when you need AI models to directly interact with blockchain networks and execute transactions
+
+Both servers can be used together to create comprehensive blockchain-powered AI applications that combine educational resources with real-time blockchain functionality.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Developer Portal MCP server" href="/docs/developer-portal-mcp-server">
+    Access Chainstack's documentation and development resources
+  </Card>
+  <Card title="EVM MCP server" href="/docs/evm-mcp-server">
+    Interact with Ethereum and EVM-compatible networks
+  </Card>
+  <Card title="Solana MCP server" href="/docs/solana-mcp-server">
+    Connect to the Solana blockchain ecosystem
+  </Card>
+</CardGroup> 

--- a/docs/solana-mcp-server.mdx
+++ b/docs/solana-mcp-server.mdx
@@ -90,9 +90,9 @@ The Solana MCP server enables AI applications to:
 
 ## Integration with AI models
 
-See the [RPC nodes MCP README file](https://github.com/chainstacklabs/rpc-nodes-mcp/blob/main/README.md) for more information on how to integrate the EVM MCP server with AI models.
+See the [RPC nodes MCP README file](https://github.com/chainstacklabs/rpc-nodes-mcp/blob/main/README.md) for more information on how to integrate the Solana MCP server with AI models.
 
-The EVM MCP server seamlessly integrates with popular AI development environments:
+The Solana MCP server seamlessly integrates with popular AI development environments:
 
 ### Cursor
 Configure the server in your [Cursor settings](https://docs.cursor.com/context/model-context-protocol) to access Chainstack's knowledge base directly within your conversations.

--- a/docs/solana-mcp-server.mdx
+++ b/docs/solana-mcp-server.mdx
@@ -1,0 +1,124 @@
+---
+title: "Solana MCP server"
+description: "Connect to the Solana blockchain ecosystem through the Solana MCP server"
+---
+
+# Solana MCP server
+
+The **Solana MCP server** is part of Chainstack's RPC Nodes MCP server suite, providing AI models with comprehensive access to the Solana blockchain ecosystem. This server enables real-time Solana interactions, account queries, program calls, and transaction analysis.
+
+## Repository
+
+The Solana MCP server is available in the [chainstacklabs/rpc-nodes-mcp](https://github.com/chainstacklabs/rpc-nodes-mcp) repository, alongside the EVM MCP server for complete blockchain coverage.
+
+## Supported networks
+
+The Solana MCP server supports all Solana networks available on Chainstack:
+
+- **Solana Mainnet** - Production Solana network
+- **Solana Devnet** - Development and testing network
+
+## Available functions
+
+The Solana MCP server provides comprehensive Solana blockchain interaction capabilities:
+
+### Account information
+- **Get account info** - Retrieve detailed account data and metadata
+- **Get account balance** - Check SOL balance for any account
+- **Get multiple accounts** - Batch query multiple accounts efficiently
+- **Get program accounts** - Find all accounts owned by a specific program
+
+### Block and slot operations
+- **Get current slot** - Retrieve the latest processed slot
+- **Get block height** - Get the current block height
+- **Get block information** - Fetch complete block data with transactions
+- **Get block time** - Retrieve block production timestamp
+- **Get block commitment** - Check block confirmation status
+
+### Transaction operations
+- **Get transaction** - Retrieve transaction details by signature
+- **Get signatures for address** - Find all transactions for an account
+- **Get signature statuses** - Check transaction confirmation status
+- **Get recent blockhash** - Get blockhash for transaction construction
+
+### Network and cluster information
+- **Get cluster nodes** - List all validator nodes in the network
+- **Get epoch info** - Current epoch details and progress
+- **Get epoch schedule** - Epoch timing and slot configuration
+- **Get identity** - Node identity and version information
+- **Get health** - Check node health and sync status
+
+### Fee and performance data
+- **Get fee for message** - Estimate transaction fees
+- **Get recent performance samples** - Network performance metrics
+- **Get recent prioritization fees** - Current priority fee levels
+- **Get minimum balance for rent exemption** - Calculate rent-exempt balance
+
+## Use cases
+
+The Solana MCP server enables AI applications to:
+
+### DeFi and token analysis
+- **Monitor SPL token balances** and transfers
+- **Track liquidity pools** and DeFi protocol states
+- **Analyze trading patterns** on Solana DEXs
+- **Monitor yield farming** and staking rewards
+
+### NFT and digital assets
+- **Query NFT collections** and metadata
+- **Track NFT ownership** and transfer history
+- **Monitor marketplace activity** and pricing
+- **Analyze digital asset trends** and popularity
+
+### Validator and staking operations
+- **Monitor validator performance** and commissions
+- **Track staking rewards** and delegations
+- **Analyze validator rankings** and metrics
+- **Monitor stake pool operations** and performance
+
+### Program development
+- **Test program interactions** and account states
+- **Debug transaction failures** and program errors
+- **Simulate program calls** with different parameters
+- **Monitor program usage** and adoption metrics
+
+### Network analytics
+- **Analyze network performance** and throughput
+- **Monitor epoch transitions** and validator changes
+- **Track fee trends** and priority patterns
+- **Generate network health** reports and metrics
+
+## Integration with AI models
+
+See the [RPC nodes MCP README file](https://github.com/chainstacklabs/rpc-nodes-mcp/blob/main/README.md) for more information on how to integrate the EVM MCP server with AI models.
+
+The EVM MCP server seamlessly integrates with popular AI development environments:
+
+### Cursor
+Configure the server in your [Cursor settings](https://docs.cursor.com/context/model-context-protocol) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Desktop
+Configure the server in your [Claude Desktop settings](https://modelcontextprotocol.io/quickstart/user) to access Chainstack's knowledge base directly within your conversations.
+
+### Claude Code
+Configure the server in your [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/mcp) to access Chainstack's knowledge base directly within your conversations.
+
+### Custom AI applications
+Use the MCP protocol to integrate Chainstack's documentation into your own AI-powered development tools and assistants.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="EVM MCP server" href="/docs/evm-mcp-server">
+    Add Ethereum and EVM capabilities
+  </Card>
+  <Card title="Developer Portal MCP server" href="/docs/developer-portal-mcp-server">
+    Access documentation and guides
+  </Card>
+  <Card title="GitHub Repository" href="https://github.com/chainstacklabs/rpc-nodes-mcp" icon="external-link">
+    View source code and installation instructions
+  </Card>
+  <Card title="Solana API Reference" href="/reference/solana-getting-started">
+    Explore available Solana methods
+  </Card>
+</CardGroup> 


### PR DESCRIPTION
The RPC nodes one will hopefully be reworked.
Adding for now mostly to have it there for visibility & marketing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "MCP servers" section to the Guides navigation, featuring dedicated documentation for MCP server offerings.
  - Introduced pages covering the MCP servers introduction, Developer Portal MCP server, EVM MCP server, and Solana MCP server, detailing their features, supported networks, use cases, and integration options for AI-driven blockchain development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->