### PR TITLE
docs: remove release notes for access rulles

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,13 +4,6 @@ title: "Release notes"
 
 import { Button } from '/snippets/button.mdx';
 
-<Update label="Chainstack updates: June 26, 2025" description=" by Vladimir">
-
-**Platform**. You can now use Access rules on Global Nodes for IP addresses and Origin.
-
-<Button href="/changelog/chainstack-updates-june-26-2025">Read more</Button>
-</Update>
-
 
 <Update label="Chainstack updates: June 12, 2025" description=" by Vladimir">
 

--- a/docs.json
+++ b/docs.json
@@ -2363,7 +2363,6 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
-          "changelog/chainstack-updates-june-26-2025",
           "changelog/chainstack-updates-june-12-2025",
           "changelog/chainstack-updates-june-11-2025",
           "changelog/chainstack-updates-june-10-2025",


### PR DESCRIPTION
We’ve rolled back the release due to Chainу.
The release is postponed until June 27.