### PR TITLE
add a note on batch response order

### DIFF
--- a/docs/http-batch-request-vs-multicall-contract.mdx
+++ b/docs/http-batch-request-vs-multicall-contract.mdx
@@ -35,7 +35,15 @@ To implement an HTTP batch request, just send a request with a payload containin
   ```
 </CodeGroup>
 
-The server sends back the results in one response. The results are arranged in the same order as the requests were received. For example:
+The server sends back the results in one response. For example:
+
+<Warning>
+  **Important: Response order is not guaranteed**
+  
+  According to the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification#batch), the server may return batch responses in any order. Always use the `id` field to match requests with responses, not the array position.
+  
+  This is especially important when using ethers.js v5, which had an issue that incorrectly relied on response ordering. If you're using ethers.js v5 and experiencing ordering issues, upgrade to ethers.js v6 where this has been fixed. See [ethers.js issue #3431](https://github.com/ethers-io/ethers.js/issues/3431) for details.
+</Warning>
 
 <CodeGroup>
   ```Json JSON

--- a/recipes/send-batch-requests-using-ethersjs.mdx
+++ b/recipes/send-batch-requests-using-ethersjs.mdx
@@ -13,6 +13,10 @@ All of these requests are done in a single round trip.
 
 This feature can be useful for reducing the load on the server and improving the performance. Here you will learn how to do it using ether.js V6.
 
+<Note>
+  **Batch response ordering**: The JSON-RPC specification does not guarantee that batch responses will be returned in the same order as requests. Always use the `id` field to match responses with their corresponding requests. This recipe uses ethers.js v6, which correctly handles response ordering. If you're using ethers.js v5, be aware of [this ordering issue](https://github.com/ethers-io/ethers.js/issues/3431).
+</Note>
+
 </Accordion>
 <Accordion title="Environment setup">
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that JSON-RPC batch responses are not guaranteed to match request order.
  * Added guidance to match responses by id rather than array position.
  * Noted that ethers.js v6 handles batch response ordering correctly; cautioned about historical ordering issues in ethers.js v5.
  * Included links to further details for users migrating or debugging batch requests.
  * Updated examples and notes to prevent misinterpretation of batch response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->