### PR TITLE
docs: add release notes access rules (June 26, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,13 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 26, 2025" description=" by Vladimir">
+
+**Platform**. You can now use Access rules on Global Nodes for IP addresses and Origin.
+
+<Button href="/changelog/chainstack-updates-june-26-2025">Read more</Button>
+</Update>
+
 
 <Update label="Chainstack updates: June 12, 2025" description=" by Vladimir">
 

--- a/changelog/chainstack-updates-june-26-2025.mdx
+++ b/changelog/chainstack-updates-june-26-2025.mdx
@@ -1,0 +1,4 @@
+---
+title: "Chainstack updates: June 26, 2025"
+---
+**Platform**. You can now use Access rules on Global Nodes for IP addresses and Origin.

--- a/docs.json
+++ b/docs.json
@@ -2363,6 +2363,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-26-2025",
           "changelog/chainstack-updates-june-12-2025",
           "changelog/chainstack-updates-june-11-2025",
           "changelog/chainstack-updates-june-10-2025",


### PR DESCRIPTION
### Summary

Adds release notes for the support of Access rules as of June 26, 2025.

### Changes
- `changelog.mdx`: New top-level update entry
- `changelog/chainstack-updates-june-26-2025.mdx`: Full content
- `docs.json`: Entry added for new changelog file

✅ Verified locally with `mintlify dev`  
✅ Links passed via `mint broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announced the ability to apply Access rules on Global Nodes based on IP addresses and Origin in the platform.
* **Documentation**
  * Added a new changelog entry for the June 26, 2025 update.
  * Updated the release notes section to include the latest update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->