### PR TITLE
Update Tempo docs from Andantino to Moderato testnet

### DIFF
--- a/docs/tempo-tutorial-dex-swap-foundry.mdx
+++ b/docs/tempo-tutorial-dex-swap-foundry.mdx
@@ -43,9 +43,9 @@ Tempo features an enshrined DEX—a precompiled contract built into the protocol
 
 | Parameter | Value |
 |-----------|-------|
-| Network name | Tempo Testnet (Andantino) |
-| Chain ID | `42429` |
-| RPC URL | `https://rpc.testnet.tempo.xyz` |
+| Network name | Tempo Testnet (Moderato) |
+| Chain ID | `42431` |
+| RPC URL | `https://rpc.moderato.tempo.xyz` |
 | Explorer | [explore.tempo.xyz](https://explore.tempo.xyz) |
 
 ## Step 1. Install tempo-foundry
@@ -69,7 +69,7 @@ You should see output containing `tempo` in the version string.
 Get testnet stablecoins using the faucet RPC method:
 
 ```bash
-cast rpc tempo_fundAddress YOUR_ADDRESS --rpc-url https://rpc.testnet.tempo.xyz
+cast rpc tempo_fundAddress YOUR_ADDRESS --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
 Check your balance:
@@ -78,7 +78,7 @@ Check your balance:
 cast call 0x20C0000000000000000000000000000000000001 \
   "balanceOf(address)(uint256)" \
   YOUR_ADDRESS \
-  --rpc-url https://rpc.testnet.tempo.xyz
+  --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
 <Note>
@@ -95,7 +95,7 @@ cast call 0xDEc0000000000000000000000000000000000000 \
   0x20C0000000000000000000000000000000000001 \
   0x20C0000000000000000000000000000000000002 \
   100000000 \
-  --rpc-url https://rpc.testnet.tempo.xyz
+  --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
 This quotes swapping 100 AlphaUSD for BetaUSD. Expected output: `100000000` (100 BetaUSD at 1:1 rate).
@@ -115,7 +115,7 @@ cast send 0x20C0000000000000000000000000000000000001 \
   "approve(address,uint256)" \
   0xDEc0000000000000000000000000000000000000 \
   100000000 \
-  --rpc-url https://rpc.testnet.tempo.xyz \
+  --rpc-url https://rpc.moderato.tempo.xyz \
   --private-key $PRIVATE_KEY \
   --fee-token 0x20C0000000000000000000000000000000000001
 ```
@@ -135,7 +135,7 @@ cast send 0xDEc0000000000000000000000000000000000000 \
   0x20C0000000000000000000000000000000000002 \
   100000000 \
   99000000 \
-  --rpc-url https://rpc.testnet.tempo.xyz \
+  --rpc-url https://rpc.moderato.tempo.xyz \
   --private-key $PRIVATE_KEY \
   --fee-token 0x20C0000000000000000000000000000000000001
 ```
@@ -154,7 +154,7 @@ Check your new BetaUSD balance:
 cast call 0x20C0000000000000000000000000000000000002 \
   "balanceOf(address)(uint256)" \
   YOUR_ADDRESS \
-  --rpc-url https://rpc.testnet.tempo.xyz
+  --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
 ## DEX interface reference

--- a/docs/tempo-tutorial-first-payment-app.mdx
+++ b/docs/tempo-tutorial-first-payment-app.mdx
@@ -31,9 +31,9 @@ A simple payment app that can:
 
 | Property | Value |
 |----------|-------|
-| Chain ID | 42429 |
-| RPC endpoint | `https://rpc.testnet.tempo.xyz` |
-| WebSocket | `wss://rpc.testnet.tempo.xyz` |
+| Chain ID | 42431 |
+| RPC endpoint | `https://rpc.moderato.tempo.xyz` |
+| WebSocket | `wss://rpc.moderato.tempo.xyz` |
 | Explorer | [explore.tempo.xyz](https://explore.tempo.xyz) |
 | Finality | ~0.5 seconds |
 

--- a/openapi/tempo_node_api/account_info/eth_getBalance.json
+++ b/openapi/tempo_node_api/account_info/eth_getBalance.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/account_info/eth_getCode.json
+++ b/openapi/tempo_node_api/account_info/eth_getCode.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/account_info/eth_getProof.json
+++ b/openapi/tempo_node_api/account_info/eth_getProof.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/account_info/eth_getStorageAt.json
+++ b/openapi/tempo_node_api/account_info/eth_getStorageAt.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/account_info/eth_getTransactionCount.json
+++ b/openapi/tempo_node_api/account_info/eth_getTransactionCount.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_blockNumber.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockByHash.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockByNumber.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockReceipts.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockReceipts.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/chain_info/eth_chainId.json
+++ b/openapi/tempo_node_api/chain_info/eth_chainId.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/chain_info/eth_syncing.json
+++ b/openapi/tempo_node_api/chain_info/eth_syncing.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/client_info/net_listening.json
+++ b/openapi/tempo_node_api/client_info/net_listening.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/client_info/net_peerCount.json
+++ b/openapi/tempo_node_api/client_info/net_peerCount.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/client_info/net_version.json
+++ b/openapi/tempo_node_api/client_info/net_version.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {
@@ -63,7 +63,7 @@
                     },
                     "result": {
                       "type": "string",
-                      "description": "The network ID (42429 for Tempo testnet)"
+                      "description": "The network ID (42431 for Tempo Moderato testnet)"
                     }
                   }
                 }

--- a/openapi/tempo_node_api/client_info/rpc_modules.json
+++ b/openapi/tempo_node_api/client_info/rpc_modules.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/client_info/web3_clientVersion.json
+++ b/openapi/tempo_node_api/client_info/web3_clientVersion.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/client_info/web3_sha3.json
+++ b/openapi/tempo_node_api/client_info/web3_sha3.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceCall.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceTransaction.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_block.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_block.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_call.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_call.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_filter.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_filter.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_replayBlockTransactions.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_replayBlockTransactions.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_replayTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_replayTransaction.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/debug_and_trace/trace_transaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_transaction.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/dex/dex_getOrderbooks.json
+++ b/openapi/tempo_node_api/dex/dex_getOrderbooks.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/dex/dex_getOrders.json
+++ b/openapi/tempo_node_api/dex/dex_getOrders.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/tempo_node_api/filter_handling/eth_getFilterChanges.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/filter_handling/eth_newBlockFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_newBlockFilter.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/filter_handling/eth_newFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_newFilter.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_uninstallFilter.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/tempo_node_api/gas_data/eth_estimateGas.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/gas_data/eth_feeHistory.json
+++ b/openapi/tempo_node_api/gas_data/eth_feeHistory.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/tempo_node_api/gas_data/eth_gasPrice.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/gas_data/eth_maxPriorityFeePerGas.json
+++ b/openapi/tempo_node_api/gas_data/eth_maxPriorityFeePerGas.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/logs_and_events/eth_getFilterLogs.json
+++ b/openapi/tempo_node_api/logs_and_events/eth_getFilterLogs.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/tempo_node_api/logs_and_events/eth_getLogs.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/tempo_specific/tempo_fundAddress.json
+++ b/openapi/tempo_node_api/tempo_specific/tempo_fundAddress.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_call.json
+++ b/openapi/tempo_node_api/transaction_info/eth_call.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByHash.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/transaction_info/eth_sendRawTransaction.json
+++ b/openapi/tempo_node_api/transaction_info/eth_sendRawTransaction.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/txpool/txpool_content.json
+++ b/openapi/tempo_node_api/txpool/txpool_content.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/openapi/tempo_node_api/txpool/txpool_status.json
+++ b/openapi/tempo_node_api/txpool/txpool_status.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://rpc.testnet.tempo.xyz"
+      "url": "https://rpc.moderato.tempo.xyz"
     }
   ],
   "paths": {

--- a/reference/tempo-eth-chainid.mdx
+++ b/reference/tempo-eth-chainid.mdx
@@ -3,7 +3,7 @@ title: eth_chainId | Tempo
 openapi: /openapi/tempo_node_api/chain_info/eth_chainId.json POST /
 ---
 
-Tempo API method that returns the chain ID of the current network. The Tempo testnet chain ID is `42429` (`0xa5bd` in hexadecimal).
+Tempo API method that returns the chain ID of the current network. The Tempo Moderato testnet chain ID is `42431` (`0xa5bf` in hexadecimal).
 
 
 ## Parameters
@@ -12,7 +12,7 @@ Tempo API method that returns the chain ID of the current network. The Tempo tes
 
 ## Response
 
-* `result` — the chain ID encoded as hexadecimal (`0xa5bd` for Tempo testnet, which is `42429` in decimal)
+* `result` — the chain ID encoded as hexadecimal (`0xa5bf` for Tempo Moderato testnet, which is `42431` in decimal)
 
 ## `eth_chainId` code examples
 

--- a/reference/tempo-eth-sendrawtransaction.mdx
+++ b/reference/tempo-eth-sendrawtransaction.mdx
@@ -59,7 +59,7 @@ tx = {
     'value': 0,  # Tempo uses TIP-20 tokens for value transfer
     'gas': 21000,
     'gasPrice': web3.eth.gas_price,
-    'chainId': 42429  # Tempo testnet
+    'chainId': 42431  # Tempo Moderato testnet
 }
 
 signed = account.sign_transaction(tx)

--- a/reference/tempo-getting-started.mdx
+++ b/reference/tempo-getting-started.mdx
@@ -23,8 +23,8 @@ Tempo is designed for high-throughput payment applications with sub-second final
 
 | Property | Value |
 |----------|-------|
-| Network name | Tempo Testnet |
-| Chain ID | 42429 (0xa5bd) |
+| Network name | Tempo Testnet (Moderato) |
+| Chain ID | 42431 (0xa5bf) |
 | Currency | USD stablecoins (no native token) |
 | Block time | ~0.5 seconds |
 | Finality | Sub-second (Simplex Consensus) |
@@ -45,7 +45,7 @@ Tempo supports all standard Ethereum JSON-RPC methods plus Tempo-specific extens
 To use the Tempo API, you need access to a Tempo RPC node. The public testnet RPC endpoint is:
 
 ```
-https://rpc.testnet.tempo.xyz
+https://rpc.moderato.tempo.xyz
 ```
 
 You can use this endpoint directly in your applications to interact with the Tempo blockchain.
@@ -68,7 +68,7 @@ Tempo includes several predeployed system contracts for payments, tokens, and co
 Tempo uses stablecoins for gas fees. To get testnet tokens, use the `tempo_fundAddress` RPC method:
 
 ```bash
-curl -X POST https://rpc.testnet.tempo.xyz \
+curl -X POST https://rpc.moderato.tempo.xyz \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",

--- a/reference/tempo-net-version.mdx
+++ b/reference/tempo-net-version.mdx
@@ -3,7 +3,7 @@ title: net_version | Tempo
 openapi: /openapi/tempo_node_api/client_info/net_version.json POST /
 ---
 
-Tempo API method that returns the current network ID. The Tempo testnet network ID is `42429`.
+Tempo API method that returns the current network ID. The Tempo Moderato testnet network ID is `42431`.
 
 
 ## Parameters
@@ -12,7 +12,7 @@ Tempo API method that returns the current network ID. The Tempo testnet network 
 
 ## Response
 
-* `result` — the network ID as a string (`42429` for Tempo testnet)
+* `result` — the network ID as a string (`42431` for Tempo Moderato testnet)
 
 ## `net_version` code examples
 


### PR DESCRIPTION
- Chain ID: 42429 → 42431 (0xa5bd → 0xa5bf)
- RPC: rpc.testnet.tempo.xyz → rpc.moderato.tempo.xyz
- WebSocket: wss://rpc.testnet.tempo.xyz → wss://rpc.moderato.tempo.xyz
- Network name: Tempo Testnet (Andantino) → Tempo Testnet (Moderato)

Updates 56 files including tutorials, API reference docs, and OpenAPI specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tempo testnet configuration to reflect Moderato testnet with new chain ID (42431) and RPC endpoint (rpc.moderato.tempo.xyz) across all tutorial and reference guides.

* **Chores**
  * Updated API specifications to reference the new testnet endpoint and network ID.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->