### PR TITLE
Add a note on TRON WebSocket events

### DIFF
--- a/docs/tron-tooling.mdx
+++ b/docs/tron-tooling.mdx
@@ -16,6 +16,12 @@ title: "TRON tooling"
 
 For the full API reference, see the official [TRON API Reference](https://developers.tron.network/reference/).
 
+<Note>
+  ### WebSocket event subscription not available
+  
+  TRON nodes currently do not support WebSocket connections for event subscriptions. If you need to subscribe to events, please vote and follow the feature request at [TRON event plugin support](https://ideas.chainstack.com/p/implement-tron-event-plugin).
+</Note>
+
 ## MetaMask
 
 On [node access details](/docs/manage-your-node#view-node-access-and-credentials), click **Add to MetaMask**.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a note after the TRON tooling API reference clarifying that TRON nodes do not support WebSocket-based event subscriptions.
  - Included a “WebSocket event subscription not available” header and a link to the TRON event plugin support feature request for tracking.
  - Informational update only; no functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->