### PR TITLE
add note on Solana blockSubcribe & Geyser

### DIFF
--- a/docs/solana-creating-a-pumpfun-bot.mdx
+++ b/docs/solana-creating-a-pumpfun-bot.mdx
@@ -70,7 +70,7 @@ To get the three addresses all once (`mint`, `bondingCurve`, and `associatedBond
 Then from the those transactions, the bot extracts the required addresses.
 
 <Note>
-  While `blockSubscribe` works for this use case, it has known stability issues with busy programs. For production bots and better performance, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser implementation guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for details.
+  While `blockSubscribe` works for this use case, it has known stability issues with busy programs. For production bots and better performance, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser implementation guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) and learn more about [Geyser](/docs/yellowstone-grpc-geyser-plugin).
 </Note>
 
 ### Buy script

--- a/docs/solana-creating-a-pumpfun-bot.mdx
+++ b/docs/solana-creating-a-pumpfun-bot.mdx
@@ -69,6 +69,10 @@ To get the three addresses all once (`mint`, `bondingCurve`, and `associatedBond
 
 Then from the those transactions, the bot extracts the required addresses.
 
+<Note>
+  While `blockSubscribe` works for this use case, it has known stability issues with busy programs. For production bots and better performance, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser implementation guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for details.
+</Note>
+
 ### Buy script
 
 The buy script takes the global pump.fun program & accounts and the system ones from `config.py` and the coin specific ones from the listener script.

--- a/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
+++ b/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
@@ -123,7 +123,7 @@ This is the account that—on the token bonding curve completion status—adds t
 Our script uses the [blockSubscribe | Solana](/reference/blocksubscribe-solana) method over WebSocket by listening to all the transactions involving the migration account `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg`, then decodes the transactions using the Raydium IDL `raydium_amm_idl.json` that's also in our [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot) . After decoding the data, it prints what we actually need—the address of the pump.fun token that migrated and the new liquidity pool address for this token on Raydium.
 
 <Note>
-  **Important for production:** The `blockSubscribe` method can experience stability issues with high-traffic programs like Raydium, including connection errors and data skipping. For production monitoring of Raydium migrations, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883) for more reliable streaming.
+  **Important for production:** The `blockSubscribe` method can experience stability issues with high-traffic programs like Raydium, including connection errors and data skipping. For production monitoring of Raydium migrations, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883) for more reliable streaming. Learn more about [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
 </Note>
 
 #### Usage

--- a/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
+++ b/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
@@ -122,6 +122,10 @@ This is the account that—on the token bonding curve completion status—adds t
 
 Our script uses the [blockSubscribe | Solana](/reference/blocksubscribe-solana) method over WebSocket by listening to all the transactions involving the migration account `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg`, then decodes the transactions using the Raydium IDL `raydium_amm_idl.json` that's also in our [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot) . After decoding the data, it prints what we actually need—the address of the pump.fun token that migrated and the new liquidity pool address for this token on Raydium.
 
+<Note>
+  **Important for production:** The `blockSubscribe` method can experience stability issues with high-traffic programs like Raydium, including connection errors and data skipping. For production monitoring of Raydium migrations, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883) for more reliable streaming.
+</Note>
+
 #### Usage
 
 <CodeGroup>

--- a/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
@@ -24,7 +24,7 @@ There is also difference in how `blockSubscribe` and `logsSubscribe` work, hence
 The script discussed in this article and that is the `learning-examples/listen_new_direct_full_details.py` script solves the issue by computing the associated bonding curve address from the bonding curve address on the fly and prints it. This way it makes it possible to snipe tokens on pump.fun using the `logsSubscribe` method only. which in general has better availability across providers and may work faster for you.
 
 <Warning>
-  **Note on blockSubscribe limitations:** While `blockSubscribe` provides transaction data, it has known stability issues with high-traffic programs—including connection errors (1006, 1009) and data skipping. For the most reliable real-time data streaming, [Geyser is recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for the fastest and most stable implementation.
+  **Note on blockSubscribe limitations:** While `blockSubscribe` provides transaction data, it has known stability issues with high-traffic programs—including connection errors (1006, 1009) and data skipping. For the most reliable real-time data streaming, [Geyser is recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for the fastest and most stable implementation. Learn more about [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
 </Warning>
 
 ## How it works

--- a/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
@@ -23,6 +23,10 @@ There is also difference in how `blockSubscribe` and `logsSubscribe` work, hence
 
 The script discussed in this article and that is the `learning-examples/listen_new_direct_full_details.py` script solves the issue by computing the associated bonding curve address from the bonding curve address on the fly and prints it. This way it makes it possible to snipe tokens on pump.fun using the `logsSubscribe` method only. which in general has better availability across providers and may work faster for you.
 
+<Warning>
+  **Note on blockSubscribe limitations:** While `blockSubscribe` provides transaction data, it has known stability issues with high-traffic programs—including connection errors (1006, 1009) and data skipping. For the most reliable real-time data streaming, [Geyser is recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for the fastest and most stable implementation.
+</Warning>
+
 ## How it works
 
 * The script subscribes to Solana logs mentioning the pump.fun program (`PUMP_PROGRAM`).

--- a/reference/blocksubscribe-solana.mdx
+++ b/reference/blocksubscribe-solana.mdx
@@ -12,7 +12,7 @@ description: "The `blockSubscribe` method in Solana allows developers to receive
 </Check>
 
 <Warning>
-  **Important:** The `blockSubscribe` method is marked as unstable and has known limitations with busy programs. Common issues include connection errors (1006, 1009) and skipped data. For production use and comprehensive block tracking, especially with high-traffic programs like Raydium or pump.fun, [Geyser is the recommended alternative](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883).
+  **Important:** The `blockSubscribe` method is marked as unstable and has known limitations with busy programs. Common issues include connection errors (1006, 1009) and skipped data. For production use and comprehensive block tracking, especially with high-traffic programs like Raydium or pump.fun, [Geyser is the recommended alternative](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). Learn more about [Geyser in our documentation](/docs/yellowstone-grpc-geyser-plugin).
 </Warning>
 
 ## Parameters

--- a/reference/blocksubscribe-solana.mdx
+++ b/reference/blocksubscribe-solana.mdx
@@ -11,6 +11,10 @@ description: "The `blockSubscribe` method in Solana allows developers to receive
   You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
+<Warning>
+  **Important:** The `blockSubscribe` method is marked as unstable and has known limitations with busy programs. Common issues include connection errors (1006, 1009) and skipped data. For production use and comprehensive block tracking, especially with high-traffic programs like Raydium or pump.fun, [Geyser is the recommended alternative](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883).
+</Warning>
+
 ## Parameters
 
 * `filter` - An object specifying the type of information to receive:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Notes/Warnings across Solana guides clarifying blockSubscribe instability under high-traffic programs (e.g., connection errors 1006/1009, skipped data).
  - Recommended using Geyser for production-grade, reliable real-time streaming; included links to official references and an implementation guide.
  - Updates applied to: pumpfun bot creation guide, pumpfun migrations to Raydium guide (two locations), token mint via logsSubscribe guide, and the blockSubscribe reference page.
  - Improves production-readiness guidance and sets expectations on reliability, availability, and provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->