### PR TITLE
Add release notes for Tempo Moderato Testnet support

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: January 21, 2026" description=" by Vladimir">
+
+**Protocols**. Tempo Moderato Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Moderato Testnet.
+
+<Button href="/changelog/chainstack-updates-january-21-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: January 5, 2026" description=" by Ake">
 
 **Subgraphs**. Chainstack is sunsetting its Subgraphs service and transitioning users to [Ormi](https://ormilabs.com/). Existing subgraphs will continue until February 1, 2026. Ormi will provide one month of free access. See the [transition guide](https://docs.ormilabs.com/subgraphs/tutorials/migrate-chainstack-subgraphs).

--- a/changelog/chainstack-updates-january-21-2026.mdx
+++ b/changelog/chainstack-updates-january-21-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: January 21, 2026"
+description: "Tempo Moderato Testnet support for Global Nodes and Dedicated Nodes"
+---
+
+**Protocols**. Tempo Moderato Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Moderato Testnet.

--- a/docs.json
+++ b/docs.json
@@ -3376,6 +3376,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-january-21-2026",
           "changelog/chainstack-updates-january-5-2026",
           "changelog/chainstack-updates-december-26-2025",
           "changelog/chainstack-updates-december-10-2025",


### PR DESCRIPTION
## Summary
- Add release notes for Tempo Moderato Testnet availability on Global Nodes and Dedicated Nodes

## Test plan
- [x] Verified locally with `mintlify dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added changelog entry for Chainstack updates (January 21, 2026) featuring Tempo Moderato Testnet availability with Global Nodes and Dedicated Nodes deployment options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->