### PR TITLE
Add Self-Hosted suffix to page titles for SEO differentiation

### DIFF
--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Deploying nodes"
+title: "Deploying nodes | Self-Hosted"
+sidebarTitle: "Deploying nodes"
 description: "How to deploy blockchain nodes using Chainstack Self-Hosted"
 ---
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -1,5 +1,6 @@
 ---
-title: "FAQ"
+title: "FAQ | Self-Hosted"
+sidebarTitle: "FAQ"
 description: "Frequently asked questions about Chainstack Self-Hosted"
 ---
 

--- a/docs/self-hosted/first-login.mdx
+++ b/docs/self-hosted/first-login.mdx
@@ -1,5 +1,6 @@
 ---
-title: "First login"
+title: "First login | Self-Hosted"
+sidebarTitle: "First login"
 description: "First login to Chainstack Self-Hosted and initial configuration steps"
 ---
 

--- a/docs/self-hosted/installation.mdx
+++ b/docs/self-hosted/installation.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Installation"
+title: "Installation | Self-Hosted"
+sidebarTitle: "Installation"
 description: "Detailed instructions for installing Chainstack Self-Hosted with basic and advanced configuration options"
 ---
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Introduction"
+title: "Introduction | Self-Hosted"
+sidebarTitle: "Introduction"
 description: "Deploy and manage blockchain infrastructure in your own environment with complete control over your data"
 ---
 

--- a/docs/self-hosted/managing-nodes.mdx
+++ b/docs/self-hosted/managing-nodes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Managing nodes"
+title: "Managing nodes | Self-Hosted"
+sidebarTitle: "Managing nodes"
 description: "Node operations and management in Chainstack Self-Hosted"
 ---
 

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Quick start"
+title: "Quick start | Self-Hosted"
+sidebarTitle: "Quick start"
 description: "Complete walkthrough from a fresh Ubuntu installation to a running Chainstack Self-Hosted Control Panel"
 ---
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Release notes"
+title: "Release notes | Self-Hosted"
+sidebarTitle: "Release notes"
 description: "Product updates and announcements for Chainstack Self-Hosted"
 rss: true
 ---

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -1,5 +1,6 @@
 ---
-title: "System requirements"
+title: "System requirements | Self-Hosted"
+sidebarTitle: "System requirements"
 description: "Hardware, software, and network requirements for running Chainstack Self-Hosted"
 ---
 

--- a/docs/self-hosted/support.mdx
+++ b/docs/self-hosted/support.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Support and feedback"
+title: "Support and feedback | Self-Hosted"
+sidebarTitle: "Support and feedback"
 description: "Get help, provide feedback, and join the Chainstack Self-Hosted beta program"
 ---
 

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Supported clients and protocols"
+title: "Supported clients and protocols | Self-Hosted"
+sidebarTitle: "Supported clients and protocols"
 description: "Blockchain protocols and networks available in Chainstack Self-Hosted"
 ---
 

--- a/docs/self-hosted/troubleshooting.mdx
+++ b/docs/self-hosted/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Troubleshooting"
+title: "Troubleshooting | Self-Hosted"
+sidebarTitle: "Troubleshooting"
 description: "Diagnose and resolve common issues with Chainstack Self-Hosted"
 ---
 


### PR DESCRIPTION
Update all Self-Hosted pages to use "Page Name | Self-Hosted" format in browser tabs/SEO while keeping sidebar titles clean via sidebarTitle.

This prevents confusion between Cloud and Self-Hosted docs in search results and browser tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced self-hosted documentation by updating page titles across all pages with "Self-Hosted" branding and adding new sidebar navigation labels. These metadata improvements provide clearer navigation paths, better content organization, and enhanced discoverability for users accessing the Self-Hosted documentation section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->