### PR TITLE
Add Ethereum debug beacon API refs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1382,7 +1382,10 @@
                   "reference/getcommitteesbystateidepochindexandslot",
                   "reference/getfinalitycheckpoints",
                   "reference/getstateroot",
-                  "reference/getblobsidecarbyslot"
+                  "reference/getblobsidecarbyslot",
+                  "reference/getdebugbeaconstatev2",
+                  "reference/getdebugbeaconheadsv2",
+                  "reference/getdebugforkchoice"
                 ]
               }
             ]

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconHeadsV2.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconHeadsV2.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Ethereum Beacon Debug Heads API",
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://ethereum-mainnet.core.chainstack.com"
+    }
+  ],
+  "paths": {
+    "/beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v2/debug/beacon/heads": {
+      "get": {
+        "summary": "Get fork choice leaves",
+        "operationId": "getDebugBeaconHeadsV2",
+        "description": "Retrieves all possible chain heads (leaves of fork choice tree). This endpoint provides insight into the current fork choice state by returning all potential chain heads that the beacon node is tracking.",
+        "tags": [
+          "Debug"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success - Fork choice leaves retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDebugChainHeadsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetDebugChainHeadsResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Array of all chain heads (fork choice leaves)",
+            "items": {
+              "$ref": "#/components/schemas/ChainHead"
+            }
+          }
+        }
+      },
+      "ChainHead": {
+        "type": "object",
+        "required": [
+          "root",
+          "slot",
+          "execution_optimistic"
+        ],
+        "properties": {
+          "root": {
+            "type": "string",
+            "format": "hex",
+            "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+            "pattern": "^0x[a-fA-F0-9]{64}$",
+            "description": "The block root of this chain head"
+          },
+          "slot": {
+            "type": "string",
+            "example": "1",
+            "description": "The slot number of this chain head"
+          },
+          "execution_optimistic": {
+            "type": "boolean",
+            "example": false,
+            "description": "True if this head references an unverified execution payload. Optimistic information may be invalidated at a later time."
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "example": 500
+          },
+          "message": {
+            "type": "string",
+            "example": "Internal server error"
+          },
+          "stacktraces": {
+            "type": "array",
+            "description": "Optional stacktraces, sent when node is in debug mode",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-readme": {
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  }
+}

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconStateV2.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconStateV2.json
@@ -1,0 +1,299 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Ethereum Beacon Debug State API",
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://ethereum-mainnet.core.chainstack.com"
+    }
+  ],
+  "paths": {
+    "/beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v2/debug/beacon/states/{state_id}": {
+      "get": {
+        "summary": "Get full BeaconState object",
+        "operationId": "getDebugBeaconStateV2",
+        "description": "Returns full BeaconState object for given stateId. This is a comprehensive debug endpoint that provides the complete state of the beacon chain at a specific point, including all validator information, balances, and other state details. Depending on Accept header it can be returned either as JSON or as bytes serialized by SSZ.",
+        "tags": [
+          "Debug"
+        ],
+        "parameters": [
+          {
+            "name": "state_id",
+            "in": "path",
+            "description": "State identifier. Can be one of: 'head' (canonical head in node's view), 'genesis', 'finalized', 'justified', <slot>, <hex encoded stateRoot with 0x prefix>.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "head"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success - Full BeaconState object retrieved",
+            "headers": {
+              "Eth-Consensus-Version": {
+                "description": "The active consensus version to which the data belongs. Required in response so client can deserialize returned JSON or SSZ data more effectively.",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "phase0",
+                    "altair",
+                    "bellatrix",
+                    "capella",
+                    "deneb",
+                    "electra"
+                  ],
+                  "example": "deneb"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetStateV2Response"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "description": "SSZ serialized BeaconState object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid state ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "State not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetStateV2Response": {
+        "type": "object",
+        "required": [
+          "version",
+          "execution_optimistic",
+          "finalized",
+          "data"
+        ],
+        "properties": {
+          "version": {
+            "type": "string",
+            "enum": [
+              "phase0",
+              "altair",
+              "bellatrix",
+              "capella",
+              "deneb",
+              "electra"
+            ],
+            "example": "deneb",
+            "description": "The consensus version of the state"
+          },
+          "execution_optimistic": {
+            "type": "boolean",
+            "example": false,
+            "description": "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time."
+          },
+          "finalized": {
+            "type": "boolean",
+            "example": false,
+            "description": "True if the response references the finalized history of the chain, as determined by fork choice."
+          },
+          "data": {
+            "type": "object",
+            "description": "The full BeaconState object. The structure varies based on the consensus version.",
+            "properties": {
+              "genesis_time": {
+                "type": "string",
+                "example": "1606824023",
+                "description": "Unix timestamp of the chain genesis"
+              },
+              "genesis_validators_root": {
+                "type": "string",
+                "format": "hex",
+                "example": "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
+                "pattern": "^0x[a-fA-F0-9]{64}$",
+                "description": "Root hash of the genesis validators"
+              },
+              "slot": {
+                "type": "string",
+                "example": "1",
+                "description": "Current slot number"
+              },
+              "fork": {
+                "type": "object",
+                "description": "Fork information",
+                "properties": {
+                  "previous_version": {
+                    "type": "string",
+                    "format": "hex",
+                    "pattern": "^0x[a-fA-F0-9]{8}$"
+                  },
+                  "current_version": {
+                    "type": "string",
+                    "format": "hex",
+                    "pattern": "^0x[a-fA-F0-9]{8}$"
+                  },
+                  "epoch": {
+                    "type": "string",
+                    "example": "1"
+                  }
+                }
+              },
+              "latest_block_header": {
+                "type": "object",
+                "description": "Latest block header information"
+              },
+              "block_roots": {
+                "type": "array",
+                "description": "Array of recent block roots",
+                "items": {
+                  "type": "string",
+                  "format": "hex",
+                  "pattern": "^0x[a-fA-F0-9]{64}$"
+                }
+              },
+              "state_roots": {
+                "type": "array",
+                "description": "Array of recent state roots",
+                "items": {
+                  "type": "string",
+                  "format": "hex",
+                  "pattern": "^0x[a-fA-F0-9]{64}$"
+                }
+              },
+              "validators": {
+                "type": "array",
+                "description": "Array of all validators",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "pubkey": {
+                      "type": "string",
+                      "format": "hex",
+                      "pattern": "^0x[a-fA-F0-9]{96}$"
+                    },
+                    "withdrawal_credentials": {
+                      "type": "string",
+                      "format": "hex",
+                      "pattern": "^0x[a-fA-F0-9]{64}$"
+                    },
+                    "effective_balance": {
+                      "type": "string"
+                    },
+                    "slashed": {
+                      "type": "boolean"
+                    },
+                    "activation_eligibility_epoch": {
+                      "type": "string"
+                    },
+                    "activation_epoch": {
+                      "type": "string"
+                    },
+                    "exit_epoch": {
+                      "type": "string"
+                    },
+                    "withdrawable_epoch": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "balances": {
+                "type": "array",
+                "description": "Validator balances",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "eth1_data": {
+                "type": "object",
+                "description": "Eth1 chain data"
+              },
+              "eth1_data_votes": {
+                "type": "array",
+                "description": "Votes for Eth1 data",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "eth1_deposit_index": {
+                "type": "string",
+                "description": "Eth1 deposit index"
+              },
+              "previous_justified_checkpoint": {
+                "type": "object",
+                "description": "Previous justified checkpoint"
+              },
+              "current_justified_checkpoint": {
+                "type": "object",
+                "description": "Current justified checkpoint"
+              },
+              "finalized_checkpoint": {
+                "type": "object",
+                "description": "Finalized checkpoint"
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "example": 404
+          },
+          "message": {
+            "type": "string",
+            "example": "State not found"
+          }
+        }
+      }
+    }
+  },
+  "x-readme": {
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  }
+}

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugForkChoice.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugForkChoice.json
@@ -1,0 +1,200 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Ethereum Beacon Debug Fork Choice API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://ethereum-mainnet.core.chainstack.com"
+    }
+  ],
+  "paths": {
+    "/beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v1/debug/fork_choice": {
+      "get": {
+        "summary": "Get fork choice array",
+        "operationId": "getDebugForkChoice",
+        "description": "Retrieves all current fork choice context including justified and finalized checkpoints, and the complete fork choice tree with all nodes and their weights.",
+        "tags": [
+          "Debug"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success - Fork choice data retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetForkChoiceResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetForkChoiceResponse": {
+        "type": "object",
+        "description": "Debugging context of fork choice",
+        "required": [
+          "justified_checkpoint",
+          "finalized_checkpoint",
+          "fork_choice_nodes"
+        ],
+        "properties": {
+          "justified_checkpoint": {
+            "$ref": "#/components/schemas/Checkpoint"
+          },
+          "finalized_checkpoint": {
+            "$ref": "#/components/schemas/Checkpoint"
+          },
+          "fork_choice_nodes": {
+            "type": "array",
+            "description": "Fork choice nodes representing the complete fork choice tree",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/ForkChoiceNode"
+            }
+          },
+          "extra_data": {
+            "type": "object",
+            "description": "Optional extra data that clients may provide, which could differ from client to client"
+          }
+        }
+      },
+      "Checkpoint": {
+        "type": "object",
+        "description": "The Checkpoint object from the CL spec",
+        "required": [
+          "epoch",
+          "root"
+        ],
+        "properties": {
+          "epoch": {
+            "type": "string",
+            "example": "1",
+            "description": "The epoch number of this checkpoint"
+          },
+          "root": {
+            "type": "string",
+            "format": "hex",
+            "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+            "pattern": "^0x[a-fA-F0-9]{64}$",
+            "description": "The block root of this checkpoint"
+          }
+        }
+      },
+      "ForkChoiceNode": {
+        "type": "object",
+        "description": "Fork choice node attributes",
+        "required": [
+          "slot",
+          "block_root",
+          "parent_root",
+          "justified_epoch",
+          "finalized_epoch",
+          "weight",
+          "validity",
+          "execution_block_hash"
+        ],
+        "properties": {
+          "slot": {
+            "type": "string",
+            "example": "1",
+            "description": "The slot to which this block corresponds"
+          },
+          "block_root": {
+            "type": "string",
+            "format": "hex",
+            "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+            "pattern": "^0x[a-fA-F0-9]{64}$",
+            "description": "The signing merkle root of the BeaconBlock"
+          },
+          "parent_root": {
+            "type": "string",
+            "format": "hex",
+            "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+            "pattern": "^0x[a-fA-F0-9]{64}$",
+            "description": "The signing merkle root of the parent BeaconBlock"
+          },
+          "justified_epoch": {
+            "type": "string",
+            "example": "1",
+            "description": "The justified epoch from this block's perspective"
+          },
+          "finalized_epoch": {
+            "type": "string",
+            "example": "1",
+            "description": "The finalized epoch from this block's perspective"
+          },
+          "weight": {
+            "type": "string",
+            "example": "1",
+            "description": "The weight/score of this block in the fork choice algorithm"
+          },
+          "validity": {
+            "type": "string",
+            "enum": [
+              "valid",
+              "invalid",
+              "optimistic"
+            ],
+            "description": "The validity status of this block"
+          },
+          "execution_block_hash": {
+            "type": "string",
+            "format": "hex",
+            "example": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+            "pattern": "^0x[a-fA-F0-9]{64}$",
+            "description": "The block_hash from the execution_payload of the BeaconBlock"
+          },
+          "extra_data": {
+            "type": "object",
+            "description": "Optional extra data that clients may provide, which could differ from client to client"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "example": 500
+          },
+          "message": {
+            "type": "string",
+            "example": "Internal server error"
+          },
+          "stacktraces": {
+            "type": "array",
+            "description": "Optional stacktraces, sent when node is in debug mode",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-readme": {
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  }
+}

--- a/reference/getdebugbeaconheadsv2.mdx
+++ b/reference/getdebugbeaconheadsv2.mdx
@@ -1,0 +1,48 @@
+---
+title: Debug beacon chain heads
+openapi: /openapi/ethereum_beacon_chain_api/debug/getDebugBeaconHeadsV2.json
+  GET /beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v2/debug/beacon/heads
+---
+
+The `/eth/v2/debug/beacon/heads` method is a debug API endpoint in the Ethereum Beacon Chain that retrieves all possible chain heads, which are the leaves of the fork choice tree. This endpoint is crucial for understanding the current state of fork choice in the beacon chain, showing all potential chain tips that the node is currently tracking and considering as possible canonical chains.
+
+<Check>
+**Get you own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+This endpoint does not require any parameters.
+
+## Response
+
+The response provides an array of all current chain heads:
+
+* `data` — array of chain head objects, each containing:
+  + `root` — the block root (32-byte hex string) uniquely identifying this chain head
+  + `slot` — the slot number of this chain head
+  + `execution_optimistic` — boolean indicating whether this head references an unverified execution payload
+
+## Usage notes
+
+The `/eth/v2/debug/beacon/heads` method provides critical insight into the fork choice mechanism of the beacon chain. In a healthy network, there is typically one primary head representing the canonical chain, but during network partitions, high latency periods, or chain reorganizations, multiple heads may exist temporarily.
+
+This endpoint is particularly useful for:
+
+* **Network monitoring** — detecting potential chain splits or forks
+* **Validator operations** — understanding which chain heads are being considered for block production
+* **Debugging consensus issues** — identifying when and why multiple chain heads exist
+* **Fork choice analysis** — studying how the beacon chain resolves competing chains
+
+Multiple heads can occur naturally during normal operation due to:
+* Network latency causing temporary disagreement between nodes
+* Competing blocks being produced for the same slot
+* Chain reorganizations as the network converges on the canonical chain
+
+The `execution_optimistic` flag is important for understanding whether a head has been fully verified with the execution layer. Optimistic heads may be invalidated if the execution payload is later found to be invalid.
+
+This is a debug endpoint and may not be available on all beacon nodes. It provides a real-time view of the fork choice state and is essential for advanced monitoring and debugging of consensus layer behavior.

--- a/reference/getdebugbeaconstatev2.mdx
+++ b/reference/getdebugbeaconstatev2.mdx
@@ -1,0 +1,57 @@
+---
+title: Debug beacon state by state_id
+openapi: /openapi/ethereum_beacon_chain_api/debug/getDebugBeaconStateV2.json
+  GET /beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v2/debug/beacon/states/{state_id}
+---
+
+The `/eth/v2/debug/beacon/states/{state_id}` method is a debug API endpoint in the Ethereum Beacon Chain that provides the complete BeaconState object for a given state identifier. This endpoint is essential for developers, validators, and network engineers who need to inspect the full state of the beacon chain for debugging, analysis, or monitoring purposes. The BeaconState contains comprehensive information about all validators, their balances, attestations, and other critical chain state data.
+
+<Check>
+**Get you own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `{state_id}`: This parameter specifies the identifier of the beacon state to retrieve. The state identifier can be:
+  * `head` — the canonical head in the node's view (most recent state)
+  * `genesis` — the initial state at chain genesis
+  * `finalized` — the most recent finalized state
+  * `justified` — the most recent justified state
+  * A specific slot number (e.g., `1000`)
+  * A hex-encoded state root with 0x prefix (e.g., `0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2`)
+
+## Response
+
+The response includes comprehensive state information:
+
+* `version` — the consensus version of the state (phase0, altair, bellatrix, capella, deneb, or electra)
+* `execution_optimistic` — boolean indicating if the response references an unverified execution payload
+* `finalized` — boolean indicating if the response references the finalized history of the chain
+* `data` — the complete BeaconState object containing:
+  + `genesis_time` — Unix timestamp of chain genesis
+  + `genesis_validators_root` — root hash of genesis validators
+  + `slot` — current slot number
+  + `fork` — fork version information
+  + `latest_block_header` — most recent block header
+  + `block_roots` — array of recent block roots
+  + `state_roots` — array of recent state roots
+  + `validators` — complete array of all validators with their properties
+  + `balances` — array of all validator balances
+  + `eth1_data` — Eth1 chain reference data
+  + `eth1_data_votes` — pending Eth1 data votes
+  + `eth1_deposit_index` — current deposit index from Eth1
+  + `previous_justified_checkpoint` — previous justified checkpoint
+  + `current_justified_checkpoint` — current justified checkpoint
+  + `finalized_checkpoint` — most recent finalized checkpoint
+
+## Usage notes
+
+The `/eth/v2/debug/beacon/states/{state_id}` method is a powerful debugging tool that provides complete visibility into the beacon chain state. This endpoint returns extensive data and should be used judiciously as responses can be very large, especially for mainnet states with hundreds of thousands of validators.
+
+The endpoint supports both JSON and SSZ (Simple Serialize) response formats. To receive SSZ-encoded data, set the `Accept` header to `application/octet-stream`. SSZ format is more efficient for large state transfers.
+
+This is a debug endpoint and may not be available on all beacon nodes. It requires significant computational resources to serialize the complete state, so response times may be longer than standard API calls.

--- a/reference/getdebugforkchoice.mdx
+++ b/reference/getdebugforkchoice.mdx
@@ -1,0 +1,70 @@
+---
+title: Debug fork choice
+openapi: /openapi/ethereum_beacon_chain_api/debug/getDebugForkChoice.json
+  GET /beacon/2f6d649e68c2f861fecd5b8a9e35139e/eth/v1/debug/fork_choice
+---
+
+The `/eth/v1/debug/fork_choice` method is a debug API endpoint in the Ethereum Beacon Chain that retrieves the complete fork choice context, including justified and finalized checkpoints and the entire fork choice tree with all nodes and their weights. This endpoint provides deep insight into the consensus mechanism's decision-making process for determining the canonical chain.
+
+<Check>
+**Get you own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+This endpoint does not require any parameters.
+
+## Response
+
+The response provides comprehensive fork choice data:
+
+* `justified_checkpoint` — the current justified checkpoint containing:
+  + `epoch` — the epoch number of the justified checkpoint
+  + `root` — the block root of the justified checkpoint
+
+* `finalized_checkpoint` — the current finalized checkpoint containing:
+  + `epoch` — the epoch number of the finalized checkpoint
+  + `root` — the block root of the finalized checkpoint
+
+* `fork_choice_nodes` — array of all nodes in the fork choice tree, each containing:
+  + `slot` — the slot number of this block
+  + `block_root` — the merkle root of this beacon block
+  + `parent_root` — the merkle root of the parent beacon block
+  + `justified_epoch` — the justified epoch from this block's perspective
+  + `finalized_epoch` — the finalized epoch from this block's perspective
+  + `weight` — the cumulative weight/score of this block in the fork choice algorithm
+  + `validity` — the validity status (`valid`, `invalid`, or `optimistic`)
+  + `execution_block_hash` — the execution layer block hash
+  + `extra_data` — optional client-specific additional data
+
+* `extra_data` — optional additional data at the response level (client-specific)
+
+## Usage notes
+
+The `/eth/v1/debug/fork_choice` method is an advanced debugging tool that exposes the internal state of the fork choice algorithm, which is the heart of Ethereum's consensus mechanism. This endpoint is invaluable for understanding how the beacon chain determines the canonical chain among potentially competing forks.
+
+Key concepts for understanding the response:
+
+* **Fork choice tree** — represents all known blocks and their relationships, forming a tree structure where each node is a block
+* **Weight** — indicates the cumulative attestation support for each block; higher weight means more validators support this chain
+* **Checkpoints** — justified and finalized checkpoints represent consensus milestones that cannot be reverted
+* **Validity states**:
+  + `valid` — block has been fully validated
+  + `invalid` — block failed validation
+  + `optimistic` — block assumed valid but not yet verified by execution layer
+
+This endpoint is particularly useful for:
+
+* **Consensus debugging** — understanding why certain blocks are chosen as canonical
+* **Network analysis** — identifying competing forks and their relative support
+* **Performance monitoring** — tracking the efficiency of finalization
+* **Research** — studying fork choice behavior under various network conditions
+* **Validator operations** — understanding attestation targets and block production decisions
+
+The fork choice algorithm uses the LMD-GHOST (Latest Message Driven - Greediest Heaviest Observed SubTree) protocol, which selects the chain with the most cumulative attestation weight while respecting finality rules.
+
+This is a debug endpoint and may not be available on all beacon nodes. The data structure can be large on networks with many competing forks or during periods of network instability.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Ethereum Beacon Chain debug endpoints:
    - Get all fork choice leaves (v2).
    - Retrieve full BeaconState by state_id with JSON or SSZ response (v2).
    - Fetch complete fork choice context and tree (v1).
- Documentation
  - Added API reference pages for the new debug endpoints with parameters, responses, and usage notes.
  - Updated public API reference list to include the new debug endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->