### PR TITLE
Trader nodes are paid plans note

### DIFF
--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -9,6 +9,10 @@ description: "A Trader Node is a service providing a regional-based endpoints wh
   Trader nodes are extremely useful when used with [Warp transactions](/docs/warp-transactions) on Solana, Ethereum, BNB Smart Chain.
 </Check>
 
+<Note>
+Trader nodes are available starting from the [paid plans](https://chainstack.com/pricing/).
+</Note>
+
 ## Modes
 
 For Trader Nodes deployed on the most of public chains, Chainstack supports the following modes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified availability of Trader nodes by adding a note indicating they’re accessible starting from paid plans, with a direct link to pricing.
  * Improves transparency on plan requirements and eligibility, reducing confusion during setup and evaluation.
  * No functional changes; content update only to guide users on access and potential upgrade paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->