### PR TITLE
solana getlargestaccounts is on dedicated nodes only

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -116,12 +116,6 @@ The following limits are applied:
   * Chainstack Cloud London `lon1` RPS: 2
   * Chainstack Cloud New York City `nyc1` RPS: 2
 
-* `getLargestAccounts`:
-
-  * Chainstack Global Network Worldwide `global1` RPS: 6
-  * Chainstack Cloud London `lon1` RPS: 6
-  * Chainstack Cloud New York City `nyc1` RPS: 6
-
 * `getTokenAccountsByOwner`:
 
   * Chainstack Global Network Worldwide `global1` RPS: 100
@@ -146,13 +140,13 @@ The following Solana accounts are unavailable for querying:
 The following methods are available only on the paid plans:
 
 * `getProgramAccounts`
-* `getLargestAccounts`
+* `getLargestAccounts` — this method is available only on [Dedicated Nodes](/docs/dedicated-node).
 * `getSupply`
 * `getTokenAccountsByOwner`
 
 ## Solana archive methods availability
 
-While most methods are supported on Solana [global nodes](/docs/global-elastic-node), only the following methods can fetch archive data:
+While most methods are supported on Solana [Global Nodes](/docs/global-elastic-node), only the following methods can fetch archive data:
 
 * `getSignaturesForAddress`
 * `getTransaction`

--- a/reference/solana-getlargestaccounts.mdx
+++ b/reference/solana-getlargestaccounts.mdx
@@ -4,8 +4,6 @@ openapi: /openapi/solana_node_api/getLargestAccounts.json POST /9de47db917d4f691
 ---
 
 <Note>
-**Not available on the Developer plan**
-
 The method is available only on [Dedicated Nodes](/docs/dedicated-node).
 </Note>
 

--- a/reference/solana-getlargestaccounts.mdx
+++ b/reference/solana-getlargestaccounts.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/solana_node_api/getLargestAccounts.json POST /9de47db917d4f691
 <Note>
 **Not available on the Developer plan**
 
-The method is available only on the [paid plans](https://chainstack.com/pricing/).
+The method is available only on [Dedicated Nodes](/docs/dedicated-node).
 </Note>
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that the `getLargestAccounts` method is available only on Dedicated Nodes, with an updated link to relevant documentation.
  * Removed specific rate limit values for the `getLargestAccounts` method.
  * Standardized capitalization of "Global Nodes" in the Solana archive methods section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->