### PR TITLE
deprecate holesky; relnote deprecation

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: October 31, 2025" description=" by Ake">
+
+**Protocols**. Ethereum Holesky Testnet has been deprecated. Please use [Sepolia Testnet or Hoodi Testnet](/docs/protocols-networks) for Ethereum testing.
+
+<Button href="/changelog/chainstack-updates-october-31-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: October 18, 2025" description=" by Vladimir">
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with Debug & Trace APIs for Plasma Mainnet and Testnet.

--- a/changelog/chainstack-updates-october-31-2025.mdx
+++ b/changelog/chainstack-updates-october-31-2025.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: October 31, 2025"
+description: "Product updates and announcements"
+---
+
+**Protocols**. Ethereum Holesky Testnet has been deprecated. Please use [Sepolia Testnet or Hoodi Testnet](/docs/protocols-networks) for Ethereum testing.

--- a/docs.json
+++ b/docs.json
@@ -3132,6 +3132,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-october-31-2025",
           "changelog/chainstack-updates-october-18-2025",
           "changelog/chainstack-updates-september-30-2025",
           "changelog/chainstack-updates-august-26-2025",

--- a/docs/blob-transactions-the-hard-way.mdx
+++ b/docs/blob-transactions-the-hard-way.mdx
@@ -231,7 +231,7 @@ Let's first run the script and then have a look at the transaction committed to 
 
   tx = {
       "type": 3, # Type-3 transaction
-      "chainId": 11155111,  # Hoodi 560048; Sepolia 11155111; Holesky 17000
+      "chainId": 11155111,  # Hoodi 560048; Sepolia 11155111; Holesky 17000 (deprecated on Oct 31, 2025)
       "from": acct.address,
       "to": "0x0000000000000000000000000000000000000000", # Does not matter what account you send it to
       "value": 0,

--- a/docs/evm-mcp-server.mdx
+++ b/docs/evm-mcp-server.mdx
@@ -13,7 +13,7 @@ The EVM MCP server is available in the [chainstacklabs/rpc-nodes-mcp](https://gi
 
 The EVM MCP server supports all EVM-compatible networks available on Chainstack, including:
 
-- **Ethereum** (Mainnet, Sepolia, Holesky)
+- **Ethereum** (Mainnet, Sepolia)
 - **Polygon** (Mainnet, Amoy testnet)
 - **BNB Smart Chain** (Mainnet, testnet)
 - **Arbitrum** (One, Sepolia)

--- a/docs/goerli-to-sepolia-transition.mdx
+++ b/docs/goerli-to-sepolia-transition.mdx
@@ -14,6 +14,10 @@ Goerli is set to be sunset in Q4 2023, and we highly recommend our customers and
 
 Goerli will be replaced by the [Holešovice](https://github.com/eth-clients/holesky) testnet, which will probably launch in the second half of 2023.
 
+<Note>
+Holesky testnet was deprecated on Oct 31, 2025.
+</Note>
+
 ## Why Sepolia?
 
 Named after a neighborhood in Athens, Sepolia launched in October 2021. Sepolia has a closed validator set and a relatively small state and history. This means that the network has a low gas fee, and is quick to sync a node. This makes Sepolia the ideal network to test out DApps and smart contracts.

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -29,7 +29,6 @@ description: "Explore Chainstack's available clouds, regions, and locations for 
 | Mainnet         | Chainstack Cloud          | ash1    | Ashburn            | Archive | Available     | NA                |
 | Mainnet         | Chainstack Cloud          | ash1    | Ashburn            | Full    | NA            | NA                |
 | Mainnet         | Chainstack Cloud          | ash1    | Ashburn            | Full    | NA            | Available         |
-| Holesky Testnet | Chainstack Global Network | global1 | Worldwide          | Archive | Available     | NA                |
 | Sepolia Testnet | Chainstack Global Network | global1 | Worldwide          | Archive | Available     | NA                |
 | Sepolia Testnet | Virtuozzo                 | eu3     | Amsterdam          | Full    | NA            | NA                |
 | Hoodi Testnet   | Chainstack Global Network | global1 | Worldwide          | Archive | Available     | NA                |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -28,7 +28,7 @@ description: "This page lists all the supported networks that you can use to dep
 | Cronos zkEVM | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Dogecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-dogecoin/#request) |
 | Etherlink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-etherlink/#request) |
-| Ethereum | Elastic, Dedicated | Full, Archive | Full, Archive | Holesky Testnet, Sepolia Testnet, Hoodi Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Ethereum | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet, Hoodi Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Fantom | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Filecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fraxchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-fraxchain/#request) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -123,25 +123,6 @@
       },
       "testnets": [
         {
-          "network_name": "Holesky Testnet",
-          "faucet_url": "https://faucet.chainstack.com",
-          "locations": [
-            {
-              "cloud": "Chainstack Global Network",
-              "node_type": "Global Node",
-              "region": "global1",
-              "location": "Worldwide",
-              "deployment_options": [
-                {
-                  "mode": "Archive",
-                  "debug_trace": true,
-                  "warp_transactions": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "network_name": "Sepolia Testnet",
           "faucet_url": "https://faucet.chainstack.com",
           "locations": [

--- a/openapi/faucet_api/get_tokens.json
+++ b/openapi/faucet_api/get_tokens.json
@@ -29,7 +29,6 @@
               "enum": [
                 "hoodi",
                 "sepolia",
-                "holesky",
                 "bnb-testnet",
                 "zksync-testnet",
                 "scroll-sepolia-testnet",

--- a/reference/chainstack-faucet-get-tokens-rpc-method.mdx
+++ b/reference/chainstack-faucet-get-tokens-rpc-method.mdx
@@ -15,7 +15,6 @@ You can also request funds directly from the [Chainstack Faucet](https://faucet.
 * `chain` — the test network you want to receive funds on.
   + `hoodi` — receive testnet ETH on Hoodi.
   + `sepolia` — receive testnet ETH on Sepolia.
-  + `holesky` — receive testnet ETH on Holesky.
   + `bnb-testnet` — receive testnet BNB.
   + `amoy` — receive testnet POL on Amoy testnet.
   + `ton-testnet` — receive TON for TON testnet.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect Ethereum Holesky Testnet deprecation as of October 31, 2025.
  * Directed users to Sepolia or Hoodi Testnet for Ethereum testing.

* **Chores**
  * Removed Holesky support from faucet API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->