### PR TITLE
Add Warp tx separate billing callouts

### DIFF
--- a/docs/bnb-trader-nodes.mdx
+++ b/docs/bnb-trader-nodes.mdx
@@ -3,7 +3,11 @@ title: "BNB Smart Chain Trader Nodes with Warp transactions"
 description: "Warp transactions propagate through [bloXroute's high-speed transaction relay network](https://docs.bloxroute.com/bdn-architecture). This makes your transactions available for validators to pick up and include in blocks much faster than regular propagation."
 ---
 
-Each extra transaction (not request, just the transaction) consumed is billed separately. For details, see [Pricing](https://chainstack.com/pricing/) .
+<Note>
+The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
+
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+</Note>
 
 ## Benefits with Chainstack
 

--- a/docs/ethereum-trader-nodes.mdx
+++ b/docs/ethereum-trader-nodes.mdx
@@ -3,7 +3,11 @@ title: "Ethereum Trader Nodes with Warp transactions"
 description: "Warp transactions propagate through [bloXroute's high-speed transaction relay network](https://docs.bloxroute.com/bdn-architecture). This makes your transactions available for validators to pick up and include in blocks much faster than regular propagation."
 ---
 
-Each extra transaction (not request, just the transaction) consumed is billed separately. For details, see [Pricing](https://chainstack.com/pricing/) .
+<Note>
+The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
+
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+</Note>
 
 ## Benefits with Chainstack
 

--- a/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
+++ b/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
@@ -8,6 +8,12 @@ title: "Sending Trader Node Warp transactions with web3.js, ethers.js, web3.py, 
 * No extra sign-up is needed for bloXroute; you keep using standard Ethereum JSON-RPC calls.
 * Examples are given for web3.js, ethers.js, web3.py, and Go’s ethclient.
 
+<Note>
+The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
+
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+</Note>
+
 ## Main article
 
 <Info>

--- a/docs/solana-trader-nodes.mdx
+++ b/docs/solana-trader-nodes.mdx
@@ -5,7 +5,12 @@ title: "Solana Trader Nodes with Warp transactions"
 <Frame>
   <iframe width="100%" height="420" src="https://www.youtube.com/embed/BCGqfXjHDac" title="Solana Trader nodes" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </Frame>
-Each extra transaction (not request, just the transaction) consumed is billed separately. For details, see [Pricing](https://chainstack.com/pricing/) .
+
+<Note>
+The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
+
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+</Note>
 
 See also the [Solana Warp transactions](https://chainstack.com/solana-trader-nodes/) page for a more general overview.
 

--- a/docs/warp-transactions.mdx
+++ b/docs/warp-transactions.mdx
@@ -6,6 +6,12 @@ sidebarTitle: Overview
 
 With the *Warp transactions* setting on, your transactions will be distributed in either through the high-speed transaction relay network if it's an EVM network or to directly to the leader if it's Solana. This will make your transaction be available for the validators to pick up and include in the block much faster than with the regular propagation.
 
+<Note>
+The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
+
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+</Note>
+
 ## Why use with Chainstack
 
 With Chainstack Trader nodes, you get the convenience of both worlds — reliable nodes for everything up to sending the transaction & the high speed of bloXroute for the transaction itself.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified billing and availability details for Warp transactions across multiple guides.
  * Added prominent notes specifying that Warp transactions are only available on paid plans and are billed separately from requests.
  * Included links to pricing and pay-as-you-go billing documentation for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->