### PR TITLE
Add missing methods for TRON

### DIFF
--- a/docs/tron-methods.mdx
+++ b/docs/tron-methods.mdx
@@ -61,8 +61,10 @@ title: "TRON methods"
 | getaccount                                 | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getaccountbalance                          | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getaccountnet                              | /wallet         | <Icon icon="square-check" iconType="solid" /> |
+| getaccountresource                         | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getakfromask                               | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getapprovedlist                            | /wallet         | <Icon icon="square-check" iconType="solid" /> |
+| getassetissuebyaccount                     | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getassetissuebyid                          | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getassetissuebyname                        | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | getassetissuelist                          | /wallet         | <Icon icon="square-check" iconType="solid" /> |
@@ -112,6 +114,7 @@ title: "TRON methods"
 | listnodes                                  | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | listproposals                              | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | listwitnesses                              | /wallet         | <Icon icon="square-check" iconType="solid" /> |
+| totaltransaction                           | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | participateassetissue                      | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | proposalapprove                            | /wallet         | <Icon icon="square-check" iconType="solid" /> |
 | proposalcreate                             | /wallet         | <Icon icon="square-check" iconType="solid" /> |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded TRON wallet documentation with three newly listed methods: getaccountresource, getassetissuebyaccount, and totaltransaction under the /wallet section.
  - Improved discoverability and reference coverage for developers integrating TRON by including these methods in the methods table.
  - No functional or behavioral changes; this update solely enhances documentation for easier lookup and implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->