### PR TITLE
Add release notes for Monad Testnet and Sonic Testnet support

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,15 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: November 21, 2025" description=" by Vladimir">
+
+**Protocols**:
+* Monad — You can now deploy [Global Nodes](/docs/global-elastic-node) for Monad Testnet.
+* Sonic — You can now deploy [Global Nodes](/docs/global-elastic-node) for Sonic Testnet.
+
+<Button href="/changelog/chainstack-updates-november-21-2025">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: November 19, 2025" description=" by Ake">
 
 **Protocols**. Sui nodes now support gRPC endpoints for high-performance access. See [Sui tooling](/docs/sui-tooling) and [authentication methods](/docs/authentication-methods-for-different-scenarios).

--- a/changelog/chainstack-updates-november-21-2025.mdx
+++ b/changelog/chainstack-updates-november-21-2025.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: November 21, 2025"
+---
+**Protocols**:
+* Monad — You can now deploy [Global Nodes](/docs/global-elastic-node) for Monad Testnet.
+* Sonic — You can now deploy [Global Nodes](/docs/global-elastic-node) for Sonic Testnet.

--- a/docs.json
+++ b/docs.json
@@ -3149,6 +3149,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-november-21-2025",
           "changelog/chainstack-updates-november-19-2025",
           "changelog/chainstack-updates-november-4-2025",
           "changelog/chainstack-updates-october-31-2025",


### PR DESCRIPTION
## Summary
- Added release notes for November 21, 2025
- Monad Testnet and Sonic Testnet now available for Global Nodes

## Test plan
- [ ] Verify release notes page renders correctly
- [ ] Check navigation in docs.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for November 21, 2025 highlighting new protocol updates
  * Monad and Sonic now support deploying Global Nodes for their respective testnets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->