### PR TITLE
Update introduction meta description

### DIFF
--- a/docs/platform-introduction.mdx
+++ b/docs/platform-introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Chainstack is the leading Web3 infrastructure provider for top chains, including Subgraphs, and add-ons like Solana Geyser."
+description: "Chainstack is the go-to blockchain node platform across 70+ chains, managed and self-hosted."
 ---
 
 Topping up with crypto is also an option at [Billing](https://console.chainstack.com/user/settings/billing). We support topping up with [150+ cryptocurrencies](https://nowpayments.io/supported-coins) .


### PR DESCRIPTION
## Summary

- Update the introduction page meta description to remove the deprecated Subgraphs mention
- Align wording with the 2026 Chainstack deck positioning ("blockchain node platform" across chains and environments)

**Before:** "Chainstack is the leading Web3 infrastructure provider for top chains, including Subgraphs, and add-ons like Solana Geyser."

**After:** "Chainstack is the go-to blockchain node platform across 70+ chains, managed and self-hosted."

Flagged by Eugene in #product-docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the platform introduction description to reflect expanded support across 70+ chains and service options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->