### PR TITLE
docs: add release notes for Hyperliquid (August 5, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,14 @@ title: "Release notes"
 import { Button } from '/snippets/button.mdx';
 
 
+<Update label="Chainstack updates: August 5, 2025" description=" by Ake" >
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Hyperliquid Mainnet and Hyperliquid Testnet, both available in full mode with EVM and INFO APIs enabled.
+
+<Button href="/changelog/chainstack-updates-august-5-2025">Read more</Button>
+</Update>
+
+
 <Update label="Chainstack updates: June 27, 2025" description=" by Ake">
 
 **Security**. You can now add [access rules](/docs/access-rules) to your node endpoints to restrict access based on HTTP `Origin` header values or IP addresses.

--- a/changelog/chainstack-updates-august-5-2025.mdx
+++ b/changelog/chainstack-updates-august-5-2025.mdx
@@ -1,0 +1,4 @@
+---
+title: "Chainstack updates: August 5, 2025"
+---
+**Global Nodes** — Hyperliquid Mainnet and Hyperliquid Testnet are now available in full mode with EVM & INFO APIs enabled.

--- a/docs.json
+++ b/docs.json
@@ -2394,6 +2394,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-5-2025",
           "changelog/chainstack-updates-june-27-2025",
           "changelog/chainstack-updates-june-12-2025",
           "changelog/chainstack-updates-june-11-2025",


### PR DESCRIPTION
### Summary

Adds release notes for Hyperliquid Mainnet and Testnet Global Nodes support (full mode, EVM & INFO APIs enabled).

### Changes
- Added new entry to `changelog.mdx`
- Created `changelog/chainstack-updates-august-5-2025.mdx`
- Updated `docs.json` to include new changelog

✅ Verified locally with `mintlify dev`  
 Checked links with `mint broken-links` - `found 8 broken links in 5 files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new changelog entry announcing the availability of Global Nodes for Hyperliquid Mainnet and Testnet in full mode, with both EVM and INFO APIs enabled.
  * Updated the release notes section to include the August 5, 2025 Chainstack update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->