### PR TITLE
Add availability notes to all Hyperliquid API reference pages

### DIFF
--- a/reference/hyperliquid-evm-debug-get-raw-block.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-block.mdx
@@ -3,6 +3,10 @@ title: debug_getRawBlock | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_get_raw_block.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_getRawBlock` JSON-RPC method returns the complete raw block data for a specific block. This method provides the entire block in its raw encoded format, including header and all transactions, useful for low-level blockchain analysis and custom block processing applications.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-get-raw-header.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-header.mdx
@@ -3,6 +3,10 @@ title: debug_getRawHeader | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_get_raw_header.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_getRawHeader` JSON-RPC method returns the raw header data for a specific block. This method provides the complete block header in its raw encoded format, useful for low-level blockchain analysis, debugging, and applications that need direct access to the block header's binary representation.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-get-raw-receipts.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-receipts.mdx
@@ -3,6 +3,10 @@ title: debug_getRawReceipts | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_get_raw_receipts.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_getRawReceipts` JSON-RPC method returns the raw receipt data for all transactions in a specific block. This method provides complete receipt information in raw encoded format for all transactions in a block, useful for bulk receipt processing and low-level blockchain analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-get-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-transaction.mdx
@@ -3,6 +3,10 @@ title: debug_getRawTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_get_raw_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_getRawTransaction` JSON-RPC method returns the raw transaction data for a specific transaction. This method provides the complete transaction in its raw encoded format, useful for low-level transaction analysis, custom parsing, and applications that need direct access to the transaction's binary representation.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-trace-block.mdx
+++ b/reference/hyperliquid-evm-debug-trace-block.mdx
@@ -3,6 +3,10 @@ title: debug_traceBlockByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_trace_block.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_traceBlockByHash` JSON-RPC method returns detailed trace information for all transactions in a specific block. This method provides comprehensive debugging information for an entire block, including call traces, gas usage, and execution details for each transaction, making it essential for block-level analysis, forensic investigations, and bulk transaction debugging.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-trace-call.mdx
+++ b/reference/hyperliquid-evm-debug-trace-call.mdx
@@ -3,6 +3,10 @@ title: debug_traceCall | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_trace_call.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_traceCall` JSON-RPC method executes a call and returns detailed trace information without creating a transaction. This method simulates transaction execution and provides comprehensive debugging information including call traces, gas usage, and state changes, making it essential for testing and debugging smart contract interactions before committing transactions to the blockchain.
 
 <Check>

--- a/reference/hyperliquid-evm-debug-trace-transaction.mdx
+++ b/reference/hyperliquid-evm-debug-trace-transaction.mdx
@@ -3,6 +3,10 @@ title: debug_traceTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_debug_trace_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `debug_traceTransaction` JSON-RPC method returns detailed trace information for a specific transaction. This method provides comprehensive debugging information including call traces, gas usage, state changes, and execution details, making it essential for transaction analysis, debugging, and forensic investigations.
 
 <Check>

--- a/reference/hyperliquid-evm-erigon-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-erigon-get-header-by-number.mdx
@@ -3,6 +3,10 @@ title: erigon_getHeaderByNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_erigon_get_header_by_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `erigon_getHeaderByNumber` JSON-RPC method retrieves block header information by block number on the Hyperliquid EVM blockchain. This method is an alias for `ots_getHeaderByNumber` and exists for compatibility with tools expecting Erigon-specific endpoints.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-big-block-gas-price.mdx
+++ b/reference/hyperliquid-evm-eth-big-block-gas-price.mdx
@@ -3,6 +3,10 @@ title: eth_bigBlockGasPrice | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_big_block_gas_price.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_bigBlockGasPrice` JSON-RPC method returns the base fee for the next big block on Hyperliquid EVM. This is a Hyperliquid-specific method that provides gas pricing for addresses using big blocks.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-blob-base-fee.mdx
+++ b/reference/hyperliquid-evm-eth-blob-base-fee.mdx
@@ -3,6 +3,10 @@ title: eth_blobBaseFee | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_blob_base_fee.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_blobBaseFee` JSON-RPC method returns the current base fee for blob transactions on the Hyperliquid EVM blockchain. This method is essential for applications working with EIP-4844 blob transactions, providing the current pricing information needed for blob data submission and cost estimation.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-block-number.mdx
@@ -3,6 +3,10 @@ title: eth_blockNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_block_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_blockNumber` JSON-RPC method returns the number of the most recent block on the Hyperliquid EVM blockchain. This method is fundamental for tracking blockchain state, monitoring synchronization status, and implementing block-based logic in applications.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-call-many.mdx
+++ b/reference/hyperliquid-evm-eth-call-many.mdx
@@ -3,6 +3,10 @@ title: eth_callMany | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_call_many.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_callMany` JSON-RPC method executes multiple call transactions in sequence without creating transactions on the blockchain. This method is useful for batch reading contract states and simulating multiple contract interactions efficiently.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-call.mdx
+++ b/reference/hyperliquid-evm-eth-call.mdx
@@ -3,6 +3,10 @@ title: eth_call | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_call.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_call` JSON-RPC method executes a new message call immediately without creating a transaction on the blockchain. This method is essential for reading data from smart contracts, calling view functions, and retrieving blockchain state without modifying it or paying gas fees.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-chain-id.mdx
+++ b/reference/hyperliquid-evm-eth-chain-id.mdx
@@ -3,6 +3,10 @@ title: eth_chainId | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_chain_id.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_chainId` JSON-RPC method returns the chain ID of the currently connected blockchain network. This method is fundamental for identifying the specific blockchain network, ensuring transaction compatibility, and implementing network-specific logic in applications.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-create-access-list.mdx
+++ b/reference/hyperliquid-evm-eth-create-access-list.mdx
@@ -3,6 +3,10 @@ title: eth_createAccessList | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_create_access_list.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_createAccessList` JSON-RPC method generates an access list for a transaction. This method simulates a transaction execution to determine which storage slots and addresses will be accessed, enabling more efficient gas usage through EIP-2930 access lists.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-estimate-gas.mdx
+++ b/reference/hyperliquid-evm-eth-estimate-gas.mdx
@@ -3,6 +3,10 @@ title: eth_estimateGas | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_estimate_gas.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_estimateGas` JSON-RPC method estimates the amount of gas required to execute a transaction without actually executing it on the blockchain. This method is essential for determining gas costs before sending transactions, helping users avoid failed transactions due to insufficient gas.
 
 On Hyperliquid, gas estimation is performed against the latest block state only.

--- a/reference/hyperliquid-evm-eth-fee-history.mdx
+++ b/reference/hyperliquid-evm-eth-fee-history.mdx
@@ -3,6 +3,10 @@ title: eth_feeHistory | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_fee_history.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_feeHistory` JSON-RPC method returns historical gas fee data for a range of blocks. This method provides essential information for gas price estimation, including base fees, gas usage ratios, and priority fee percentiles.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-gas-price.mdx
+++ b/reference/hyperliquid-evm-eth-gas-price.mdx
@@ -3,6 +3,10 @@ title: eth_gasPrice | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_gas_price.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_gasPrice` JSON-RPC method returns the base fee for the next small block on Hyperliquid EVM. This method provides the gas price for standard (small) block transactions.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-balance.mdx
+++ b/reference/hyperliquid-evm-eth-get-balance.mdx
@@ -3,6 +3,10 @@ title: eth_getBalance | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_balance.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBalance` JSON-RPC method returns the balance of an account at a given block number. This method is fundamental for checking account balances and is essential for wallet applications, portfolio tracking, and balance verification.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-block-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-by-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getBlockByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_block_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBlockByHash` JSON-RPC method returns information about a block by its hash. This method is essential for retrieving detailed block information when you have the block hash, commonly used for block exploration, transaction verification, and blockchain analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-block-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-by-number.mdx
@@ -3,6 +3,10 @@ title: eth_getBlockByNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_block_by_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBlockByNumber` JSON-RPC method returns information about a block by its number. This method is essential for retrieving block data when you know the block number, commonly used for sequential block processing, blockchain synchronization, and historical data analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-block-receipts.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-receipts.mdx
@@ -3,6 +3,10 @@ title: eth_getBlockReceipts | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_block_receipts.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBlockReceipts` JSON-RPC method returns all transaction receipts for a given block. This method is highly efficient for retrieving receipt data for all transactions in a block with a single API call, making it ideal for block processing, event extraction, and comprehensive transaction analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-block-transaction-count-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-transaction-count-by-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getBlockTransactionCountByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_block_transaction_count_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBlockTransactionCountByHash` JSON-RPC method returns the number of transactions in a block by its hash. This method provides a lightweight way to get transaction count information without retrieving the full block data, making it efficient for block analysis and statistics.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-block-transaction-count-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-transaction-count-by-number.mdx
@@ -3,6 +3,10 @@ title: eth_getBlockTransactionCountByNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_block_transaction_count_by_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getBlockTransactionCountByNumber` JSON-RPC method returns the number of transactions in a block by its number. This method provides a lightweight way to get transaction count information for sequential block analysis, making it efficient for building statistics and monitoring network activity over time.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-code.mdx
+++ b/reference/hyperliquid-evm-eth-get-code.mdx
@@ -3,6 +3,10 @@ title: eth_getCode | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_code.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getCode` JSON-RPC method returns the bytecode of a smart contract at a given address and block. This method is essential for contract verification, analysis, and determining whether an address contains a smart contract or is an externally owned account (EOA).
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-filter-changes.mdx
+++ b/reference/hyperliquid-evm-eth-get-filter-changes.mdx
@@ -3,6 +3,10 @@ title: eth_getFilterChanges | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_filter_changes.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getFilterChanges` JSON-RPC method returns an array of logs or block hashes that have occurred since the last poll for the specified filter. This method is used to retrieve new results from filters created with `eth_newFilter` or `eth_newBlockFilter`, providing an efficient polling mechanism for monitoring blockchain events.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-filter-logs.mdx
+++ b/reference/hyperliquid-evm-eth-get-filter-logs.mdx
@@ -3,6 +3,10 @@ title: eth_getFilterLogs | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_filter_logs.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getFilterLogs` JSON-RPC method returns an array of all logs matching the filter with the given ID. Unlike `eth_getFilterChanges`, this method returns all matching logs from the entire filter range, not just changes since the last poll. This method is useful for retrieving the complete history of events matching a filter.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-header-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-header-by-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getHeaderByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_header_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getHeaderByHash` JSON-RPC method returns the block header information for a given block hash. This method provides header data without the transaction list, offering a lightweight way to access block metadata when you have the specific block hash.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-header-by-number.mdx
@@ -3,6 +3,10 @@ title: eth_getHeaderByNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_header_by_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getHeaderByNumber` JSON-RPC method returns the block header information for a given block number. This method provides header data without the transaction list, offering a lightweight way to access block metadata and is more efficient than fetching the full block when only header information is needed.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-logs.mdx
+++ b/reference/hyperliquid-evm-eth-get-logs.mdx
@@ -3,6 +3,10 @@ title: eth_getLogs | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_logs.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getLogs` JSON-RPC method returns event logs that match specified filter criteria. This method is essential for retrieving smart contract events, monitoring contract activity, and building event-driven applications on the blockchain.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-proof.mdx
+++ b/reference/hyperliquid-evm-eth-get-proof.mdx
@@ -3,6 +3,10 @@ title: eth_getProof | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_proof.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getProof` JSON-RPC method returns the Merkle proof for an account and optionally some storage keys. This method is essential for verifying account states and storage values without trusting the node, enabling light clients and cross-chain verification systems.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-hash-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getRawTransactionByBlockHashAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_raw_transaction_by_block_hash_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the raw transaction data by block hash and transaction index. Use this method to retrieve the RLP-encoded raw transaction from a specific position within a known block.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-number-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getRawTransactionByBlockNumberAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_raw_transaction_by_block_number_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the raw transaction data by block number and transaction index. Use this method to retrieve the RLP-encoded raw transaction from a specific position within a block identified by its number.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getRawTransactionByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_raw_transaction_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the raw transaction data by its hash. Use this method to retrieve the RLP-encoded raw transaction when you have the transaction hash.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-storage-at.mdx
+++ b/reference/hyperliquid-evm-eth-get-storage-at.mdx
@@ -3,6 +3,10 @@ title: eth_getStorageAt | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_storage_at.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getStorageAt` JSON-RPC method returns the value stored at a specific storage position in a smart contract. This method provides direct access to contract storage, enabling contract state inspection, debugging, and advanced contract analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getSystemTxsByBlockHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_system_txs_by_block_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getSystemTxsByBlockHash` JSON-RPC method returns system transactions for a given block hash on Hyperliquid EVM. This Hyperliquid-specific method provides access to internal system transactions using the block's unique hash identifier, ensuring precise block identification even during chain reorganizations.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
@@ -3,6 +3,10 @@ title: eth_getSystemTxsByBlockNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_system_txs_by_block_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getSystemTxsByBlockNumber` JSON-RPC method returns system transactions for a given block number on Hyperliquid EVM. This Hyperliquid-specific method provides access to internal system transactions that handle protocol operations, network maintenance, and other system-level activities.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-block-hash-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionByBlockHashAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_by_block_hash_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getTransactionByBlockHashAndIndex` JSON-RPC method returns transaction information by block hash and transaction index. This method is useful for retrieving specific transactions when you know the block hash and the transaction's position within that block.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-block-number-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionByBlockNumberAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_by_block_number_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getTransactionByBlockNumberAndIndex` JSON-RPC method returns transaction information by block number and transaction index. This method is ideal for sequential transaction processing and building comprehensive blockchain datasets when working with block numbers.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns transaction information by its hash. Use this method to retrieve specific transaction details when you have the transaction hash.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-by-sender-and-nonce.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-sender-and-nonce.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionBySenderAndNonce | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_by_sender_and_nonce.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getTransactionBySenderAndNonce` JSON-RPC method retrieves transaction information by specifying the sender address and transaction nonce on the Hyperliquid EVM blockchain. This method is particularly useful for tracking specific transactions when you know the sender and the sequence number of their transaction.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-count.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-count.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionCount | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_count.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the number of transactions sent from an address (the nonce). This is essential for creating new transactions with the correct nonce value.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-transaction-receipt.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-receipt.mdx
@@ -3,6 +3,10 @@ title: eth_getTransactionReceipt | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_transaction_receipt.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the receipt of a transaction by its hash, containing execution results, gas usage, event logs, and transaction status. Use this to verify transaction execution and extract contract events.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-uncle-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-by-block-hash-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getUncleByBlockHashAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_uncle_by_block_hash_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getUncleByBlockHashAndIndex` JSON-RPC method returns information about an uncle block by block hash and uncle index position. Uncle blocks are valid blocks that were not included in the main chain but are referenced by the main chain blocks for network security.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-uncle-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-by-block-number-and-index.mdx
@@ -3,6 +3,10 @@ title: eth_getUncleByBlockNumberAndIndex | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_uncle_by_block_number_and_index.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_getUncleByBlockNumberAndIndex` JSON-RPC method returns information about an uncle block by block number and uncle index position. Uncle blocks are valid blocks that were not included in the main chain but are referenced by the main chain blocks for network security.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-uncle-count-by-block-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-count-by-block-hash.mdx
@@ -3,6 +3,10 @@ title: eth_getUncleCountByBlockHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_uncle_count_by_block_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the number of uncle blocks for a given block hash. Use this method to get the count of uncle (ommer) blocks associated with a specific block.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-get-uncle-count-by-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-count-by-block-number.mdx
@@ -3,6 +3,10 @@ title: eth_getUncleCountByBlockNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_get_uncle_count_by_block_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the number of uncle blocks for a given block number. Use this method to get the count of uncle (ommer) blocks associated with a block identified by its number.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-max-priority-fee-per-gas.mdx
+++ b/reference/hyperliquid-evm-eth-max-priority-fee-per-gas.mdx
@@ -3,6 +3,10 @@ title: eth_maxPriorityFeePerGas | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_max_priority_fee_per_gas.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the current maximum priority fee per gas for EIP-1559 transactions. On Hyperliquid, this method always returns zero as priority fees are not used.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-new-block-filter.mdx
+++ b/reference/hyperliquid-evm-eth-new-block-filter.mdx
@@ -3,6 +3,10 @@ title: eth_newBlockFilter | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_new_block_filter.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_newBlockFilter` JSON-RPC method creates a filter object to notify when new blocks arrive on the blockchain. This method returns a filter ID that can be used with `eth_getFilterChanges` to retrieve new block hashes as they are mined, providing an efficient way to monitor blockchain progression.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-new-filter.mdx
+++ b/reference/hyperliquid-evm-eth-new-filter.mdx
@@ -3,6 +3,10 @@ title: eth_newFilter | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_new_filter.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_newFilter` JSON-RPC method creates a filter object to notify when logs match the specified criteria. This method returns a filter ID that can be used with `eth_getFilterChanges` and `eth_getFilterLogs` to retrieve matching logs. Filters are essential for monitoring specific events on the blockchain.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-protocol-version.mdx
+++ b/reference/hyperliquid-evm-eth-protocol-version.mdx
@@ -3,6 +3,10 @@ title: eth_protocolVersion | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_protocol_version.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_protocolVersion` JSON-RPC method returns the current Ethereum protocol version supported by the Hyperliquid EVM node. This method is essential for ensuring compatibility between client applications and the blockchain network, helping developers verify protocol support and maintain version compatibility.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-send-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-eth-send-raw-transaction.mdx
@@ -3,6 +3,10 @@ title: eth_sendRawTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_send_raw_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_sendRawTransaction` JSON-RPC method submits a pre-signed transaction to the network for broadcasting and inclusion in a block. This method is essential for sending transactions that have been signed offline or by external wallets, enabling secure transaction submission without exposing private keys.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-simulate-v1.mdx
+++ b/reference/hyperliquid-evm-eth-simulate-v1.mdx
@@ -3,6 +3,10 @@ title: eth_simulateV1 | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_simulate_v1.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_simulateV1` JSON-RPC method provides transaction simulation capabilities on the Hyperliquid EVM blockchain. This method allows developers to execute transactions in a controlled environment without actually submitting them to the blockchain, enabling testing, gas estimation, and outcome prediction.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-subscribe-logs.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-logs.mdx
@@ -3,6 +3,10 @@ title: eth_subscribe ("logs") | Hyperliquid EVM
 description: Subscribe to real-time updates about new event logs on Hyperliquid EVM blockchain. Receive notifications whenever new logs matching the filter are emitted.
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_subscribe("logs")` JSON-RPC method allows developers to subscribe to real-time updates about new event logs on the Hyperliquid EVM blockchain. The application will receive notifications whenever new logs matching the filter are emitted, making it essential for monitoring smart contract events and building reactive dApps.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-subscribe-newheads.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-newheads.mdx
@@ -3,6 +3,10 @@ title: eth_subscribe ("newHeads") | Hyperliquid EVM
 description: Subscribe to real-time notifications for new block headers on Hyperliquid EVM blockchain. Sends notifications whenever a new block is added.
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_subscribe("newHeads")` JSON-RPC method allows developers to receive real-time notifications regarding new block headers on the Hyperliquid EVM blockchain. It sends notifications whenever a new block is added, making it essential for applications that need to track blockchain state changes in real-time.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-subscribe-syncing.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-syncing.mdx
@@ -3,6 +3,10 @@ title: eth_subscribe ("syncing") | Hyperliquid EVM
 description: Subscribe to notifications about the node's synchronization status on Hyperliquid EVM. Receive updates when the node starts or stops syncing with the network.
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_subscribe("syncing")` JSON-RPC method allows developers to subscribe to notifications about the synchronization status of a Hyperliquid EVM node. The subscription provides real-time updates when the node starts or stops syncing with the network, making it essential for monitoring node health and ensuring data consistency.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-syncing.mdx
+++ b/reference/hyperliquid-evm-eth-syncing.mdx
@@ -3,6 +3,10 @@ title: eth_syncing | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_syncing.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the synchronization status of the node. On Hyperliquid, this method always returns `false` as nodes are always considered synchronized.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-uninstall-filter.mdx
+++ b/reference/hyperliquid-evm-eth-uninstall-filter.mdx
@@ -3,6 +3,10 @@ title: eth_uninstallFilter | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_uninstall_filter.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_uninstallFilter` JSON-RPC method uninstalls a filter with the given ID. This method should be called when polling is no longer needed to free up server resources and maintain optimal performance. Filters may also be automatically uninstalled if they are not polled for an extended period of time.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-unsubscribe.mdx
+++ b/reference/hyperliquid-evm-eth-unsubscribe.mdx
@@ -3,6 +3,10 @@ title: eth_unsubscribe | Hyperliquid EVM
 description: Cancel an active WebSocket subscription on Hyperliquid EVM. Stop receiving notifications for a previously established subscription.
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `eth_unsubscribe` JSON-RPC method allows developers to cancel an active WebSocket subscription on the Hyperliquid EVM blockchain. This method is used to stop receiving notifications for subscriptions created with `eth_subscribe`, helping to manage resources and control data flow in applications.
 
 <Check>

--- a/reference/hyperliquid-evm-eth-using-big-blocks.mdx
+++ b/reference/hyperliquid-evm-eth-using-big-blocks.mdx
@@ -3,6 +3,10 @@ title: eth_usingBigBlocks | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_eth_using_big_blocks.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns whether a specific address is using big blocks on Hyperliquid EVM. This Hyperliquid-specific method helps determine if an address can utilize enhanced transaction processing capabilities.
 
 <Check>

--- a/reference/hyperliquid-evm-net-listening.mdx
+++ b/reference/hyperliquid-evm-net-listening.mdx
@@ -3,6 +3,10 @@ title: net_listening | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_net_listening.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `net_listening` JSON-RPC method returns true if the client is actively listening for network connections. This method is useful for checking the network connectivity status of the Hyperliquid EVM node and verifying that it can accept incoming peer connections.
 
 <Check>

--- a/reference/hyperliquid-evm-net-peer-count.mdx
+++ b/reference/hyperliquid-evm-net-peer-count.mdx
@@ -3,6 +3,10 @@ title: net_peerCount | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_net_peer_count.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `net_peerCount` JSON-RPC method returns the number of peers currently connected to the client. This method provides information about the node's network connectivity and can be used to monitor network health, connectivity status, and the decentralization level of the blockchain network.
 
 <Check>

--- a/reference/hyperliquid-evm-net-version.mdx
+++ b/reference/hyperliquid-evm-net-version.mdx
@@ -3,6 +3,10 @@ title: net_version | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_net_version.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the current network ID for the Hyperliquid EVM. Use this to identify which network the client is connected to.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-api-level.mdx
+++ b/reference/hyperliquid-evm-ots-get-api-level.mdx
@@ -3,6 +3,10 @@ title: ots_getApiLevel | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_api_level.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getApiLevel` JSON-RPC method returns the Otterscan API version level supported by the Hyperliquid EVM node. This method allows clients, particularly the Otterscan block explorer, to determine which API features are available on the connected node.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-block-details-by-hash.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-details-by-hash.mdx
@@ -3,6 +3,10 @@ title: ots_getBlockDetailsByHash | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_block_details_by_hash.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getBlockDetailsByHash` JSON-RPC method retrieves expanded block details by block hash on the Hyperliquid EVM blockchain. This Otterscan-specific method provides a tailored response for block detail pages in block explorers, including calculated total fees and other aggregated information.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-block-details.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-details.mdx
@@ -3,6 +3,10 @@ title: ots_getBlockDetails | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_block_details.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getBlockDetails` JSON-RPC method retrieves expanded block details by block number on the Hyperliquid EVM blockchain. This Otterscan-specific method provides a tailored response for block detail pages in block explorers, including calculated total fees and other aggregated information.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-block-transactions.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-transactions.mdx
@@ -3,6 +3,10 @@ title: ots_getBlockTransactions | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_block_transactions.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getBlockTransactions` JSON-RPC method retrieves paginated transactions for a specific block on the Hyperliquid EVM blockchain. This Otterscan-specific method optimizes data transfer by removing verbose fields like logs and providing pagination support for blocks with many transactions.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-contract-creator.mdx
+++ b/reference/hyperliquid-evm-ots-get-contract-creator.mdx
@@ -3,6 +3,10 @@ title: ots_getContractCreator | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_contract_creator.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getContractCreator` JSON-RPC method retrieves the transaction hash and creator address for a deployed contract on the Hyperliquid EVM blockchain. This Otterscan-specific method helps identify who deployed a smart contract and in which transaction.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-ots-get-header-by-number.mdx
@@ -3,6 +3,10 @@ title: ots_getHeaderByNumber | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_header_by_number.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getHeaderByNumber` JSON-RPC method retrieves block header information by block number on the Hyperliquid EVM blockchain. This Otterscan-specific method provides a lightweight way to fetch block headers without retrieving full block data, making it efficient for block explorer operations.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-internal-operations.mdx
+++ b/reference/hyperliquid-evm-ots-get-internal-operations.mdx
@@ -3,6 +3,10 @@ title: ots_getInternalOperations | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_internal_operations.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getInternalOperations` JSON-RPC method retrieves all internal ETH transfers and operations that occurred within a transaction on the Hyperliquid EVM blockchain. This Otterscan-specific method reveals value transfers that happen inside smart contract execution, which are not visible in standard transaction receipts.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-transaction-by-sender-and-nonce.mdx
+++ b/reference/hyperliquid-evm-ots-get-transaction-by-sender-and-nonce.mdx
@@ -3,6 +3,10 @@ title: ots_getTransactionBySenderAndNonce | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_transaction_by_sender_and_nonce.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getTransactionBySenderAndNonce` JSON-RPC method retrieves a transaction hash by specifying the sender address and nonce on the Hyperliquid EVM blockchain. This Otterscan-specific method helps locate transactions when you know the sender and nonce but not the transaction hash.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-get-transaction-error.mdx
+++ b/reference/hyperliquid-evm-ots-get-transaction-error.mdx
@@ -3,6 +3,10 @@ title: ots_getTransactionError | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_get_transaction_error.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_getTransactionError` JSON-RPC method retrieves the raw revert reason for failed transactions on the Hyperliquid EVM blockchain. This Otterscan-specific method provides detailed error messages from smart contract failures, helping developers debug transaction issues.
 
 <Check>

--- a/reference/hyperliquid-evm-ots-has-code.mdx
+++ b/reference/hyperliquid-evm-ots-has-code.mdx
@@ -3,6 +3,10 @@ title: ots_hasCode | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_has_code.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_hasCode` JSON-RPC method checks whether a specified address contains deployed contract code on the Hyperliquid EVM blockchain. This Otterscan-specific method provides a quick way to determine if an address is a smart contract or an externally owned account (EOA).
 
 <Check>

--- a/reference/hyperliquid-evm-ots-trace-transaction.mdx
+++ b/reference/hyperliquid-evm-ots-trace-transaction.mdx
@@ -3,6 +3,10 @@ title: ots_traceTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_ots_trace_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `ots_traceTransaction` JSON-RPC method returns the complete execution trace of a transaction on the Hyperliquid EVM blockchain. This Otterscan-specific method extracts all variations of calls, contract creations, and self-destructs, presenting them as a detailed call tree that reveals the full execution flow.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-block.mdx
+++ b/reference/hyperliquid-evm-trace-block.mdx
@@ -3,6 +3,10 @@ title: trace_block | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_block.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_block` JSON-RPC method returns trace information for all transactions in a specific block. This method provides execution traces for all transactions within a block using OpenEthereum-style tracing, making it essential for comprehensive block analysis and monitoring.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-call-many.mdx
+++ b/reference/hyperliquid-evm-trace-call-many.mdx
@@ -3,6 +3,10 @@ title: trace_callMany | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_call_many.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_callMany` JSON-RPC method executes multiple calls and returns trace information for each call. This method allows batch simulation of multiple transactions with detailed execution traces, making it ideal for complex scenario testing, batch analysis, and multi-step transaction planning.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-call.mdx
+++ b/reference/hyperliquid-evm-trace-call.mdx
@@ -3,6 +3,10 @@ title: trace_call | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_call.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_call` JSON-RPC method executes a call and returns trace information using OpenEthereum-style tracing. This method simulates a transaction and provides detailed execution traces without committing changes to the blockchain, making it ideal for transaction analysis, debugging, and testing before actual execution.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-filter.mdx
+++ b/reference/hyperliquid-evm-trace-filter.mdx
@@ -3,6 +3,10 @@ title: trace_filter | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_filter.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_filter` JSON-RPC method returns traces matching specified filter criteria. This method allows filtering traces by block range, addresses, and other criteria to find specific transaction patterns, making it essential for blockchain analysis, forensic investigations, and monitoring specific address activities.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-trace-raw-transaction.mdx
@@ -3,6 +3,10 @@ title: trace_rawTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_raw_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_rawTransaction` JSON-RPC method executes a raw transaction and returns trace information. This method simulates the execution of a raw transaction and provides detailed execution traces, making it useful for analyzing pre-signed transactions and testing transaction execution without broadcasting.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-replay-block-transactions.mdx
+++ b/reference/hyperliquid-evm-trace-replay-block-transactions.mdx
@@ -3,6 +3,10 @@ title: trace_replayBlockTransactions | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_replay_block_transactions.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_replayBlockTransactions` JSON-RPC method replays all transactions in a block and returns trace information for each transaction. This method provides detailed execution traces for all transactions in a specific block by replaying their execution, making it essential for comprehensive block analysis.
 
 <Check>

--- a/reference/hyperliquid-evm-trace-replay-transaction.mdx
+++ b/reference/hyperliquid-evm-trace-replay-transaction.mdx
@@ -3,6 +3,10 @@ title: trace_replayTransaction | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_trace_replay_transaction.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `trace_replayTransaction` JSON-RPC method replays a specific transaction and returns trace information. This method provides detailed execution traces for a single transaction by replaying its execution, making it essential for transaction debugging, analysis, and forensic investigation.
 
 <Check>

--- a/reference/hyperliquid-evm-web3-client-version.mdx
+++ b/reference/hyperliquid-evm-web3-client-version.mdx
@@ -3,6 +3,10 @@ title: web3_clientVersion | Hyperliquid EVM
 openapi: /openapi/hyperliquid_node_api/evm_web3_client_version.json post /evm
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Returns the current client version for the Hyperliquid EVM. Use this to identify the client implementation and version.
 
 <Check>

--- a/reference/hyperliquid-exchange-batch-modify.mdx
+++ b/reference/hyperliquid-exchange-batch-modify.mdx
@@ -3,6 +3,10 @@ title: Batch modify orders | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_batch_modify.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-cancel-order-by-cloid.mdx
+++ b/reference/hyperliquid-exchange-cancel-order-by-cloid.mdx
@@ -3,6 +3,10 @@ title: Cancel order by cloid | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_cancel_by_cloid.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-cancel-order.mdx
+++ b/reference/hyperliquid-exchange-cancel-order.mdx
@@ -3,6 +3,10 @@ title: Cancel order | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_cancel_order.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-modify-order.mdx
+++ b/reference/hyperliquid-exchange-modify-order.mdx
@@ -3,6 +3,10 @@ title: Modify order | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_modify_order.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-place-order.mdx
+++ b/reference/hyperliquid-exchange-place-order.mdx
@@ -3,6 +3,10 @@ title: Place order | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_place_order.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-schedule-cancel.mdx
+++ b/reference/hyperliquid-exchange-schedule-cancel.mdx
@@ -3,6 +3,10 @@ title: Schedule cancel | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_schedule_cancel.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-spot-perp-transfer.mdx
+++ b/reference/hyperliquid-exchange-spot-perp-transfer.mdx
@@ -3,6 +3,10 @@ title: Spot ↔ Perp transfer | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_spot_perp_transfer.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-spot-send.mdx
+++ b/reference/hyperliquid-exchange-spot-send.mdx
@@ -3,6 +3,10 @@ title: Spot token transfer | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_spot_send.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-update-isolated-margin.mdx
+++ b/reference/hyperliquid-exchange-update-isolated-margin.mdx
@@ -3,6 +3,10 @@ title: Update isolated margin | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_update_isolated_margin.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-update-leverage.mdx
+++ b/reference/hyperliquid-exchange-update-leverage.mdx
@@ -3,6 +3,10 @@ title: Update leverage | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_update_leverage.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-usd-send.mdx
+++ b/reference/hyperliquid-exchange-usd-send.mdx
@@ -3,6 +3,10 @@ title: USDC transfer | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_usd_send.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-exchange-withdraw.mdx
+++ b/reference/hyperliquid-exchange-withdraw.mdx
@@ -3,6 +3,10 @@ title: Withdraw USDC | Hyperliquid exchange
 openapi: /openapi/hyperliquid_node_api/exchange_withdraw.json post /exchange
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 This endpoint requires signature authentication. See our comprehensive [Authentication via Signatures guide](/docs/hyperliquid-authentication-guide) for implementation details.
 </Note>

--- a/reference/hyperliquid-info-activeassetdata.mdx
+++ b/reference/hyperliquid-info-activeassetdata.mdx
@@ -3,6 +3,10 @@ title: activeAssetData | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_activeassetdata.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 Retrieves active asset data for a specific user and coin, including leverage settings, trading limits, and current market price.
 
 <Info>

--- a/reference/hyperliquid-info-allmids.mdx
+++ b/reference/hyperliquid-info-allmids.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_allmids.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 Retrieves mid prices for all available coins on the Hyperliquid exchange. If the order book is empty, the last trade price is used as a fallback.

--- a/reference/hyperliquid-info-batch-clearinghouse-states.mdx
+++ b/reference/hyperliquid-info-batch-clearinghouse-states.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_batch_clearinghouse_states.json post
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "batchClearinghouseStates"` retrieves perpetuals account summaries for multiple users in one call. Use this to efficiently fetch positions, margin usage, and account values across many addresses.

--- a/reference/hyperliquid-info-candle-snapshot.mdx
+++ b/reference/hyperliquid-info-candle-snapshot.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_candle_snapshot.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 Retrieves historical candlestick (OHLCV) data for a specific asset within a time range. Only the most recent 5000 candles are available.

--- a/reference/hyperliquid-info-clearinghousestate.mdx
+++ b/reference/hyperliquid-info-clearinghousestate.mdx
@@ -3,6 +3,10 @@ title: clearinghouseState | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_clearinghousestate.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "clearinghouseState"` retrieves a user's perpetuals account summary including open positions and margin information for the Hyperliquid exchange. This endpoint provides comprehensive data about a user's trading positions, leverage, margin usage, and account value.
 
 <Check>

--- a/reference/hyperliquid-info-delegations.mdx
+++ b/reference/hyperliquid-info-delegations.mdx
@@ -3,6 +3,10 @@ title: delegations | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_delegations.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "delegations"` retrieves a user's active delegations on the Hyperliquid network. This endpoint provides a simple list of current delegations showing the validator address, delegated amount, and lock expiration timestamp for each delegation.
 
 <Check>

--- a/reference/hyperliquid-info-delegator-history.mdx
+++ b/reference/hyperliquid-info-delegator-history.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_delegator_history.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "delegatorHistory"` retrieves comprehensive staking history for a specific user on the Hyperliquid exchange. This endpoint provides detailed historical data about delegation and undelegation events, including timestamps, transaction hashes, and complete event details, enabling thorough analysis of staking behavior and validator relationships.

--- a/reference/hyperliquid-info-delegator-rewards.mdx
+++ b/reference/hyperliquid-info-delegator-rewards.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_delegator_rewards.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "delegatorRewards"` retrieves comprehensive staking rewards history for a specific user on the Hyperliquid exchange. This endpoint provides detailed historical data about rewards earned from delegation and validator commission, including timestamps and reward amounts, enabling thorough analysis of staking reward performance and validator earnings.

--- a/reference/hyperliquid-info-delegator-summary.mdx
+++ b/reference/hyperliquid-info-delegator-summary.mdx
@@ -3,6 +3,10 @@ title: delegatorSummary | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_delegator_summary.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "delegatorSummary"` provides a concise overview of a user's delegation status on the Hyperliquid network. This endpoint returns key metrics about the user's staking position, including total delegated amounts, undelegated amounts, and pending withdrawal information.
 
 <Check>

--- a/reference/hyperliquid-info-exchangestatus.mdx
+++ b/reference/hyperliquid-info-exchangestatus.mdx
@@ -3,6 +3,10 @@ title: exchangeStatus | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_exchangestatus.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "exchangeStatus"` retrieves the current status of the Hyperliquid exchange, including information about all available trading assets and their configurations. This endpoint provides essential metadata about the exchange's operational status and available markets.
 
 <Check>

--- a/reference/hyperliquid-info-extraagents.mdx
+++ b/reference/hyperliquid-info-extraagents.mdx
@@ -3,6 +3,10 @@ title: extraAgents | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_extraagents.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "extraAgents"` retrieves information about additional agents or authorized accounts associated with a user's wallet on the Hyperliquid exchange. This endpoint provides details about delegated permissions, agent activities, and access control configurations for advanced account management.
 
 <Check>

--- a/reference/hyperliquid-info-frontendopenorders.mdx
+++ b/reference/hyperliquid-info-frontendopenorders.mdx
@@ -3,6 +3,10 @@ title: frontendOpenOrders | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_frontendopenorders.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "frontendOpenOrders"` retrieves a user's open orders with additional frontend-specific formatting and metadata. This endpoint provides enhanced order information specifically designed for display in trading interfaces, including order types, trigger conditions, and other UI-relevant data.
 
 <Check>

--- a/reference/hyperliquid-info-funding-history.mdx
+++ b/reference/hyperliquid-info-funding-history.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_funding_history.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "fundingHistory"` retrieves historical funding rates and premiums for a specific perpetual contract on the Hyperliquid exchange. This endpoint provides comprehensive data about funding costs over time, enabling analysis of market sentiment, carry trade opportunities, and long-term trading strategy optimization.

--- a/reference/hyperliquid-info-gossip-root-ips.mdx
+++ b/reference/hyperliquid-info-gossip-root-ips.mdx
@@ -3,6 +3,10 @@ title: gossipRootIps | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_gossip_root_ips.json post /info
 ---
 
+<Info>
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "gossipRootIps"` retrieves a list of recently available seed peer IP addresses for non-validators looking to connect to the Hyperliquid network. This endpoint provides reliable peer addresses that can be used as seed peers for node synchronization and network connectivity.
 
 <Check>

--- a/reference/hyperliquid-info-historical-orders.mdx
+++ b/reference/hyperliquid-info-historical-orders.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_historical_orders.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "historicalOrders"` retrieves a user's historical orders on the Hyperliquid exchange. This endpoint provides comprehensive order history including detailed order information and final status for each order, making it essential for trade analysis, reporting, and order management.

--- a/reference/hyperliquid-info-l2-book.mdx
+++ b/reference/hyperliquid-info-l2-book.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_l2_book.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "l2Book"` retrieves a Level 2 order book snapshot for a specific asset on the Hyperliquid exchange. This endpoint provides real-time market depth information showing the best bid and ask prices with their corresponding quantities and order counts.

--- a/reference/hyperliquid-info-leadingvaults.mdx
+++ b/reference/hyperliquid-info-leadingvaults.mdx
@@ -3,6 +3,10 @@ title: leadingVaults | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_leadingvaults.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "leadingVaults"` retrieves information about all vaults managed by a specific vault leader on the Hyperliquid exchange. This endpoint provides comprehensive data about a vault leader's managed funds, including performance metrics, vault configurations, and management details.
 
 <Check>

--- a/reference/hyperliquid-info-liquidatable.mdx
+++ b/reference/hyperliquid-info-liquidatable.mdx
@@ -3,6 +3,10 @@ title: liquidatable | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_liquidatable.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "liquidatable"` checks whether a user's positions are currently at risk of liquidation on the Hyperliquid exchange. This endpoint provides critical risk management information including liquidation status, leverage ratios, margin usage, and account health metrics.
 
 <Check>

--- a/reference/hyperliquid-info-max-builder-fee.mdx
+++ b/reference/hyperliquid-info-max-builder-fee.mdx
@@ -3,6 +3,10 @@ title: maxBuilderFee | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_max_builder_fee.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "maxBuilderFee"` retrieves the maximum builder fee that a user has approved for a specific builder on the Hyperliquid network. This endpoint is essential for understanding fee arrangements between users and builders in the MEV (Maximum Extractable Value) ecosystem.
 
 <Check>

--- a/reference/hyperliquid-info-maxmarketorderntls.mdx
+++ b/reference/hyperliquid-info-maxmarketorderntls.mdx
@@ -3,6 +3,10 @@ title: maxMarketOrderNtls | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_maxmarketorderntls.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "maxMarketOrderNtls"` retrieves the maximum notional values and sizes allowed for market orders across all available assets on the Hyperliquid exchange. This endpoint provides essential trading limits that help prevent excessive market impact and ensure orderly market operations.
 
 <Check>

--- a/reference/hyperliquid-info-meta-and-asset-ctxs.mdx
+++ b/reference/hyperliquid-info-meta-and-asset-ctxs.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_meta_and_asset_ctxs.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "metaAndAssetCtxs"` retrieves comprehensive asset contexts for perpetuals trading on the Hyperliquid exchange. This endpoint provides both universe metadata defining available assets and real-time market data including mark prices, funding rates, open interest, volume metrics, and price impact information for all perpetual contracts.

--- a/reference/hyperliquid-info-meta.mdx
+++ b/reference/hyperliquid-info-meta.mdx
@@ -3,6 +3,10 @@ title: meta | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_meta.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "meta"` retrieves perpetuals metadata including universe and margin tables for the Hyperliquid exchange. This endpoint provides essential information about available trading pairs, their decimal precision, maximum leverage, and margin tier configurations.
 
 <Check>

--- a/reference/hyperliquid-info-openorders.mdx
+++ b/reference/hyperliquid-info-openorders.mdx
@@ -3,6 +3,10 @@ title: openOrders | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_openorders.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "openOrders"` retrieves a user's open orders for both perpetuals and spot trading on the Hyperliquid exchange. This endpoint provides essential information about all pending orders that have not yet been filled or canceled.
 
 <Check>

--- a/reference/hyperliquid-info-order-status.mdx
+++ b/reference/hyperliquid-info-order-status.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_order_status.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "orderStatus"` retrieves the current status and details of a specific order on the Hyperliquid exchange. This endpoint accepts either an order ID (oid) or client order ID (cloid) to query order information, making it essential for order tracking and management.

--- a/reference/hyperliquid-info-perpdeployauctionstatus.mdx
+++ b/reference/hyperliquid-info-perpdeployauctionstatus.mdx
@@ -3,6 +3,10 @@ title: perpDeployAuctionStatus | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_perpdeployauctionstatus.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 The `perpDeployAuctionStatus` call will return non-null when [HIP-3: Builder-Deployed Perpetuals](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-3-builder-deployed-perpetuals) goes live on the mainnet.
 </Note>

--- a/reference/hyperliquid-info-perpdexs.mdx
+++ b/reference/hyperliquid-info-perpdexs.mdx
@@ -3,6 +3,10 @@ title: perpDexs | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_perpdexs.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 <Note>
 The `perpDexs` call will return non-null when [HIP-3: Builder-Deployed Perpetuals](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-3-builder-deployed-perpetuals) goes live on the mainnet.
 </Note>

--- a/reference/hyperliquid-info-perps-at-open-interest-cap.mdx
+++ b/reference/hyperliquid-info-perps-at-open-interest-cap.mdx
@@ -3,6 +3,10 @@ title: perpsAtOpenInterestCap | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_perps_at_open_interest_cap.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "perpsAtOpenInterestCap"` retrieves a list of perpetual contracts that have reached their open interest cap on the Hyperliquid network. This endpoint is crucial for understanding market capacity constraints and identifying contracts with maximum position exposure.
 
 <Check>

--- a/reference/hyperliquid-info-portfolio.mdx
+++ b/reference/hyperliquid-info-portfolio.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_portfolio.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "portfolio"` retrieves comprehensive portfolio performance data for a specific user on the Hyperliquid exchange. This endpoint provides detailed historical performance metrics across multiple time periods, enabling thorough analysis of trading performance, account value progression, and volume activity.

--- a/reference/hyperliquid-info-predicted-fundings.mdx
+++ b/reference/hyperliquid-info-predicted-fundings.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_predicted_fundings.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "predictedFundings"` retrieves predicted funding rates for all perpetual contracts across different exchanges including Binance Perp, Hyperliquid Perp, and Bybit Perp. This endpoint provides comprehensive market data for cross-exchange arbitrage strategies, funding cost analysis, and market sentiment evaluation.

--- a/reference/hyperliquid-info-recent-trades.mdx
+++ b/reference/hyperliquid-info-recent-trades.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_recent_trades.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "recentTrades"` retrieves the most recent public trades for a specific asset on the Hyperliquid exchange. This endpoint provides real-time trade data including execution prices, quantities, and timing information, making it essential for market analysis, price discovery, and trading decision-making.

--- a/reference/hyperliquid-info-referral.mdx
+++ b/reference/hyperliquid-info-referral.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_referral.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "referral"` retrieves comprehensive referral information for a specific user on the Hyperliquid exchange. This endpoint provides detailed data about referral relationships, rewards, volume metrics, and referrer status, enabling thorough analysis of referral program participation and performance.

--- a/reference/hyperliquid-info-spot-meta-and-asset-ctxs.mdx
+++ b/reference/hyperliquid-info-spot-meta-and-asset-ctxs.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_spot_meta_and_asset_ctxs.json post /
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "spotMetaAndAssetCtxs"` retrieves comprehensive metadata and market contexts for all spot assets on the Hyperliquid exchange. This endpoint provides detailed information about token specifications, trading pairs, market prices, volumes, supply metrics, and EVM contract details for spot trading analysis and integration.

--- a/reference/hyperliquid-info-spotclearinghousestate.mdx
+++ b/reference/hyperliquid-info-spotclearinghousestate.mdx
@@ -3,6 +3,10 @@ title: spotClearinghouseState | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_spotclearinghousestate.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "spotClearinghouseState"` retrieves a user's token balances for spot trading on the Hyperliquid exchange. This endpoint provides detailed information about available balances, held amounts in open orders, and entry notional values for all spot tokens in the user's account.
 
 <Check>

--- a/reference/hyperliquid-info-spotdeploystate.mdx
+++ b/reference/hyperliquid-info-spotdeploystate.mdx
@@ -3,6 +3,10 @@ title: spotDeployState | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_spotdeploystate.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "spotDeployState"` returns the Spot Deploy Auction state. It exposes per‑token genesis state and the current gas auction parameters used for spot token deployment.
 
 <Check>

--- a/reference/hyperliquid-info-spotmeta.mdx
+++ b/reference/hyperliquid-info-spotmeta.mdx
@@ -3,6 +3,10 @@ title: spotMeta | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_spotmeta.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "spotMeta"` retrieves spot metadata including tokens and universe for the Hyperliquid exchange. This endpoint provides essential information about available spot tokens, their specifications, and trading pairs.
 
 <Check>

--- a/reference/hyperliquid-info-subaccounts.mdx
+++ b/reference/hyperliquid-info-subaccounts.mdx
@@ -3,6 +3,10 @@ title: subAccounts | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_subaccounts.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "subAccounts"` retrieves information about all sub-accounts associated with a master account on the Hyperliquid exchange. This endpoint provides comprehensive data about sub-account configurations, balances, positions, and trading activity for advanced account management and portfolio segregation.
 
 <Check>

--- a/reference/hyperliquid-info-token-details.mdx
+++ b/reference/hyperliquid-info-token-details.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_token_details.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "tokenDetails"` retrieves comprehensive information about a specific token on the Hyperliquid exchange. This endpoint provides detailed supply metrics, pricing data, deployment information, and circulation details for in-depth token analysis and portfolio management.

--- a/reference/hyperliquid-info-user-fills-by-time.mdx
+++ b/reference/hyperliquid-info-user-fills-by-time.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_user_fills_by_time.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "userFillsByTime"` retrieves a user's trading fills (executed orders) within a specific time range on the Hyperliquid exchange. This endpoint provides time-filtered access to detailed trade execution data, making it ideal for historical analysis and reporting.

--- a/reference/hyperliquid-info-user-fills.mdx
+++ b/reference/hyperliquid-info-user-fills.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_user_fills.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "userFills"` retrieves a user's trading fills (executed orders) on the Hyperliquid exchange. This endpoint returns detailed information about completed trades, including prices, sizes, fees, and profit/loss data for both perpetual and spot markets.

--- a/reference/hyperliquid-info-user-funding.mdx
+++ b/reference/hyperliquid-info-user-funding.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_user_funding.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "userFunding"` retrieves the funding history for a specific user account on the Hyperliquid exchange. This endpoint provides detailed information about funding payments and receipts across all perpetual positions over time, allowing users to track their funding costs and analyze trading performance.

--- a/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
+++ b/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_user_non_funding_ledger_updates.json
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "userNonFundingLedgerUpdates"` retrieves comprehensive ledger updates for a specific user account on the Hyperliquid exchange, excluding funding payments. This endpoint provides detailed information about all account activities including deposits, withdrawals, transfers, liquidations, spot trading, and other balance-affecting operations.

--- a/reference/hyperliquid-info-user-role.mdx
+++ b/reference/hyperliquid-info-user-role.mdx
@@ -3,6 +3,10 @@ title: userRole | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_user_role.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "userRole"` retrieves the role and account type information for a specific user on the Hyperliquid network. This endpoint is essential for understanding the account structure, permissions, and relationships within the Hyperliquid ecosystem.
 
 <Check>

--- a/reference/hyperliquid-info-user-to-multi-sig-signers.mdx
+++ b/reference/hyperliquid-info-user-to-multi-sig-signers.mdx
@@ -3,6 +3,10 @@ title: userToMultiSigSigners | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_user_to_multi_sig_signers.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "userToMultiSigSigners"` retrieves the list of multi-signature signers associated with a specific user on the Hyperliquid network. This endpoint is essential for understanding the multi-signature setup and authorized signers for a user's account.
 
 <Check>

--- a/reference/hyperliquid-info-user-twap-slice-fills.mdx
+++ b/reference/hyperliquid-info-user-twap-slice-fills.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_user_twap_slice_fills.json post /inf
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "userTwapSliceFills"` retrieves a user's TWAP (Time-Weighted Average Price) slice fills on the Hyperliquid exchange. This endpoint provides detailed information about individual fill executions that result from TWAP order slicing, enabling analysis of TWAP execution quality and performance.

--- a/reference/hyperliquid-info-userfees.mdx
+++ b/reference/hyperliquid-info-userfees.mdx
@@ -3,6 +3,10 @@ title: userFees | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_userfees.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "userFees"` retrieves detailed information about a user's fee structure and trading costs on the Hyperliquid exchange. This endpoint provides comprehensive fee information including base rates, VIP tiers, discounts, and effective rates after all reductions are applied.
 
 <Check>

--- a/reference/hyperliquid-info-userratelimit.mdx
+++ b/reference/hyperliquid-info-userratelimit.mdx
@@ -3,6 +3,10 @@ title: userRateLimit | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_userratelimit.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "userRateLimit"` retrieves detailed information about a user's API rate limit configuration and current usage on the Hyperliquid exchange. This endpoint provides essential information for managing API usage, avoiding rate limiting, and optimizing request patterns for high-frequency applications.
 
 <Check>

--- a/reference/hyperliquid-info-uservaultequities.mdx
+++ b/reference/hyperliquid-info-uservaultequities.mdx
@@ -3,6 +3,10 @@ title: userVaultEquities | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_uservaultequities.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "userVaultEquities"` retrieves detailed information about a user's equity positions across all vaults they have invested in on the Hyperliquid exchange. This endpoint provides comprehensive investment tracking including current values, profit/loss metrics, and withdrawal details for each vault position.
 
 <Check>

--- a/reference/hyperliquid-info-validator-l1-votes.mdx
+++ b/reference/hyperliquid-info-validator-l1-votes.mdx
@@ -3,6 +3,10 @@ title: validatorL1Votes | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_validator_l1_votes.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "validatorL1Votes"` retrieves information about validator participation in L1 governance voting on the Hyperliquid network. This endpoint provides data about validator voting behavior, consensus participation, and governance engagement.
 
 <Check>

--- a/reference/hyperliquid-info-vault-details.mdx
+++ b/reference/hyperliquid-info-vault-details.mdx
@@ -4,7 +4,7 @@ openapi: /openapi/hyperliquid_node_api/info_vault_details.json post /info
 ---
 
 <Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet.
+You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
 The `info` endpoint with `type: "vaultDetails"` retrieves comprehensive information about a specific vault on the Hyperliquid exchange. This endpoint provides detailed vault metrics including portfolio performance, follower information, leader details, and vault configuration settings, enabling thorough analysis of vault operations and performance.

--- a/reference/hyperliquid-info-vaultsummaries.mdx
+++ b/reference/hyperliquid-info-vaultsummaries.mdx
@@ -3,6 +3,10 @@ title: vaultSummaries | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_vaultsummaries.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "vaultSummaries"` retrieves summary information for all available vaults on the Hyperliquid exchange. This endpoint provides vault metadata including names, addresses, TVL, and relationship information for all vaults in the system.
 
 <Check>

--- a/reference/hyperliquid-info-web-data2.mdx
+++ b/reference/hyperliquid-info-web-data2.mdx
@@ -3,6 +3,10 @@ title: webData2 | Hyperliquid info
 openapi: /openapi/hyperliquid_node_api/info_web_data2.json post /4f8d8f4040bdacd1577bff8058438274/info
 ---
 
+<Info>
+This method is available on Chainstack. Not all Hyperliquid methods are available — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+</Info>
+
 The `info` endpoint with `type: "webData2"` returns aggregate information about a user for frontend consumption. It is primarily a convenience aggregation used by web clients.
 
 <Check>


### PR DESCRIPTION
## Summary

- Every Hyperliquid method reference page now explicitly states whether the endpoint is available through Chainstack or only on the official Hyperliquid public API
- All pages cross-link to [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability table
- Fixes confusion reported by sales leads who assumed all documented methods were available through Chainstack nodes

## Changes

| Change | Pages |
|---|---|
| Added "available on Chainstack" note (82 EVM + 28 Info) | 110 |
| Added "public API only" note (12 Exchange + `gossipRootIps`) | 13 |
| Updated existing "public API only" note with cross-link | 22 |
| **Total files touched** | **145** |

## Notes on the two callout variants

**Chainstack-available pages:**
> This method is available on Chainstack. Not all Hyperliquid methods are available — see Hyperliquid methods for the full availability breakdown.

**Public-only pages:**
> You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See Hyperliquid methods for the full availability breakdown.

## Test plan

- [ ] Verify Mintlify renders the `<Info>` callouts correctly on a few sample pages
- [ ] Confirm the cross-link to `/docs/hyperliquid-methods` resolves properly
- [ ] Spot-check one page from each category (EVM, Info Chainstack, Info public, Exchange)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation across EVM, Exchange, and Info endpoints to clarify method availability on Chainstack and official Hyperliquid API
  * Added informational notes indicating which endpoints are supported on each platform
  * Added cross-references to Hyperliquid methods documentation for complete availability breakdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->