### PR TITLE
Add TRON gRPC support release notes

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: January 22, 2026" description=" by Vladimir">
+
+**Protocols**. TRON Mainnet and Nile Testnet now support gRPC endpoints on [Global Nodes](/docs/global-elastic-node). See also [TRON tooling](/docs/tron-tooling) and [authentication methods](/docs/authentication-methods-for-different-scenarios).
+
+<Button href="/changelog/chainstack-updates-january-22-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: January 21, 2026" description=" by Vladimir">
 
 **Protocols**. Tempo Moderato Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Moderato Testnet. See also [Tempo tooling](/docs/tempo-tooling), [Tempo API reference](/reference/tempo-getting-started), and tutorials on [building a payment app](/docs/tempo-tutorial-first-payment-app) and [DEX swaps with Foundry](/docs/tempo-tutorial-dex-swap-foundry).

--- a/changelog/chainstack-updates-january-22-2026.mdx
+++ b/changelog/chainstack-updates-january-22-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: January 22, 2026"
+description: "TRON gRPC support for Global Nodes"
+---
+
+**Protocols**. TRON Mainnet and Nile Testnet now support gRPC endpoints on [Global Nodes](/docs/global-elastic-node). See also [TRON tooling](/docs/tron-tooling) and [authentication methods](/docs/authentication-methods-for-different-scenarios).

--- a/docs.json
+++ b/docs.json
@@ -3370,6 +3370,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-january-22-2026",
           "changelog/chainstack-updates-january-21-2026",
           "changelog/chainstack-updates-january-5-2026",
           "changelog/chainstack-updates-december-26-2025",


### PR DESCRIPTION
## Summary
- Add release notes for TRON Mainnet and Nile Testnet gRPC endpoints support on Global Nodes
- Update navigation in docs.json

## Test plan
- [ ] Verify changelog.mdx renders correctly
- [ ] Verify changelog/chainstack-updates-january-22-2026.mdx renders correctly
- [ ] Check navigation in Release notes section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TRON Mainnet and Nile Testnet gRPC endpoints are now available and supported on Global Nodes.

* **Documentation**
  * Added dedicated changelog entry documenting newly available TRON gRPC endpoint support on Global Nodes. Includes detailed references to TRON tooling documentation and authentication methods to facilitate seamless integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->