### PR TITLE
docs: add release notes for WARP & Unichain testnet (August 22, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,15 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: August 21, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Unichain Tetsnet. 
+**WARP**. Now WARP transactions are available for GEN Nodes for Solana, Ethereum, and BSC.
+
+<Button href="/changelog/chainstack-updates-august-21-2025">Read more</Button>
+</Update>
+
+
 <Update label="Chainstack updates: August 11, 2025" description=" by Ake" >
 
 **Protocols**. Flashblocks preconfirmations for the Base nodes are now available on Chainstack. See [Flashblocks on Base](/docs/flashblocks-on-base).

--- a/changelog/chainstack-updates-august-22-2025.mdx
+++ b/changelog/chainstack-updates-august-22-2025.mdx
@@ -1,0 +1,5 @@
+---
+title: "Chainstack updates: August 22, 2025"
+---
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for Unichain Tetsnet. 
+**WARP**. Now WARP transactions are available for GEN Nodes for Solana, Ethereum, and BSC.

--- a/docs.json
+++ b/docs.json
@@ -2565,6 +2565,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-22-2025",
           "changelog/chainstack-updates-august-11-2025",
           "changelog/chainstack-updates-august-5-2025",
           "changelog/chainstack-updates-june-27-2025",


### PR DESCRIPTION
Relnotes: WARP + Unichain