### PR TITLE
Add Sui Mainnet gRPC support to release notes

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: November 18, 2025" description=" by Vladimir">
+
+**Protocols**. Now, you can use gRPC for Sui Mainnet [Global Nodes](/docs/global-elastic-node).
+
+<Button href="/changelog/chainstack-updates-november-18-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: November 4, 2025" description=" by Vladimir">
 
 **Protocols**. Now, you can deploy Bitcoin Signet for [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node).

--- a/changelog/chainstack-updates-november-18-2025.mdx
+++ b/changelog/chainstack-updates-november-18-2025.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: November 18, 2025"
+description: "Product updates and announcements"
+---
+
+**Protocols**. Now, you can use gRPC for Sui Mainnet [Global Nodes](/docs/global-elastic-node).

--- a/docs.json
+++ b/docs.json
@@ -3132,6 +3132,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-november-18-2025",
           "changelog/chainstack-updates-november-4-2025",
           "changelog/chainstack-updates-october-31-2025",
           "changelog/chainstack-updates-october-18-2025",


### PR DESCRIPTION
## Summary

- Added release notes for November 18, 2025
- Announced gRPC support for Sui Mainnet Global Nodes

## Changes

- Updated changelog.mdx with new entry
- Created changelog/chainstack-updates-november-18-2025.mdx
- Updated docs.json navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with November 18, 2025 entry documenting gRPC support for Sui Mainnet Global Nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->