### PR TITLE
Update & fix API references

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1797,7 +1797,6 @@
             "group": "TON node API",
             "pages": [
               "reference/getting-started-ton",
-              "reference/getting-started-ton",
               "reference/ton-getaddressinformation-v2",
               "reference/ton-getextendedaddressinformation-v2",
               "reference/ton-getwalletinformation-v2",
@@ -1962,7 +1961,6 @@
           {
             "group": "Zksync node API",
             "pages": [
-              "reference/getting-started-zksync",
               "reference/getting-started-zksync",
               "reference/zks_l1chainid",
               "reference/zks_estimatefee",

--- a/reference/arbitrum-debug-and-trace-rpc-methods.mdx
+++ b/reference/arbitrum-debug-and-trace-rpc-methods.mdx
@@ -70,4 +70,4 @@ This tracer does nothing but respond with a blank object. This a no operations t
 
 ### `stylusTracer`
 
-This tracer is for debugging Stylus contracts by tracing calls between the WasmVM and EVM, allowing developers to fully understand their Stylus transactions. See also [debug\_traceTransaction with stylusTracer](/reference/gettransaction).
+This tracer is for debugging Stylus contracts by tracing calls between the WasmVM and EVM, allowing developers to fully understand their Stylus transactions.

--- a/reference/arbitrum-gettransactionbyblockhashandindex.mdx
+++ b/reference/arbitrum-gettransactionbyblockhashandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockHashAndIndex | Arbitrum
+openapi: /openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /5b8d22690a57f293b3a1ed8758014e35
 ---
 
 Arbitrum API method that retrieves information about a specific transaction based on the block hash and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.

--- a/reference/arbitrum-gettransactionbyblocknumberandindex.mdx
+++ b/reference/arbitrum-gettransactionbyblocknumberandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockNumberAndIndex | Arbitrum
+openapi: /openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /5b8d22690a57f293b3a1ed8758014e35
 ---
 
 Arbitrum API method that retrieves information about a specific transaction based on the block number and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.
@@ -22,7 +23,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 * `quantity` — the integer identifying the transaction index position within the block, encoded as hexadecimal.

--- a/reference/arbitrum-gettransactionbyhash.mdx
+++ b/reference/arbitrum-gettransactionbyhash.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByHash | Arbitrum
+openapi: /openapi/arbitrum_node_api/transaction_info/eth_getTransactionByHash.json POST /5b8d22690a57f293b3a1ed8758014e35
 ---
 
 Arbitrum API method that returns the information about a transaction from the transaction hash. It is used to retrieve information about a specific transaction by its hash. The method returns an object with details about the transaction, such as the sender, recipient, gas used, transaction value, and more.
@@ -28,7 +29,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `maxFeePerGas` — the maximum amount the sender of the transaction is willing to pay per unit of gas for the transaction to be executed.
   + `maxPriorityFeePerGas` — the maximum priority fee the sender of the transaction is willing to pay per unit of gas.
   + `hash` — the hash that uniquely identifies the transaction.
-  + `input` — the optional input data sent with the transaction., usually used to interact with smart contracts.
+  + `input` — the optional input data sent with the transaction, usually used to interact with smart contracts.
   + `nonce` — a counter identifying the transaction's number sent by the sender wallet; it essentially identifies how many transactions an account has made. Used to ensure each transaction is executed only once.
   + `to` — the address of the recipient of the transaction if it was a transaction to an address. For contract creation transactions, this field is `null`.
   + `transactionIndex` — the index of the transaction within the block. This field is `null` for transactions that have not yet been included in a block.

--- a/reference/arbitrum-gettransactionreceipt.mdx
+++ b/reference/arbitrum-gettransactionreceipt.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionReceipt | Arbitrum
+openapi: /openapi/arbitrum_node_api/transaction_info/eth_getTransactionReceipt.json POST /5b8d22690a57f293b3a1ed8758014e35
 ---
 
 <Note>

--- a/reference/arbitrum-tracetransaction.mdx
+++ b/reference/arbitrum-tracetransaction.mdx
@@ -31,7 +31,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 curl https://arbitrum-mainnet.core.chainstack.com/d44bf5f1b27688507d0ccd50bf263e83 \
 -X POST \
 -H "Content-Type: application/json" \
---data '{"method":"debug_traceTransaction","params":["0x3c9329b765d88c03d18f87dc1f2b5138c89d9a415d5c73dc7827b87aca176c8e", {"tracer": "StylusTracer"}], "id":1,"jsonrpc":"2.0"}'
+--data '{"method":"debug_traceTransaction","params":["0x3c9329b765d88c03d18f87dc1f2b5138c89d9a415d5c73dc7827b87aca176c8e", {"tracer": "stylusTracer"}], "id":1,"jsonrpc":"2.0"}'
 ```
 
 ## Response types

--- a/reference/arbitrum-tracetransaction.mdx
+++ b/reference/arbitrum-tracetransaction.mdx
@@ -4,6 +4,12 @@ title: debug_traceTransaction with stylusTracer
 
 Arbitrum API method that provides a native tracer called `stylusTracer` for debugging Stylus contracts. This method returns detailed execution traces of transactions involving Stylus contracts by capturing metadata for each HostIO (calls the WasmVM makes to read and write data in the EVM). Combined with the contract's source code, this gives developers complete visibility into transaction execution for debugging purposes.
 
+<Note>
+**Available on customized dedicated nodes only**
+
+Custom JavaScript tracers are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+</Note>
+
 <Check>
 **Get your own node endpoint today**
 
@@ -18,6 +24,15 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 * `hash` — the hash identifying a transaction.
 * `object` — (optional) an object identifying the type of tracer and its configuration:
   + `stylusTracer` — tracer that captures metadata for each HostIO executed during a Stylus transaction.
+
+## JSON-RPC example
+
+```shell
+curl https://arbitrum-mainnet.core.chainstack.com/d44bf5f1b27688507d0ccd50bf263e83 \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"method":"debug_traceTransaction","params":["0x3c9329b765d88c03d18f87dc1f2b5138c89d9a415d5c73dc7827b87aca176c8e", {"tracer": "StylusTracer"}], "id":1,"jsonrpc":"2.0"}'
+```
 
 ## Response types
 

--- a/reference/debug_traceblockbyhash-fantom-chain.mdx
+++ b/reference/debug_traceblockbyhash-fantom-chain.mdx
@@ -26,6 +26,15 @@ Fantom API method that traces the execution of a block. This method can debug an
   * `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   * `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByHash","params":["0x00043882000007ac65a7650d8c4cd06636dbde73d1e9458378aecc4c652184b2", {"tracer": "4byteTracer"}]}'
+```
+
 ## Response types
 
 ### `4byteTracer` response

--- a/reference/debug_traceblockbynumber-fantom.mdx
+++ b/reference/debug_traceblockbynumber-fantom.mdx
@@ -39,6 +39,15 @@ description: "Fantom API method that enables the tracing of the execution of a s
   * `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   * `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":["latest", {"tracer": "callTracer"}]}'
+```
+
 ## Response types
 
 ### `4byteTracer` response

--- a/reference/debug_tracetransaction-fantom.mdx
+++ b/reference/debug_tracetransaction-fantom.mdx
@@ -55,6 +55,15 @@ You can also use additional configuration parameters. The following settings are
   When no built-in tracer is selected, the response defaults to the [Struct/opcode logger](https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#structopcode-logger).
 </Info>
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"debug_traceTransaction","params":["0xa2b1e35f59d184da1996b37803ed2e8e81057be7d07a93af48a410fd9338d616", {"tracer": "callTracer"}]}'
+```
+
 ## Response types
 
 ### `4byteTracer` response

--- a/reference/ethereum-getblockreceipts.mdx
+++ b/reference/ethereum-getblockreceipts.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getBlockReceipts | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_getBlockReceipts.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
 Ethereum API method that retrieves all transaction receipts for a given block. Transaction receipts contain information about the execution status of a transaction and can be useful for monitoring the status of transfers or contract execution on the blockchain.
@@ -28,7 +29,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block.wiki/json-rpc/API#the-default-block-parameter) and [How The Merge Impacts Ethereum’s Application Layer](https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block) and [How the Merge impacts Ethereum’s application layer](https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer).
 </Note>
 
 

--- a/reference/ethereum-gettransactionbyblockhashandindex.mdx
+++ b/reference/ethereum-gettransactionbyblockhashandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockHashAndIndex | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
 Ethereum API method that retrieves information about a specific transaction based on the block hash and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.

--- a/reference/ethereum-gettransactionbyblocknumberandindex.mdx
+++ b/reference/ethereum-gettransactionbyblocknumberandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockNumberAndIndex | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
 Ethereum API method that retrieves information about a specific transaction based on the block number and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.

--- a/reference/ethereum-gettransactionbyhash.mdx
+++ b/reference/ethereum-gettransactionbyhash.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByHash | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_getTransactionByHash.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
 Ethereum API method that returns the information about a transaction from the transaction hash. It is used to retrieve information about a specific transaction by its hash. The method returns an object with details about the transaction, such as the sender, recipient, gas used, transaction value, and more.

--- a/reference/ethereum-gettransactionreceipt.mdx
+++ b/reference/ethereum-gettransactionreceipt.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionReceipt | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_getTransactionReceipt.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
 <Note>

--- a/reference/ethereum-newpendingtransactionfilter.mdx
+++ b/reference/ethereum-newpendingtransactionfilter.mdx
@@ -1,8 +1,9 @@
 ---
 title: eth_newPendingTransactionFilter | Ethereum
+openapi: /openapi/ethereum_node_api/transaction_info/eth_newPendingTransactionFilter.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
 ---
 
-Ethereum API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the [eth\_getFilterChanges](/reference/ethereum-getfilterchanges) method. The `eth_newBlockFilter` method is useful for developers who must be notified of new blocks on the blockchain in real time.
+Ethereum API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the [eth\_getFilterChanges](/reference/ethereum-getfilterchanges) method. The `eth_newPendingTransactionFilter` method is useful for developers who must be notified of new pending transactions in real time.
 
 <Check>
 **Get you own node endpoint today**

--- a/reference/getbalance.mdx
+++ b/reference/getbalance.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getBalance | Polygon
+openapi: /openapi/polygon_node_api/account_info/eth_getBalance.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns the balance of a specific Polygon account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Polygon account for various purposes, such as checking available funds or displaying balance information.
@@ -23,7 +24,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 
@@ -77,7 +78,7 @@ One practical use case for `eth_getBalance` is to check the balance of an accoun
 
 Here's an example of how you can achieve this in web3.js:
 
-```javascript inedx.js
+```javascript index.js
 const Web3 = require("web3");
 const NODE_URL = "CHAINSTACK_NODE_URL";
 const web3 = new Web3(NODE_URL);

--- a/reference/getcode.mdx
+++ b/reference/getcode.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getCode | Polygon
+openapi: /openapi/polygon_node_api/account_info/eth_getCode.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that retrieves the compiled bytecode of a smart contract providing its address as a parameter. This method returns a hexadecimal string representing the smart contract's bytecode.
@@ -25,7 +26,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 

--- a/reference/getstorageat.mdx
+++ b/reference/getstorageat.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getStorageAt | Polygon
+openapi: /openapi/polygon_node_api/account_info/eth_getStorageAt.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
@@ -28,7 +29,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 

--- a/reference/gettransactioncount.mdx
+++ b/reference/gettransactioncount.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionCount | Polygon
+openapi: /openapi/polygon_node_api/account_info/eth_getTransactionCount.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
@@ -23,7 +24,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 

--- a/reference/gnosis-gettransactionbyblockhashandindex.mdx
+++ b/reference/gnosis-gettransactionbyblockhashandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockHashAndIndex | Gnosis
+openapi: /openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /512e720763b369ed620657f84d38d2af
 ---
 
 Gnosis Chain API method that retrieves information about a specific transaction based on the block hash and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.

--- a/reference/gnosis-gettransactionbyblocknumberandindex.mdx
+++ b/reference/gnosis-gettransactionbyblocknumberandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockNumberAndIndex | Gnosis
+openapi: /openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /512e720763b369ed620657f84d38d2af
 ---
 
 Gnosis Chain API method that retrieves information about a specific transaction based on the block number and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Gnosis Chain.

--- a/reference/gnosis-gettransactionbyhash.mdx
+++ b/reference/gnosis-gettransactionbyhash.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByHash | Gnosis
+openapi: /openapi/gnosis_node_api/transaction_info/eth_getTransactionByHash.json POST /512e720763b369ed620657f84d38d2af
 ---
 
 Gnosis Chain API method that returns the information about a transaction from the transaction hash. It is used to retrieve information about a specific transaction by its hash. The method returns an object with details about the transaction, such as the sender, recipient, gas used, transaction value, and more.

--- a/reference/gnosis-gettransactionreceipt.mdx
+++ b/reference/gnosis-gettransactionreceipt.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionReceipt | Gnosis
+openapi: /openapi/gnosis_node_api/transaction_info/eth_getTransactionReceipt.json POST /512e720763b369ed620657f84d38d2af
 ---
 
 <Note>

--- a/reference/gnosis-newpendingtransactionfilter.mdx
+++ b/reference/gnosis-newpendingtransactionfilter.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_newPendingTransactionFilter | Gnosis
+openapi: /openapi/gnosis_node_api/transaction_info/eth_newPendingTransactionFilter.json POST /512e720763b369ed620657f84d38d2af
 ---
 
 Gnosis Chain API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the [eth\_getFilterChanges](/reference/gnosis-getfilterchanges) method. The `eth_newBlockFilter` method is useful for developers who must be notified of new blocks on the blockchain in real time.

--- a/reference/hyperliquid-evm-eth-call.mdx
+++ b/reference/hyperliquid-evm-eth-call.mdx
@@ -115,6 +115,8 @@ The method returns the result of the contract call as a hexadecimal string.
 
 ## Example request
 
+This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \

--- a/reference/hyperliquid-evm-eth-estimate-gas.mdx
+++ b/reference/hyperliquid-evm-eth-estimate-gas.mdx
@@ -51,77 +51,14 @@ The method returns the estimated gas amount as a hexadecimal string.
 - Gas price fluctuations and network congestion
 - Dynamic contract behavior based on inputs
 
-## Usage example
-
-### Basic implementation
-
-```javascript
-// Estimate gas for a transaction on Hyperliquid
-const estimateGas = async (transactionObject) => {
-  const response = await fetch('https://hyperliquid-mainnet.core.chainstack.com/YOUR_ENDPOINT/evm', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'eth_estimateGas',
-      params: [transactionObject],
-      id: 1
-    })
-  });
-  
-  const data = await response.json();
-  const gasEstimate = parseInt(data.result, 16);
-  
-  return {
-    hex: data.result,
-    decimal: gasEstimate,
-    withBuffer: Math.ceil(gasEstimate * 1.2) // Add 20% buffer
-  };
-};
-
-// Example: Estimate gas for an ERC-20 transfer
-const estimateTokenTransfer = async () => {
-  const transaction = {
-    from: "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
-    to: "0x5555555555555555555555555555555555555555", // Token contract
-    data: "0xa9059cbb000000000000000000000000fefefefefefefefefefefefefefefefefefefefe0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-  };
-  
-  try {
-    const estimate = await estimateGas(transaction);
-    console.log(`Estimated gas: ${estimate.decimal}`);
-    console.log(`Recommended gas limit: ${estimate.withBuffer}`);
-    return estimate;
-  } catch (error) {
-    console.error('Gas estimation failed:', error);
-    throw error;
-  }
-};
-
-// Usage
-estimateTokenTransfer()
-  .then(estimate => console.log('Gas estimation successful:', estimate))
-  .catch(error => console.error('Error:', error));
-```
-
-## Best practices
-
-### Transaction preparation
-
-**Gas estimation workflow:**
-- Always estimate gas before sending transactions
-- Add a reasonable buffer (10-20%) to prevent out-of-gas errors
-- Use estimates for transaction cost calculations
-- Test estimates with various input parameters
-
 **Hyperliquid considerations:**
 - Estimates are based on latest block state only
 - Monitor actual vs estimated gas usage for optimization
 - Implement fallback gas limits for critical transactions
 
 ## Example request
+
+This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
 ```shell Shell
 curl -X POST \

--- a/reference/hyperliquid-evm-eth-get-code.mdx
+++ b/reference/hyperliquid-evm-eth-get-code.mdx
@@ -29,127 +29,6 @@ The method takes two parameters:
 
 The method returns the contract bytecode as a hexadecimal string, or `"0x"` if no code exists at the address.
 
-### Response structure
-
-**Contract bytecode:**
-- `result` — The contract bytecode as a hexadecimal string with `0x` prefix
-
-### Data interpretation
-
-**Bytecode format:**
-- Returned as hexadecimal string with `0x` prefix
-- Contains the deployed contract's runtime bytecode
-- `"0x"` indicates no code (externally owned account)
-- Non-empty string indicates a smart contract
-
-**Contract identification:**
-```javascript
-// Check if address is a contract
-const isContract = (code) => code !== "0x" && code.length > 2;
-
-// Check if address is an EOA
-const isEOA = (code) => code === "0x";
-```
-
-## Usage example
-
-### Basic implementation
-
-```javascript
-// Get contract bytecode on Hyperliquid
-const getContractCode = async (address) => {
-  const response = await fetch('https://hyperliquid-mainnet.core.chainstack.com/YOUR_ENDPOINT/evm', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'eth_getCode',
-      params: [address, 'latest'], // Only 'latest' is supported
-      id: 1
-    })
-  });
-  
-  const data = await response.json();
-  return data.result;
-};
-
-// Check if address is a contract or EOA
-const analyzeAddress = async (address) => {
-  const code = await getContractCode(address);
-  
-  const isContract = code !== "0x" && code.length > 2;
-  const isEOA = code === "0x";
-  
-  return {
-    address,
-    code,
-    isContract,
-    isEOA,
-    codeSize: isContract ? (code.length - 2) / 2 : 0, // Convert hex to bytes
-    hasCode: isContract
-  };
-};
-
-// Analyze multiple addresses
-const analyzeMultipleAddresses = async (addresses) => {
-  const results = [];
-  
-  for (const address of addresses) {
-    try {
-      const analysis = await analyzeAddress(address);
-      results.push(analysis);
-    } catch (error) {
-      console.error(`Error analyzing address ${address}:`, error);
-      results.push({
-        address,
-        error: error.message,
-        isContract: null,
-        isEOA: null
-      });
-    }
-  }
-  
-  return results;
-};
-
-// Check for common proxy patterns
-const checkProxyPattern = (bytecode) => {
-  if (bytecode === "0x") return { isProxy: false, type: null };
-  
-  // EIP-1167 minimal proxy pattern
-  if (bytecode.includes("363d3d373d3d3d363d73")) {
-    return { isProxy: true, type: "EIP-1167 Minimal Proxy" };
-  }
-  
-  // Other common proxy patterns
-  if (bytecode.includes("3660008037600080366000845af43d6000803e")) {
-    return { isProxy: true, type: "Delegatecall Proxy" };
-  }
-  
-  return { isProxy: false, type: null };
-};
-
-// Usage examples
-const contractAddress = "0x5555555555555555555555555555555555555555";
-const eoaAddress = "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA";
-
-analyzeAddress(contractAddress)
-  .then(analysis => {
-    console.log('Contract Analysis:', analysis);
-    if (analysis.isContract) {
-      const proxyInfo = checkProxyPattern(analysis.code);
-      console.log('Proxy Analysis:', proxyInfo);
-    }
-  })
-  .catch(error => console.error('Error:', error));
-
-// Analyze multiple addresses
-analyzeMultipleAddresses([contractAddress, eoaAddress])
-  .then(results => console.log('Multiple Address Analysis:', results))
-  .catch(error => console.error('Error:', error));
-```
 
 ## Hyperliquid-specific considerations
 
@@ -170,6 +49,8 @@ analyzeMultipleAddresses([contractAddress, eoaAddress])
 - Use for implementing different handling logic for different address types
 
 ## Example request
+
+This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
 ```shell Shell
 curl -X POST \

--- a/reference/hyperliquid-evm-eth-get-logs.mdx
+++ b/reference/hyperliquid-evm-eth-get-logs.mdx
@@ -128,112 +128,6 @@ The method returns an array of log objects matching the filter criteria.
 }
 ```
 
-## Usage example
-
-### Basic implementation
-
-```javascript
-// Get logs from Hyperliquid with proper constraints
-const getLogs = async (filterObject) => {
-  const response = await fetch('https://hyperliquid-mainnet.core.chainstack.com/YOUR_ENDPOINT/evm', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'eth_getLogs',
-      params: [filterObject],
-      id: 1
-    })
-  });
-  
-  const data = await response.json();
-  return data.result;
-};
-
-// Get Transfer events from a specific contract
-const getTransferEvents = async (contractAddress, fromBlock, toBlock) => {
-  // Ensure block range doesn't exceed 50 blocks (Hyperliquid limit)
-  const startBlock = parseInt(fromBlock, 16);
-  const endBlock = parseInt(toBlock, 16);
-  
-  if (endBlock - startBlock > 50) {
-    throw new Error('Block range cannot exceed 50 blocks on Hyperliquid');
-  }
-  
-  const filter = {
-    address: contractAddress,
-    topics: [
-      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef" // Transfer event signature
-    ],
-    fromBlock: fromBlock,
-    toBlock: toBlock
-  };
-  
-  const logs = await getLogs(filter);
-  
-  // Decode Transfer events
-  return logs.map(log => ({
-    from: "0x" + log.topics[1].slice(26), // Remove padding
-    to: "0x" + log.topics[2].slice(26),
-    value: parseInt(log.data, 16),
-    blockNumber: parseInt(log.blockNumber, 16),
-    transactionHash: log.transactionHash
-  }));
-};
-
-// Get logs with multiple topic filters (up to 4 topics on Hyperliquid)
-const getFilteredLogs = async (contractAddress, fromBlock, toBlock) => {
-  const filter = {
-    address: contractAddress,
-    topics: [
-      ["0xevent1hash", "0xevent2hash"], // Multiple event types
-      null, // Any value for second topic
-      "0xspecificvalue", // Specific value for third topic
-      null  // Any value for fourth topic (max 4 topics on Hyperliquid)
-    ],
-    fromBlock: fromBlock,
-    toBlock: toBlock
-  };
-  
-  return await getLogs(filter);
-};
-
-// Process logs in chunks to respect 50-block limit
-const processLogsInChunks = async (contractAddress, startBlock, endBlock) => {
-  const allLogs = [];
-  const chunkSize = 50; // Hyperliquid limit
-  
-  for (let i = startBlock; i <= endBlock; i += chunkSize) {
-    const chunkEnd = Math.min(i + chunkSize - 1, endBlock);
-    const fromBlockHex = "0x" + i.toString(16);
-    const toBlockHex = "0x" + chunkEnd.toString(16);
-    
-    try {
-      const logs = await getTransferEvents(contractAddress, fromBlockHex, toBlockHex);
-      allLogs.push(...logs);
-    } catch (error) {
-      console.error(`Error processing blocks ${i}-${chunkEnd}:`, error);
-    }
-  }
-  
-  return allLogs;
-};
-
-// Usage examples
-const contractAddress = "0x5555555555555555555555555555555555555555";
-
-getTransferEvents(contractAddress, "0x9d0c37", "0x9d0c42")
-  .then(transfers => console.log('Transfer Events:', transfers))
-  .catch(error => console.error('Error:', error));
-
-// Process larger range in chunks
-processLogsInChunks(contractAddress, 10291248, 10291348)
-  .then(allLogs => console.log(`Processed ${allLogs.length} events`))
-  .catch(error => console.error('Error:', error));
-```
-
 ## Hyperliquid-specific limitations
 
 ### Block range constraint
@@ -291,6 +185,8 @@ processLogsInChunks(contractAddress, 10291248, 10291348)
 ```
 
 ## Example request
+
+This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
 ```shell Shell
 curl -X POST \

--- a/reference/hyperliquid-evm-eth-get-storage-at.mdx
+++ b/reference/hyperliquid-evm-eth-get-storage-at.mdx
@@ -232,6 +232,8 @@ getStorageAt(contractAddress, '0x0')
 
 ## Example request
 
+This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \

--- a/reference/hyperliquid-info-perpdeployauctionstatus.mdx
+++ b/reference/hyperliquid-info-perpdeployauctionstatus.mdx
@@ -3,6 +3,10 @@ title: perpDeployAuctionStatus | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_perpdeployauctionstatus.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Note>
+The `perpDeployAuctionStatus` call will return non-null when [HIP-3: Builder-Deployed Perpetuals](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-3-builder-deployed-perpetuals) goes live on the mainnet.
+</Note>
+
 The `info` endpoint with `type: "perpDeployAuctionStatus"` retrieves the status information about perpetual contract deployment auctions on the Hyperliquid exchange. This endpoint provides timing information and gas-related data for the auction system.
 
 <Check>

--- a/reference/hyperliquid-info-perpdexs.mdx
+++ b/reference/hyperliquid-info-perpdexs.mdx
@@ -3,6 +3,10 @@ title: perpDexs | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_perpdexs.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Note>
+The `perpDexs` call will return non-null when [HIP-3: Builder-Deployed Perpetuals](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-3-builder-deployed-perpetuals) goes live on the mainnet.
+</Note>
+
 The `info` endpoint with `type: "perpDexs"` retrieves information about all available perpetual DEXs (Decentralized Exchanges) on the Hyperliquid ecosystem. This endpoint provides basic identification and deployment information for each perpetual DEX instance.
 
 <Check>

--- a/reference/hyperliquid-info-referral.mdx
+++ b/reference/hyperliquid-info-referral.mdx
@@ -9,6 +9,8 @@ You can only use this endpoint on the official Hyperliquid public API. It is not
 
 The `info` endpoint with `type: "referral"` retrieves comprehensive referral information for a specific user on the Hyperliquid exchange. This endpoint provides detailed data about referral relationships, rewards, volume metrics, and referrer status, enabling thorough analysis of referral program participation and performance.
 
+The example curl call is for the user `0x1442ad477ded1b0028b57621aa7b6f7eadb8f568` that used the AXIOM referral code `0x1cc34f6af34653c515b47a83e1de70ba9b0cda1f`. Here's an example `setReferrer` transaction [0xaa79d3a0073a73925828041e25e24a012300149a6f622a0727287dafe158fff5](https://hypurrscan.io/tx/0xaa79d3a0073a73925828041e25e24a012300149a6f622a0727287dafe158fff5).
+
 <Check>
 **Get your own node endpoint today**
 

--- a/reference/hyperliquid-info-user-funding.mdx
+++ b/reference/hyperliquid-info-user-funding.mdx
@@ -9,6 +9,10 @@ You can only use this endpoint on the official Hyperliquid public API. It is not
 
 The `info` endpoint with `type: "userFunding"` retrieves the funding history for a specific user account on the Hyperliquid exchange. This endpoint provides detailed information about funding payments and receipts across all perpetual positions over time, allowing users to track their funding costs and analyze trading performance.
 
+<Info>
+This endpoint is similar to [userNonFundingLedgerUpdates](/reference/hyperliquid-info-user-non-funding-ledger-updates) — both query the Hyperliquid `info` API with different `type` values and return structurally similar arrays. The key difference is in the output content: this page returns only funding events, while [userNonFundingLedgerUpdates](/reference/hyperliquid-info-user-non-funding-ledger-updates) returns all other balance‑affecting ledger updates (deposits, withdrawals, transfers, liquidations, spot activity), excluding funding.
+</Info>
+
 <Check>
 **Get your own node endpoint today**
 

--- a/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
+++ b/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
@@ -9,6 +9,10 @@ You can only use this endpoint on the official Hyperliquid public API. It is not
 
 The `info` endpoint with `type: "userNonFundingLedgerUpdates"` retrieves comprehensive ledger updates for a specific user account on the Hyperliquid exchange, excluding funding payments. This endpoint provides detailed information about all account activities including deposits, withdrawals, transfers, liquidations, spot trading, and other balance-affecting operations.
 
+<Info>
+This endpoint is similar to [userFunding](/reference/hyperliquid-info-user-funding) — both query the Hyperliquid `info` API with different `type` values and return arrays of time‑ordered events. The difference is in scope: [userFunding](/reference/hyperliquid-info-user-funding) returns only funding events, whereas this page returns non‑funding ledger updates (deposits, withdrawals, transfers, liquidations, spot activity).
+</Info>
+
 <Check>
 **Get your own node endpoint today**
 

--- a/reference/polygon-getblockreceipts.mdx
+++ b/reference/polygon-getblockreceipts.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getBlockReceipts | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that retrieves all transaction receipts for a given block. Transaction receipts contain information about the execution status of a transaction and can be useful for monitoring the status of transfers or contract execution on the blockchain. This method is available on Erigon only.
@@ -18,11 +19,11 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 * `quantity or tag` — the block hash, block number encoded as hexadecimal, or the string with:
 
   + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block
-  + `earliest` — the earliest available or genesis block.
+  + `earliest` — the earliest available or genesis block
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 
@@ -126,7 +127,7 @@ async function retrieveTransactionLogs(blockNumber) {
 
 // call retrieveTransactionLogs on the latest block of the chain
 async function main() {
-    const blockNumber = 'lates';
+     const blockNumber = 'latest';
     const logs = await retrieveTransactionLogs(blockNumber);
     console.log(logs);
 }

--- a/reference/polygon-gettransactionbyblockhashandindex.mdx
+++ b/reference/polygon-gettransactionbyblockhashandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockHashAndIndex | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that retrieves information about a specific transaction based on the block hash and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Ethereum blockchain.

--- a/reference/polygon-gettransactionbyblocknumberandindex.mdx
+++ b/reference/polygon-gettransactionbyblocknumberandindex.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByBlockNumberAndIndex | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that retrieves information about a specific transaction based on the block number and the transaction index within the block. This information can be used to track transactions, debug issues, analyze data, and build decentralized applications on the Polygon blockchain.
@@ -18,7 +19,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
 
   + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block.
-  + `earliest` — the earliest available or genesis block.
+  + `earliest` — the earliest available or genesis block
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>

--- a/reference/polygon-gettransactionbyhash.mdx
+++ b/reference/polygon-gettransactionbyhash.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionByHash | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns the information about a transaction from the transaction hash. It is used to retrieve information about a specific transaction by its hash. The method returns an object with details about the transaction, such as the sender, recipient, gas used, transaction value, and more.
@@ -28,7 +29,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `maxFeePerGas` — the maximum amount the sender of the transaction is willing to pay per unit of gas for the transaction to be executed.
   + `maxPriorityFeePerGas` — the maximum priority fee the sender of the transaction is willing to pay per unit of gas.
   + `hash` — the hash that uniquely identifies the transaction.
-  + `input` — the optional input data sent with the transaction., usually used to interact with smart contracts.
+  + `input` — the optional input data sent with the transaction, usually used to interact with smart contracts.
   + `nonce` — a counter identifying the transaction's number sent by the sender wallet; it essentially identifies how many transactions an account has made. Used to ensure each transaction is executed only once.
   + `to` — the address of the recipient of the transaction if it was a transaction to an address. For contract creation transactions, this field is `null`.
   + `transactionIndex` — the index of the transaction within the block. This field is `null` for transactions that have not yet been included in a block.

--- a/reference/polygon-gettransactionreceipt.mdx
+++ b/reference/polygon-gettransactionreceipt.mdx
@@ -1,5 +1,6 @@
 ---
 title: eth_getTransactionReceipt | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 <Note>

--- a/reference/polygon-newpendingtransactionfilter.mdx
+++ b/reference/polygon-newpendingtransactionfilter.mdx
@@ -1,8 +1,9 @@
 ---
 title: eth_newPendingTransactionFilter | Polygon
+openapi: /openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
-Polygon API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the [eth\_getFilterChanges](/reference/getfilterchanges) method. The `eth_newBlockFilter` method is useful for developers who must be notified of new blocks on the blockchain in real time.
+Polygon API method that creates a filter that listens for new pending transactions on the blockchain. It returns a filter ID, which can be used to retrieve the results using the `eth_getFilterChanges` method. The `eth_newPendingTransactionFilter` method is useful for developers who must be notified of new pending transactions in real time.
 
 <Check>
 **Get you own node endpoint today**
@@ -24,14 +25,14 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 ## Code examples
 
 <Warning>
-The filters created are stored on the blockchain client instance. The filter fill is automatically deleted if not polled within a certain time (5 minutes by default).
+The filters created are stored on the blockchain client instance. The filter is automatically deleted if not polled within a certain time (5 minutes by default).
 </Warning>
 
 
 Use the following methods with the filter ID:
 
-* [eth\_getFilterChanges](/reference/getfilterchanges) to retrieve updates
-* [eth\_uninstallFilter](/reference/uninstallfilter) to remove the filter
+* `eth_getFilterChanges` to retrieve updates
+* `eth_uninstallFilter` to remove the filter
 
 ## `eth_newPendingTransactionFilter` code examples
 
@@ -152,7 +153,5 @@ This code sets up an Ethereum filter to listen for new pending transactions and 
 The code consists of three functions: `createFilter`, `getValue`, and `main`. Here's an overview of how each function works:
 
 The `createFilter` function sets up a new filter using the `eth_newPendingTransactionFilter` method. It returns the ID of the filter, which can be used to retrieve data from the filter later.
-
-The `getValue` function retrieves the list of new pending transactions using the [eth\_getFilterChanges](/reference/getfilterchanges) method and loops through each transaction. For each transaction, it retrieves the transaction data using the [eth\_getTransactionByHash](/reference/polygon-gettransactionbyhash) method and checks if the transaction value is greater than or equal to 100 MATIC. If the value is above this threshold, the function logs information about the transaction to the console.
 
 The `main` function sets up the program by first calling the `createFilter` function to create a new filter and retrieve its ID. It then sets an interval to call the `getValue` function every 1 second, passing the filter ID as an argument to retrieve the latest transaction data at regular intervals.

--- a/reference/polygon-trace_block.mdx
+++ b/reference/polygon-trace_block.mdx
@@ -1,5 +1,6 @@
 ---
 title: trace_block | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/trace_block.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns traces for all the transactions within a specific block. Developers can use the `trace_block` method to gain insight into the behavior of smart contracts within a block, analyze gas usage and optimize their contracts accordingly. This method is only available on an Erigon instance.
@@ -22,7 +23,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 

--- a/reference/polygon-trace_transaction.mdx
+++ b/reference/polygon-trace_transaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: trace_transaction | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/trace_transaction.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that traces a specific transaction. It provides a detailed record of all the steps taken by the Ethereum Virtual Machine (EVM) during the execution, including all the operations performed and the changes made to the blockchain state. This method is available on Erigon only.

--- a/reference/polygon-traceblockbyhash.mdx
+++ b/reference/polygon-traceblockbyhash.mdx
@@ -1,5 +1,6 @@
 ---
 title: debug_traceBlockByHash | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that traces the execution of a block. This method can be used to debug and analyze smart contracts and transactions on the Polygon blockchain. It provides a detailed trace of the execution of a block, including information on all the transactions and calls that interacted with the block, as well as the gas used, memory, storage operations, and other performance metrics for each operation.

--- a/reference/polygon-traceblockbynumber.mdx
+++ b/reference/polygon-traceblockbynumber.mdx
@@ -1,5 +1,6 @@
 ---
 title: debug_traceBlockByNumber | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that enables the tracing of the execution of a specific block using its number. This method can be used to troubleshoot and analyze smart contracts and transactions on the Polygon blockchain. It provides an in-depth trace of the block execution, with details on all the interactions, such as transactions and calls, that took place.
@@ -26,7 +27,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 * `tracer` — an object identifying the type of tracer and its configuration:

--- a/reference/polygon-tracecall.mdx
+++ b/reference/polygon-tracecall.mdx
@@ -1,5 +1,6 @@
 ---
 title: debug_traceCall | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceCall.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that traces the execution of [eth\_call | Polygon](/reference/ethcall) within the context of a specific block's execution. This method uses the final state of the parent block as its base and allows developers to trace the execution of a particular call.
@@ -34,7 +35,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `pending` — the pending state and transactions block. The current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
-See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter).
+See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).
 </Note>
 
 * `object` — (optional) an object identifying the type of tracer and its configuration:

--- a/reference/polygon-tracetransaction.mdx
+++ b/reference/polygon-tracetransaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: debug_traceTransaction | Polygon
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json POST /a9bca2f0f84b54086ceebe590316fff3
 ---
 
 Polygon API method that returns a transaction's traces by replaying it. This method provides a detailed breakdown of every step in the execution of a transaction on the Polygon blockchain, including gas usage and opcode output. What sets it apart is its ability to accurately simulate the transaction's execution path by replaying any prior transactions, making it a powerful tool for developers to identify and diagnose issues in their applications.
@@ -49,7 +50,7 @@ Note that on an Erigon client, this setting is the opposite and is named `disabl
 * `timeout` — setting that allows developers to customize the method's timeout period for JavaScript-based tracing calls. The default timeout is `5s`, and you can find the values formats in the [Go documentation](https://pkg.go.dev/time#ParseDuration).
 
 <Note>
-It's worth noting that when using one of the three built-in tracers in Polygon clients, the `enableMemory`, `disableStorage`, `disableStack`, and `enableReturnData`settings will not have any effect.
+It's worth noting that when using one of the three built-in tracers in Polygon clients, the `enableMemory`, `disableStorage`, `disableStack`, and `enableReturnData` settings will not have any effect.
 
 When no built-in tracer is selected, the response defaults to the [Struct/opcode logger](https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#structopcode-logger).
 </Note>

--- a/reference/trace-filter-fantom.mdx
+++ b/reference/trace-filter-fantom.mdx
@@ -20,6 +20,15 @@ description: "Fantom API method that filters and retrieves transaction execution
 * `offset` — the offset trace number, indicating the starting point for trace retrieval. This is useful for pagination.
 * `count` — the integer number of traces to display in a batch, allowing for controlled data retrieval.
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"trace_filter","params":[{"fromBlock":"0x4bbb701","toBlock":"0x4bbb701","toAddress":["0x5dD4A25B354993e3201419db5172dfEEDaF39AdF"],"offset":2,"count":1}]}'
+```
+
 ## Response
 
 * `blockHash` — the hash of the block in which the trace was included.

--- a/reference/trace-get-fantom.mdx
+++ b/reference/trace-get-fantom.mdx
@@ -16,6 +16,15 @@ description: "Fantom API method that retrieves a specific trace from a transacti
 * `txHash` — the hash of the transaction from which to retrieve the trace.
 * `traceIndex` — an array of integers specifying the zero-based indices of the traces to retrieve.
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"trace_get","params":["0xa2b1e35f59d184da1996b37803ed2e8e81057be7d07a93af48a410fd9338d616", ["0x1"]]}'
+```
+
 ## Response
 
 * `action` — an object that describes the action taken by the transaction:

--- a/reference/trace-transaction-fantom.mdx
+++ b/reference/trace-transaction-fantom.mdx
@@ -15,6 +15,15 @@ description: "Fantom API method that traces a specific transaction. It provides 
 
 * `hash` — the hash identifying a transaction
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"trace_transaction","params":["0xa2b1e35f59d184da1996b37803ed2e8e81057be7d07a93af48a410fd9338d616"]}'
+```
+
 ## Response
 
 * `action` — an object that describes the action taken by the transaction:

--- a/reference/trace_block-fantom.mdx
+++ b/reference/trace_block-fantom.mdx
@@ -29,6 +29,15 @@ description: "Fantom API method that returns traces for all the transactions wit
       See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-block-parameter) and [How The Merge Impacts Ethereum’s Application Layer](https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer).
     </Info>
 
+## JSON-RPC example
+
+```shell
+curl https://fantom-mainnet.core.chainstack.com/4ab982aa70a7baead515ffdb5915df3f \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"jsonrpc":"2.0","id":1,"method":"trace_block","params":["latest"]}'
+```
+
 ## Response
 
 * `result` — an object containing the traces of all of the transactions in the block:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added OpenAPI metadata across Arbitrum, Ethereum, Polygon, and Gnosis reference pages.
  - Added/updated JSON-RPC examples for Fantom and Arbitrum; introduced stylusTracer availability note.
  - Updated default block links to ethereum.org; clarified notes for Hyperliquid endpoints.
  - Simplified Hyperliquid examples; removed overly detailed sections.
  - Fixed typos/punctuation and corrected sample parameters (e.g., “lates” → “latest”).
- Chores
  - Removed duplicate page entries in docs.json for TON and Zksync groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->