### PR TITLE
Change MCP server instructions to streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,32 @@ Since we are in the age of AI and LLMs, here are three additional ways to use th
 
 * This repository is public, so your agents can just ingest it.
 * [llms-full.txt](https://docs.chainstack.com/llms-full.txt) is automatically generated and published on every change.
-* Built-in MCP server — just run `npx @mintlify/mcp@latest add chainstack` to add the Developer Portal as a local MCP server.
+* Hosted MCP server — available at `https://docs.chainstack.com/mcp` (streamable HTTP, not SSE).
 
 Note that the Developer Portal MCP server is a docs project and is different from an [RPC node MCP server](https://ideas.chainstack.com/p/mcp-server) that we are also building.
 
 ### MCP server
 
-Built-in MCP server — just run `npx @mintlify/mcp@latest add chainstack` to add the Developer Portal as a local MCP server.
+The Chainstack Developer Portal provides a hosted MCP (Model Context Protocol) server at `https://docs.chainstack.com/mcp`.
+
+This is a **streamable HTTP** MCP server (not SSE). It provides AI models with access to search and navigate through all Chainstack documentation.
+
+#### Supported AI tools
+
+* **Claude Code**: `claude mcp add --transport http Chainstack-Developer-Portal https://docs.chainstack.com/mcp`
+* **Cursor**: Click the "Connect to Cursor" button on any docs page
+* **VS Code**: Click the "Connect to VS Code" button on any docs page  
+* **Windsurf**: Add to `~/.codeium/windsurf/mcp_config.json`:
+  ```json
+  {
+    "mcpServers": {
+      "chainstack-developer-portal": {
+        "serverUrl": "https://docs.chainstack.com/mcp"
+      }
+    }
+  }
+  ```
+* **Kiro**: Not yet supported (tracking: [kirodotdev/Kiro#23](https://github.com/kirodotdev/Kiro/issues/23))
 
 ### Contributing to the Developer Portal
 

--- a/docs.json
+++ b/docs.json
@@ -24,7 +24,11 @@
       "copy",
       "view",
       "chatgpt",
-      "claude"
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
     ]
   },
   "api": {

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -5,115 +5,72 @@ description: "Access Chainstack's documentation and development resources throug
 
 The **Developer Portal MCP server** is integrated with Chainstack's documentation platform powered by Mintlify. This MCP server provides AI models with comprehensive access to Chainstack's blockchain development resources, documentation, and guides.
 
+This is a streamable HTTP MCP server, and not an SSE connection. Streamable HTTP is the latest MCP standard overtaking SSE.
+
 ## Installation
 
-Install the Developer Portal MCP server using the Mintlify MCP CLI:
+You can install the Developer Portal MCP server using the contextual menu buttons at the top of this page:
 
-```bash
-npx mint-mcp add chainstack
+- **Copy MCP Server** — copies the streamable HTTP MCP server URL to your clipboard
+- **Connect to Cursor** — automatically installs the MCP server in Cursor
+- **Connect to VS Code** — automatically installs the MCP server in VS Code
+
+### Cursor
+
+Just click the **Connect to Cursor** button at the top of any page to automatically install the MCP server in Cursor.
+
+### VS Code
+
+Just click the **Connect to VS Code** button at the top of any page to automatically install the MCP server in VS Code.
+
+### Claude Code
+
+To add the Chainstack MCP server to Claude Code, use the following command:
+
+```
+claude mcp add --transport http Chainstack-Developer-Portal https://docs.chainstack.com/mcp
 ```
 
-Select your AI IDE:
+The MCP server will be automatically configured and available in your Claude Code conversations.
 
-```bash
-?  Select MCP client: › Use arrow keys to select. Return to submit.
-❯   Cursor
-    Windsurf
-    Claude Desktop
-    All
-```
+### Windsurf
 
-This automatically configures the Chainstack Developer portal MCP server to work with the selected AI IDE by updating the `mcp.json` file.
+To add the Chainstack MCP server to Windsurf:
 
-To enable Amazon’s Kiro IDE, select any option, copy the printed output, and paste it into your `~/.kiro/settings/mcp.json` file.
+1. Open Windsurf Settings by pressing `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux)
+2. Type "Open Windsurf Settings" and select it
+3. Navigate to the **Cascade** section
+4. Click **"Add Custom Server +"** or edit the configuration file directly
 
-Example:
+Add the following configuration to `~/.codeium/windsurf/mcp_config.json`:
 
 ```json
 {
   "mcpServers": {
-    "aws-docs": {
-      "command": "uvx",
-      "args": ["awslabs.aws-documentation-mcp-server@latest"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false,
-      "autoApprove": []
-    },
-    "chainstack": {
-      "command": "node",
-      "args": [
-        "$HOME/.mcp/chainstack/src/index.js"
-      ]
+    "chainstack-developer-portal": {
+      "serverUrl": "https://docs.chainstack.com/mcp"
     }
   }
 }
 ```
 
-## Capabilities
+5. Save the configuration and click **"Refresh Servers"** in the Cascade settings
+6. Verify the integration by clicking the Hammer Icon in the Cascade toolbar — the Chainstack documentation search tool should appear
 
-### Documentation, guides, and best practices
-- **Getting started guides** for all supported blockchain protocols
-- **Step-by-step tutorials** for common blockchain development tasks
-- **Best practices** for blockchain application development
-- **Integration examples** and code snippets
+### Kiro
 
-### API references
-- **Complete API documentation** for all Chainstack services
-- **Method references** for supported blockchain protocols
-- **Request and response examples** for all API endpoints
-- **Authentication and authorization** guidelines
+<Note>
+Kiro does not currently support streamable HTTP MCP servers. Support is being tracked in [this feature request](https://github.com/kirodotdev/Kiro/issues/23). Once streamable HTTP support is added, the Chainstack Developer Portal MCP server will be compatible with Kiro.
+</Note>
 
-### Protocol information
-- **Network configurations** for all supported blockchains
-- **Node types and modes** available on Chainstack
-- **Supported methods** for each blockchain protocol
-- **Regional availability** and performance characteristics
+### Manual configuration
 
-### Tooling and development resources
-- **SDK documentation** and usage examples
-- **Development tools** and utilities
-- **Recipes** for common development tasks
+For other AI tools that support streamable HTTP MCP, use the following URL:
 
-## Integration with AI models
+```
+https://docs.chainstack.com/mcp
+```
 
-The Developer Portal MCP server seamlessly integrates with popular AI development environments:
+This URL provides access to the complete Chainstack documentation and development resources through the Model Context Protocol.
 
-### Cursor
-Configure the server in your [Cursor settings](https://docs.cursor.com/context/model-context-protocol) to access Chainstack's knowledge base directly within your conversations.
-
-### Claude Desktop
-Configure the server in your [Claude Desktop settings](https://modelcontextprotocol.io/quickstart/user) to access Chainstack's knowledge base directly within your conversations.
-
-### Claude Code
-Configure the server in your [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/mcp) to access Chainstack's knowledge base directly within your conversations.
-
-### Custom AI applications
-Use the MCP protocol to integrate Chainstack's documentation into your own AI-powered development tools and assistants.
-
-## Benefits
-
-Using the Developer Portal MCP server provides several advantages:
-
-- **Up-to-date information**: Always access the latest Chainstack documentation and features
-- **Consistent guidance**: Receive answers based on official Chainstack best practices
-- **Comprehensive coverage**: Access information about all supported protocols and services
-- **Structured knowledge**: Benefit from professionally curated and organized content
-
-## Next steps
-
-<CardGroup cols={2}>
-  <Card title="EVM MCP server" href="/docs/evm-mcp-server">
-    Combine with live blockchain interactions
-  </Card>
-  <Card title="Solana MCP server" href="/docs/solana-mcp-server">
-    Add Solana blockchain capabilities
-  </Card>
-  <Card title="Mintlify MCP documentation" href="https://mintlify.com/docs/mcp" icon="external-link">
-    Learn more about MCP integration
-  </Card>
-  <Card title="Chainstack API documentation" href="/reference/blockchain-apis">
-    Explore available APIs and methods
-  </Card>
-</CardGroup> 
+Again, do note that this is a streamable HTTP MCP connection, and not an SSE connection. Streamable HTTP is the latest MCP standard overtaking SSE.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added new docs site options for Perplexity, MCP, Cursor, and VS Code in contextual actions.

- Documentation
  - Updated README to describe the hosted MCP server (streamable HTTP, not SSE) at https://docs.chainstack.com/mcp, with “Supported AI tools” and integration steps for Claude Code, Cursor, VS Code, and Windsurf (JSON example). Noted Kiro is not yet supported and clarified separation from the RPC node MCP server.
  - Rewrote Developer Portal MCP server guide with UI-driven setup, direct commands, tool-specific flows, manual config path, and HTTP (not SSE) emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->