### PR TITLE
Add from_slot note on Geyser

### DIFF
--- a/docs/yellowstone-grpc-geyser-plugin.mdx
+++ b/docs/yellowstone-grpc-geyser-plugin.mdx
@@ -19,7 +19,7 @@ Benefits
 - Uses a standard gRPC interface with protobuf-formatted payloads.
 - Accessible from any language supporting gRPC (Python, Go, Rust, JavaScript).
 - Ideal for analytics, sniping bots, MEV strategies, data indexing, real-time dashboards, and compliance monitoring.
-- Comprehensive data including transaction details, instructions, and logs.
+- `from_slot`/`fromSlot` support to replay and recover missed events. For an example, see `learning-examples/historical_replay_with_from_slot.py` in [Solana Geyser Python tutorial](https://github.com/chainstacklabs/grpc-geyser-tutorial).
 
 ## Enable the Yellowstone gRPC Geyser plugin
 
@@ -62,7 +62,7 @@ The following Solana accounts are unavailable for streaming:
 See:
 
 - [Solana Geyser Python tutorial](https://github.com/chainstacklabs/grpc-geyser-tutorial)
-- [Bonk fun sniping bot with Geyser](https://github.com/chainstacklabs/letsbonk-fun-bot)
+- [Pump fun and Bonk fun sniping bot with Geyser](https://github.com/chainstacklabs/pumpfun-bonkfun-bot)
 - [Solana: Listening to pump.fun token mint using Geyser](/docs/solana-listening-to-pumpfun-token-mint-using-geyser)
 - [Solana: Listening to programs using Geyser and Yellowstone gRPC (Node.js)](/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js)
 - [Yellowstone repository](https://github.com/rpcpool/yellowstone-grpc)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Benefits to highlight support for from_slot/fromSlot parameters to replay and recover missed events, with a link to an example script in the Solana Geyser Python tutorial.
  * Renamed and refreshed Tooling reference to “Pump fun and Bonk fun sniping bot with Geyser,” updating the link to the new URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->