### PR TITLE
docs: add release notes for Geyser 1 (Sep 30, 2025)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,14 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: September 30, 2025" description=" by Vladimir" >
+
+**Nodes** and **Add-ons**. We’ve expanded [Add-ons](/docs/add-ons): the [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin) is now available on Solana for **$49 per 1 stream** on both [Global Nodes](/docs/global-elastic-node) and [Unlimited Nodes](/docs/unlimited-node).
+
+<Button href="/changelog/chainstack-updates-september-30-2025">Read more</Button>
+</Update>
+
+
 <Update label="Chainstack updates: August 26, 2025" description=" by Ake">
 
 **Protocols**. Hyperliquid HyperEVM nodes are now in archive mode available with Debug & Trace methods and WebSocket support. See also [Hyperliquid methods](/docs/hyperliquid-methods) and [Hyperliquid API reference](/reference/hyperliquid-getting-started). As a reminder, HyperCore is also supported.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Chainstack updates: September 30, 2025” entry to the changelog, featuring a Nodes and Add-ons notice, a link to the Yellowstone gRPC Geyser plugin, and a “Read more” button.
  * Positioned after the initial component imports and before the August 26, 2025 update.
  * No existing changelog entries were modified, improving clarity and visibility of the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->