### PR TITLE
Update Self-Hosted beta signup links

### DIFF
--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -169,7 +169,7 @@ Your storage class must support volume expansion. Most cloud providers and moder
 
 ### How do I join the beta program?
 
-Fill out the beta signup form: [Join the Chainstack Self-Hosted Beta](https://3b81e.share.hsforms.com/2cWH4wEOeTOySPUNKOVDEEQ)
+Fill out the beta signup form: [Join the Chainstack Self-Hosted Beta](https://chainstack.com/self-hosted/)
 
 ### What does the beta include?
 

--- a/docs/self-hosted/installation.mdx
+++ b/docs/self-hosted/installation.mdx
@@ -48,7 +48,7 @@ Basic installation automatically generates secure passwords and deploys the comp
 ./cpctl install -v v1.0.0 -s STORAGE_CLASS_NAME
 ```
 
-To get the installer, [join our beta program](/docs/self-hosted/support#join-the-beta).
+To get the installer, [join our beta program](https://chainstack.com/self-hosted/).
 
 </Step>
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -6,7 +6,7 @@ description: "Deploy and manage blockchain infrastructure in your own environmen
 Welcome to the documentation for Chainstack Self-Hosted, a control plane for deploying and managing blockchain infrastructure in your own environment.
 
 <Note>
-Chainstack Self-Hosted is currently in beta. We actively welcome feedback and feature requests. See [how to join the beta](/docs/self-hosted/support#join-the-beta) for details.
+Chainstack Self-Hosted is currently in beta. We actively welcome feedback and feature requests. See [how to join the beta](https://chainstack.com/self-hosted/) for details.
 </Note>
 
 ## What is Chainstack Self-Hosted?
@@ -24,4 +24,4 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 - Technical support — [Chainstack Support Center](https://support.chainstack.com/hc/en-us)
 - Feedback and feature requests — [Chainstack Feedback](https://ideas.chainstack.com/en?b=6968ecf76c93cb94db0422c8)
-- Beta program — [Join the beta](https://3b81e.share.hsforms.com/2cWH4wEOeTOySPUNKOVDEEQ)
+- Beta program — [Join the beta](https://chainstack.com/self-hosted/)

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -139,7 +139,7 @@ If you're using the default k3s local-path storage class (single disk), you can 
 
 <Step title="Get the installer">
 
-Get the installer by [joining the beta](/docs/self-hosted/support#join-the-beta).
+Get the installer by [joining the beta](https://chainstack.com/self-hosted/).
 
 </Step>
 

--- a/docs/self-hosted/support.mdx
+++ b/docs/self-hosted/support.mdx
@@ -86,7 +86,7 @@ Chainstack Self-Hosted is currently in beta, and we're actively looking for part
 
 Fill out the beta signup form:
 
-<Card title="Join the Chainstack Self-Hosted Beta" icon="rocket" href="https://3b81e.share.hsforms.com/2cWH4wEOeTOySPUNKOVDEEQ">
+<Card title="Join the Chainstack Self-Hosted Beta" icon="rocket" href="https://chainstack.com/self-hosted/">
   Get early access to new features and direct communication with the product team.
 </Card>
 
@@ -109,4 +109,4 @@ The beta program will continue through 2026 as we work toward general availabili
 |---------|---------|
 | Technical support | [support.chainstack.com](https://support.chainstack.com/hc/en-us) |
 | Feature requests | [Chainstack Feedback](https://ideas.chainstack.com/en?b=6968ecf76c93cb94db0422c8) |
-| Beta signup | [Signup form](https://3b81e.share.hsforms.com/2cWH4wEOeTOySPUNKOVDEEQ) |
+| Beta signup | [Signup form](https://chainstack.com/self-hosted/) |


### PR DESCRIPTION
## Summary

- Replace all Self-Hosted beta signup links with `https://chainstack.com/self-hosted/`
- Updates 7 links across 5 files (introduction, faq, support, installation, quick-start)

## Test plan

- [ ] Verify links render correctly in Mintlify preview
- [ ] Confirm new URL resolves properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined documentation links across self-hosted pages (FAQ, Installation, Introduction, Quick Start, Support) to direct users to the official Chainstack Self-Hosted page for beta signup and program information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->