### PR TITLE
Document Ronin Saigon testnet L1 to L2 migration

### DIFF
--- a/docs/ronin-consensus-algorithm.mdx
+++ b/docs/ronin-consensus-algorithm.mdx
@@ -43,6 +43,14 @@ To advance decentralization, Ronin has integrated DPoS, allowing token holders t
 * **Bridge operators**: Manage asset transfers between Ronin and other EVM-compatible chains, with specific rewards and penalties.
 * **Maintenance and unavailability**: Systems in place for maintenance modes and slashing for non-performance, ensuring operational continuity.
 
+### Transition to Ethereum L2
+
+Ronin is migrating from an independent sidechain to an Ethereum Layer 2 using Optimism's OP Stack with EigenDA for data availability and RON as the custom gas token.
+
+The Saigon testnet completed its L2 migration on February 5, 2026, at block 45,528,550. The testnet chain ID changed from `2021` to `202601`. The mainnet migration is planned for Q1–Q2 2026, with the mainnet chain ID remaining `2020`.
+
+For details on how the migration affects RPC queries on Chainstack nodes, see the [Ronin tooling](/docs/ronin-tooling) page.
+
 ### Final remarks
 
 Ronin's hybrid consensus approach, combining PoA and DPoS, aims to balance efficiency with increased decentralization, reflecting the evolving landscape of blockchain governance.

--- a/docs/ronin-tooling.mdx
+++ b/docs/ronin-tooling.mdx
@@ -5,6 +5,26 @@ description: "Complete Ronin tooling guide for Chainstack nodes. Use web3.js, we
 
 Get started with a [reliable Ronin RPC endpoint](https://chainstack.com/build-better-with-ronin/) to use the tools below.
 
+<Warning>
+### Saigon testnet L1 to L2 migration
+
+On February 5, 2026, the Ronin Saigon testnet migrated from L1 to an Ethereum L2 using the OP Stack at block 45,528,550. The chain ID changed from `2021` to `202601`.
+
+**Block range sharding on Chainstack Saigon testnet nodes:**
+
+* Blocks 0–45,528,549 are served by the old L1 backend (chain ID `2021`)
+* Blocks 45,528,550 onward are served by the new L2 backend (chain ID `202601`)
+
+There is no block overlap between the two backends. Range-based methods like `eth_getLogs` cannot span both ranges in a single call—you must explicitly target either the L1 range or the L2 range.
+
+**Block explorers:**
+
+* Current (L2): [saigon-explorer.roninchain.com](https://saigon-explorer.roninchain.com/)
+* Legacy (L1): [legacy-saigon-explorer.roninchain.com](https://legacy-saigon-explorer.roninchain.com/)
+
+The Ronin mainnet is also planned to migrate to an Ethereum L2 in Q1–Q2 2026. The mainnet chain ID will remain `2020`.
+</Warning>
+
 ## web3.js
 
 Build DApps using [web3.js](https://github.com/web3/web3.js) and Ronin nodes deployed with Chainstack.
@@ -157,7 +177,7 @@ where
 * NETWORK\_ID — Ronin network ID:
 
   * Ronin Mainnet: `2020`
-  * Saigon Testnet: `2021`
+  * Saigon Testnet: `202601`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -182,6 +202,6 @@ where
 * NETWORK\_ID — Ronin network ID:
 
   * Ronin Mainnet: `2020`
-  * Saigon Testnet: `2021`
+  * Saigon Testnet: `202601`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-ronin.mdx
+++ b/reference/getting-started-ronin.mdx
@@ -8,6 +8,16 @@ Ronin is an EVM blockchain crafted for developers building games with player-own
 
 Find useful Ronin tools in the [Ronin tooling](/docs/ronin-tooling) section.
 
+<Warning>
+### Saigon testnet L1 to L2 migration
+
+On February 5, 2026, the Ronin Saigon testnet migrated from L1 to an Ethereum L2 using the OP Stack at block 45,528,550. The chain ID changed from `2021` to `202601`.
+
+On Chainstack Saigon testnet nodes, blocks 0–45,528,549 are served by the old L1 backend and blocks 45,528,550 onward are served by the new L2 backend. There is no block overlap—range-based methods like `eth_getLogs` cannot span both ranges in a single call. See [eth_getLogs](/reference/ronin-getlogs) for details.
+
+The Ronin mainnet is also planned to migrate to an Ethereum L2 in Q1–Q2 2026. The mainnet chain ID will remain `2020`.
+</Warning>
+
 <Check>
   ### Get you own node endpoint today
 

--- a/reference/ronin-getlogs.mdx
+++ b/reference/ronin-getlogs.mdx
@@ -7,6 +7,19 @@ The interactive example is tracking transfers for the [USDC contract](https://ap
 
 The `eth_getLogs` method returns an array of logs matching a specified filter object. This is a powerful feature for fetching historical data, such as transactions or events emitted by smart contracts.
 
+<Warning>
+### Saigon testnet block range sharding
+
+After the Saigon testnet L1 to L2 migration on February 5, 2026 (block 45,528,550), Chainstack nodes serve two separate backends:
+
+* Blocks 0–45,528,549 — old L1 backend (chain ID `2021`)
+* Blocks 45,528,550 onward — new L2 backend (chain ID `202601`)
+
+There is no block overlap. Your `eth_getLogs` calls with `fromBlock` and `toBlock` parameters **must not span block 45,528,550**. Query either the L1 range or the L2 range in a single request—requests that cross the boundary will return incomplete results.
+
+For example, to query the L1 range, set `toBlock` to `0x2B6B5E5` (45,528,549) or earlier. To query the L2 range, set `fromBlock` to `0x2B6B5E6` (45,528,550) or later.
+</Warning>
+
 <Check>
 **Get you own node endpoint today**
 


### PR DESCRIPTION
## Summary

- Update Saigon testnet chain ID from `2021` to `202601` in `ronin-tooling.mdx` (ethers.js HTTP and WebSocket sections)
- Add `<Warning>` callouts on `ronin-tooling.mdx`, `getting-started-ronin.mdx`, and `ronin-getlogs.mdx` explaining the Saigon testnet L1→L2 migration (OP Stack, Feb 5 2026, block 45,528,550), block range sharding on Chainstack nodes, and the new/legacy explorer links
- Add "Transition to Ethereum L2" section to `ronin-consensus-algorithm.mdx` covering OP Stack + EigenDA, testnet migration details, and mainnet Q1–Q2 2026 timeline

## Context

The Ronin Saigon testnet migrated to an Ethereum L2 via a hard fork at block 45,528,550 on Feb 5, 2026. Chainstack nodes now shard requests across two backends (L1 for blocks 0–45,528,549, L2 for 45,528,550+). Range-based RPC methods like `eth_getLogs` cannot span both backends in a single call—this must be documented for developers.

## Test plan

- [ ] Verify Mintlify renders the `<Warning>` callouts correctly on all four pages
- [ ] Confirm chain ID `202601` displays correctly in the ethers.js code examples
- [ ] Verify internal links between pages resolve (`/docs/ronin-tooling`, `/reference/ronin-getlogs`)
- [ ] Check hex values `0x2B6B5E5` / `0x2B6B5E6` match decimal 45,528,549 / 45,528,550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on Ronin's transition to Ethereum Layer 2 using Optimism's OP Stack.
  * Documented Saigon testnet migration with updated chain IDs and migration milestones.
  * Added warnings about block range sharding for RPC queries post-migration.
  * Updated RPC endpoint references and examples for testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->