### PR TITLE
Document archive state methods and RU billing

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -26,10 +26,28 @@ These rules apply consistently unless noted below for specific protocols.
 - Archive state requests (historical state at a past block): 2 RUs.
 - Debug and trace APIs: 2 RUs per call (require archive state).
 
-Examples of archive‑state usage on EVMs:
+### Archive state methods
 
-- `debug_*` and `trace_*` methods, including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block`.
-- State at historical blocks (for example, `eth_getStorageAt` or `eth_getProof` when querying past blocks).
+These methods are billed at 2 RUs when called against a block older than ~128 blocks from the tip:
+
+- `eth_getBalance`
+- `eth_getCode`
+- `eth_getTransactionCount`
+- `eth_getStorageAt`
+- `eth_call`
+- `eth_getProof`
+- `eth_callMany`
+- `eth_createAccessList`
+
+Calls targeting `latest`, `pending`, or a recent block within the ~128-block window are billed at 1 RU.
+
+<Note>
+The exact threshold may vary slightly by network but is approximately 128 blocks for most EVM networks on Chainstack.
+</Note>
+
+### Debug and trace methods
+
+All `debug_*` and `trace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block` — are billed at 2 RUs per call, as they require archive state.
 
 For debug and trace capabilities by protocol, see [debug & trace APIs](/docs/debug-and-trace-apis).
 

--- a/reference/arbitrum-ethcall.mdx
+++ b/reference/arbitrum-ethcall.mdx
@@ -11,6 +11,10 @@ Arbitrum API method that enables instant execution of a new message call without
 The interactive example in this page uses `eth_call` to call the `owner` method from the [Uniswap V3: Factory smart contract on Arbitrum](https://arbiscan.io/address/0x1F98431c8aD98523631AE4a59f267346ea31F984#code). It returns the address owning the smart contract.
 </Note>
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/arbitrum-getbalance.mdx
+++ b/reference/arbitrum-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/arbitrum_node_api/accounts_info/eth_getBalance.json POST /5b8d
 
 Arbitrum API method that returns the balance of a specific Arbitrum account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of an Arbitrum account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/arbitrum-getcode.mdx
+++ b/reference/arbitrum-getcode.mdx
@@ -7,6 +7,10 @@ Arbitrum API method that retrieves the compiled bytecode of a smart contract pro
 
 Developers can use this bytecode to verify if a smart contract is legitimate and to ensure that it performs the intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/arbitrum-getstorageat.mdx
+++ b/reference/arbitrum-getstorageat.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/arbitrum_node_api/accounts_info/eth_getStorageAt.json POST /5b
 Arbitrum API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/arbitrum-gettransactioncount.mdx
+++ b/reference/arbitrum-gettransactioncount.mdx
@@ -6,6 +6,10 @@ openapi: /openapi/arbitrum_node_api/accounts_info/eth_getTransactionCount.json P
 
 Arbitrum API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`. It is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/aurora-ethcall.mdx
+++ b/reference/aurora-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/aurora_node_api/eth_call.json POST /6df1a1b3061097e66349993a96
 
 Aurora API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/aurora-getbalance.mdx
+++ b/reference/aurora-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/aurora_node_api/eth_getBalance.json POST /6df1a1b3061097e66349
 
 Aurora API method that returns the balance of a specific account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Fantom account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/aurora-getcode.mdx
+++ b/reference/aurora-getcode.mdx
@@ -7,6 +7,10 @@ Aurora API method that retrieves the compiled bytecode of a smart contract, prov
 
 Developers can use this bytecode to verify whether a smart contract is legitimate and ensure that it performs its intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/aurora-getstorageat.mdx
+++ b/reference/aurora-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/aurora_node_api/eth_getStorageAt.json POST /6df1a1b3061097e663
 
 Aurora API method that returns the data stored at a specific storage slot within a smart contract. It can help developers read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/aurora-gettransactioncount.mdx
+++ b/reference/aurora-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/aurora_node_api/eth_getTransactionCount.json POST /6df1a1b3061
 
 Aurora API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/avalanche-ethcall.mdx
+++ b/reference/avalanche-ethcall.mdx
@@ -11,6 +11,10 @@ Avalanche API method that enables instant execution of a new message call withou
 The interactive example on this page uses `eth_call` to call the `poolLength` method from [Trader Joe: Master Chef Joe V2 smart contract on Avalanche](https://snowtrace.io/address/0xd6a4F121CA35509aF06A0Be99093d08462f53052#code). It returns how many liquidity pools are available on the Trader Joe exchange.
 </Note>
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/avalanche-getbalance.mdx
+++ b/reference/avalanche-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/avalanche_node_api/accounts_info/eth_getBalance.json POST /876
 
 Avalanche API method that returns the balance of a specific Avalanche account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of an Avalanche account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/avalanche-getcode.mdx
+++ b/reference/avalanche-getcode.mdx
@@ -7,6 +7,10 @@ Avalanche API method that retrieves the compiled bytecode of a smart contract pr
 
 Developers can use this bytecode to verify if a smart contract is legitimate and to ensure that it performs the intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/avalanche-getstorageat.mdx
+++ b/reference/avalanche-getstorageat.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/avalanche_node_api/accounts_info/eth_getStorageAt.json POST /8
 Avalanche API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/avalanche-gettransactioncount.mdx
+++ b/reference/avalanche-gettransactioncount.mdx
@@ -6,6 +6,10 @@ openapi: /openapi/avalanche_node_api/accounts_info/eth_getTransactionCount.json 
 
 Avalanche API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-callmany.mdx
+++ b/reference/base-callmany.mdx
@@ -7,6 +7,10 @@ Base API method `eth_callMany` executes a list of transaction bundles without cr
 
 This examples simulates the transfer of 100 USDC to an address in block 12279785 at transaction position 1 in the block and does the balance check of the address for the USDT, all in one call.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-getbalance.mdx
+++ b/reference/base-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/base_node_api/eth_getBalance.json POST /2fc1de7f08c0465f6a28e3
 
 Base API method `eth_getBalance` retrieves the balance of an account at a given block. This method is essential for applications that need to display or utilize the current balance of an Ethereum address.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-getcode.mdx
+++ b/reference/base-getcode.mdx
@@ -7,6 +7,10 @@ Base API method `eth_getCode` retrieves the code stored at a specific address. T
 
 This example retrieves the bytecode of the [USDC token](https://basescan.org/address/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913) on the Base Mainnet.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-getproof.mdx
+++ b/reference/base-getproof.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/base_node_api/eth_getProof.json POST /2fc1de7f08c0465f6a28e3c3
 
 Base API method `eth_getProof` retrieves the account and storage values of the specified account, including the Merkle-proof. This method is used to verify the data without needing the entire state on the client side.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-getstorageat.mdx
+++ b/reference/base-getstorageat.mdx
@@ -7,6 +7,10 @@ Base API method `eth_getStorageAt` retrieves the value from a specific storage p
 
 This example makes a call to slot 7 of the [USDC contract](https://basescan.org/address/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913) on the Base Mainnet.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/base-gettransactioncount.mdx
+++ b/reference/base-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/base_node_api/eth_getTransactionCount.json POST /2fc1de7f08c04
 
 Base API method `eth_getTransactionCount` retrieves the number of transactions sent from a specified address, often used to determine the nonce for the next transaction from that address.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/bnb-ethcall.mdx
+++ b/reference/bnb-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/bnb_node_api/eth_call.json POST /35848e183f3e3303c8cfeacbea831
 
 BNB API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/bnb-getbalance.mdx
+++ b/reference/bnb-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/bnb_node_api/eth_getBalance.json POST /35848e183f3e3303c8cfeac
 
 BNB API method that returns the balance of a specific Ethereum account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a BNB account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/bnb-getcode.mdx
+++ b/reference/bnb-getcode.mdx
@@ -7,6 +7,10 @@ BNB API method that retrieves the compiled bytecode of a smart contract, providi
 
 Developers can use this bytecode to verify whether a smart contract is legitimate and ensure that it performs its intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/bnb-getproof.mdx
+++ b/reference/bnb-getproof.mdx
@@ -6,7 +6,7 @@ openapi: "/openapi/bnb_node_api/eth_getProof.json POST /35848e183f3e3303c8cfeacb
 BNB API method that returns a Merkle proof for a specific account, contract storage, or both for a given block. Merkle proofs enable users to verify the existence and authenticity of data within a Merkle trie, a data structure that helps optimize and secure data retrieval in blockchains.
 
 <Note>
-  eth_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Warning>

--- a/reference/bnb-getstorageat.mdx
+++ b/reference/bnb-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/bnb_node_api/eth_getStorageAt.json POST /35848e183f3e3303c8cfe
 
 BNB API method that returns the data stored at a specific storage slot within a smart contract. It can help developers read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/bnb-gettransactioncount.mdx
+++ b/reference/bnb-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/bnb_node_api/eth_getTransactionCount.json POST /35848e183f3e33
 
 BNB API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/cronos-ethcall.mdx
+++ b/reference/cronos-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/cronos_node_api/eth_call.json POST /b9b0fb92029d58b396139a9e89
 
 Cronos API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/cronos-getbalance.mdx
+++ b/reference/cronos-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/cronos_node_api/eth_getBalance.json POST /b9b0fb92029d58b39613
 
 Cronos API method that returns the balance of a specific account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Fantom account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/cronos-getcode.mdx
+++ b/reference/cronos-getcode.mdx
@@ -7,6 +7,10 @@ Cronos API method that retrieves the compiled bytecode of a smart contract, prov
 
 Developers can use this bytecode to verify whether a smart contract is legitimate and ensure that it performs its intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/cronos-getproof.mdx
+++ b/reference/cronos-getproof.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/cronos_node_api/eth_getProof.json POST /b9b0fb92029d58b396139a
 Cronos API method that returns a Merkle proof for a specific account, contract storage, or both for a given block. Merkle proofs enable users to verify the existence and authenticity of data within a Merkle trie, a data structure that helps optimize and secure data retrieval in blockchains.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/cronos-getstorageat.mdx
+++ b/reference/cronos-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/cronos_node_api/eth_getStorageAt.json POST /b9b0fb92029d58b396
 
 Cronos API method that returns the data stored at a specific storage slot within a smart contract. It can help developers read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/cronos-gettransactioncount.mdx
+++ b/reference/cronos-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/cronos_node_api/eth_getTransactionCount.json POST /b9b0fb92029
 
 Cronos API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethcall.mdx
+++ b/reference/ethcall.mdx
@@ -11,6 +11,10 @@ Polygon API method that enables instant execution of a new message call without 
 The interactive example in this page uses `eth_call` to call the `lpToken` method from [SushiSwap MiniChefV2 smart contract on Polygon](https://polygonscan.com/address/0x0769fd68dfb93167989c6f7254cd0d766fb2841f#code). It returns the address of the liquidity pool at the index specified in the data. In this case, the input is 1, and it returns the [current address for the USDC-WETH pool for SushiSwap](https://polygonscan.com/address/0x34965ba0ac2451a34a0471f04cca3f990b8dea27) on Polygon.
 </Note>
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethereum-ethcall.mdx
+++ b/reference/ethereum-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ethereum_node_api/execute_transactions/eth_call.json POST /0a9
 
 Ethereum API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethereum-getbalance.mdx
+++ b/reference/ethereum-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ethereum_node_api/accounts_info/eth_getBalance.json POST /0a9d
 
 Ethereum API method that returns the balance of a specific Ethereum account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of an Ethereum account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethereum-getcode.mdx
+++ b/reference/ethereum-getcode.mdx
@@ -7,6 +7,10 @@ Ethereum API method that retrieves the compiled bytecode of a smart contract pro
 
 Developers can use this bytecode to verify if a smart contract is legitimate and to ensure that it performs the intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethereum-getstorageat.mdx
+++ b/reference/ethereum-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ethereum_node_api/accounts_info/eth_getStorageAt.json POST /0a
 
 Ethereum API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ethereum-gettransactioncount.mdx
+++ b/reference/ethereum-gettransactioncount.mdx
@@ -6,6 +6,10 @@ openapi: /openapi/ethereum_node_api/accounts_info/eth_getTransactionCount.json P
 
 Ethereum API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/fantom-ethcall.mdx
+++ b/reference/fantom-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/fantom_node_api/eth_call.json POST /4ab982aa70a7baead515ffdb59
 
 Fantom API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/fantom-getbalance.mdx
+++ b/reference/fantom-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/fantom_node_api/eth_getBalance.json POST /4ab982aa70a7baead515
 
 Fantom API method that returns the balance of a specific account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Fantom account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/fantom-getproof.mdx
+++ b/reference/fantom-getproof.mdx
@@ -6,6 +6,10 @@ openapi: /openapi/fantom_node_api/eth_getProof.json POST /4ab982aa70a7baead515ff
 Fantom API method that returns a Merkle proof for a specific account, contract storage, or both for a given block. Merkle proofs enable users to verify the existence and authenticity of data within a Merkle trie, a data structure that helps optimize and secure data retrieval in blockchains.
 
 <Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
+<Note>
 **No longer supported**
 
 The Sonic node client no longer supports `eth_getProof` for the Fantom chain. [See GitHub Issue](https://github.com/Fantom-foundation/Sonic/issues/379).

--- a/reference/fantom-getstorageat.mdx
+++ b/reference/fantom-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/fantom_node_api/eth_getStorageAt.json POST /4ab982aa70a7baead5
 
 Fantom API method that returns the data stored at a specific storage slot within a smart contract. It can help developers read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/fantom-gettransactioncount.mdx
+++ b/reference/fantom-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/fantom_node_api/eth_getTransactionCount.json POST /4ab982aa70a
 
 Fantom API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/getbalance.mdx
+++ b/reference/getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/polygon_node_api/account_info/eth_getBalance.json POST /a9bca2
 
 Polygon API method that returns the balance of a specific Polygon account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Polygon account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/getcode.mdx
+++ b/reference/getcode.mdx
@@ -7,6 +7,10 @@ Polygon API method that retrieves the compiled bytecode of a smart contract prov
 
 Developers can use this bytecode to verify if a smart contract is legitimate and to ensure that it performs the intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/getproof.mdx
+++ b/reference/getproof.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/ethereum_node_api/accounts_info/eth_getProof.json POST /0a9d79
 Ethereum API method that returns a Merkle proof for a specific account, contract storage, or both for a given block. Merkle proofs enable users to verify the existence and authenticity of data within a Merkle trie, a data structure that helps in optimizing and securing data retrieval in blockchains.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/getstorageat.mdx
+++ b/reference/getstorageat.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/polygon_node_api/account_info/eth_getStorageAt.json POST /a9bc
 Polygon API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/gettransactioncount.mdx
+++ b/reference/gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/polygon_node_api/account_info/eth_getTransactionCount.json POS
 
 Polygon API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/gnosis-ethcall.mdx
+++ b/reference/gnosis-ethcall.mdx
@@ -11,6 +11,10 @@ Gnosis Chain API method that enables instant execution of a new message call wit
 The interactive example in this page uses `eth_call` to call the `lpToken` method from [SushiSwap MiniChefV2 smart contract on Gnosis Chain](https://gnosisscan.io/address/0xdDCbf776dF3dE60163066A5ddDF2277cB445E0F3#readContract). It returns the address of the liquidity pool at the index specified in the data. In this case, the input is 1, and it returns the [current address for the WETH-WBTC pool for SushiSwap](https://gnosisscan.io/address/0xe21F631f47bFB2bC53ED134E83B8cff00e0EC054) on Gnosis Chain.
 </Note>
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/gnosis-getbalance.mdx
+++ b/reference/gnosis-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/gnosis_node_api/accounts_info/eth_getBalance.json POST /512e72
 
 Gnosis Chain API method that returns the balance of a specific Gnosis Chain account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a Gnosis Chain account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/gnosis-getcode.mdx
+++ b/reference/gnosis-getcode.mdx
@@ -7,6 +7,10 @@ Gnosis Chain API method that retrieves the compiled bytecode of a smart contract
 
 Developers can use this bytecode to verify if a smart contract is legitimate and to ensure that it performs the intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/gnosis-getstorageat.mdx
+++ b/reference/gnosis-getstorageat.mdx
@@ -6,7 +6,7 @@ openapi: /openapi/gnosis_node_api/accounts_info/eth_getStorageAt.json POST /512e
 Gnosis Chain API method that returns the data stored at a specific storage slot within a smart contract. It can help developers to read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
 <Note>
-eth\_getProof requires an archive node.
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
 </Note>
 
 <Check>

--- a/reference/gnosis-gettransactioncount.mdx
+++ b/reference/gnosis-gettransactioncount.mdx
@@ -6,6 +6,10 @@ openapi: /openapi/gnosis_node_api/accounts_info/eth_getTransactionCount.json POS
 
 Gnosis Chain API method that returns the number of transactions sent from an address at the selected block. This value is also called `nonce`; it is an important piece of information, especially to ensure that a transaction is not sent twice.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-createaccesslist.mdx
+++ b/reference/monad-createaccesslist.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/monad_node_api/execute_transactions/eth_createAccessList.json 
 
 Monad API method that creates an EIP-2930 access list for a transaction. This method returns a list of addresses and storage keys that the transaction will access, which can be used to reduce gas costs for subsequent executions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-ethcall.mdx
+++ b/reference/monad-ethcall.mdx
@@ -11,6 +11,10 @@ Monad API method that executes a new message call immediately without creating a
 - Does not accept EIP-4844 (blob) transaction type, as EIP-4844 is not supported on Monad.
 </Note>
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-getbalance.mdx
+++ b/reference/monad-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/monad_node_api/accounts_info/eth_getBalance.json POST /
 
 Monad API method that returns the balance of the account at the given address. The balance is returned in wei, the smallest unit of MON.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-getcode.mdx
+++ b/reference/monad-getcode.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/monad_node_api/accounts_info/eth_getCode.json POST /
 
 Monad API method that returns the code at a given address. This is used to check if an address is a smart contract and retrieve its bytecode.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-getstorageat.mdx
+++ b/reference/monad-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/monad_node_api/accounts_info/eth_getStorageAt.json POST /
 
 Monad API method that returns the value from a storage position at a given address. This method allows you to read the raw storage of smart contracts, which is useful for debugging and analyzing contract state.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/monad-gettransactioncount.mdx
+++ b/reference/monad-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/monad_node_api/accounts_info/eth_getTransactionCount.json POST
 
 Monad API method that returns the number of transactions sent from an address. This is also known as the account nonce, which is used to prevent transaction replay and ensure proper transaction ordering.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-callmany.mdx
+++ b/reference/optimism-callmany.mdx
@@ -7,6 +7,10 @@ Optimism API method `eth_callMany` executes a list of transaction bundles withou
 
 This examples simulates the transfer of 100 USDT to an address in block 116318465 at transaction position 1 in the block and does the balance check of the address for the USDT, all in one call.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-createaccesslist.mdx
+++ b/reference/optimism-createaccesslist.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/optimism_node_api/eth_createAccessList.json POST /efb0a5eccd2c
 
 Optimism API method `eth_createAccessList` generates an access list for a transaction based on specific default values. An access list includes addresses and storage keys the transaction intends to access, facilitating more efficient gas usage.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-getbalance.mdx
+++ b/reference/optimism-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/optimism_node_api/eth_getBalance.json POST /efb0a5eccd2caa5135
 
 Optimism API method `eth_getBalance` retrieves the balance of an account at a given block. This method is essential for applications that need to display or utilize the current balance of an Ethereum address.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-getcode.mdx
+++ b/reference/optimism-getcode.mdx
@@ -7,6 +7,10 @@ Optimism API method `eth_getCode` retrieves the code stored at a specific addres
 
 This example retrieves the bytecode of the [Chainlink token](https://optimistic.etherscan.io/address/0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6) on the Optimism Mainnet.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-getproof.mdx
+++ b/reference/optimism-getproof.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/optimism_node_api/eth_getProof.json POST /efb0a5eccd2caa5135eb
 
 Optimism API method `eth_getProof` retrieves the account and storage values of the specified account, including the Merkle-proof. This method is used to verify the data without needing the entire state on the client side.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-getstorageat.mdx
+++ b/reference/optimism-getstorageat.mdx
@@ -7,6 +7,10 @@ Optimism API method `eth_getStorageAt` retrieves the value from a specific stora
 
 This example makes a call to slot 7 of the [USDC contract](https://optimistic.etherscan.io/token/0x0b2c639c533813f4aa9d7837caf62653d097ff85) on the Optimism Mainnet.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/optimism-gettransactioncount.mdx
+++ b/reference/optimism-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/optimism_node_api/eth_getTransactionCount.json POST /efb0a5ecc
 
 Optimism API method `eth_getTransactionCount` retrieves the number of transactions sent from a specified address, often used to determine the nonce for the next transaction from that address.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/plasma-eth-createaccesslist.mdx
+++ b/reference/plasma-eth-createaccesslist.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/plasma_node_api/execute_transactions/eth_createAccessList.json
 
 Plasma API method that creates an EIP-2930 access list for a transaction.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 ## Parameters
 
 * `object` — the transaction call object

--- a/reference/ronin-getbalance.mdx
+++ b/reference/ronin-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ronin_node_api/eth_getBalance.json POST /3997273fc956a67dc6982
 
 The `eth_getBalance` method returns the balance of the account of a given address, expressed in wei. This method provides a simple way to query the amount of Ether held by an address at a specific block height.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ronin-getcode.mdx
+++ b/reference/ronin-getcode.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ronin_node_api/eth_getCode.json POST /3997273fc956a67dc6982384
 
 The `eth_getCode` method returns the bytecode stored at a given address. This method is typically used to retrieve the bytecode of smart contracts deployed on the Ronin network.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ronin-getstorageat.mdx
+++ b/reference/ronin-getstorageat.mdx
@@ -7,6 +7,10 @@ This example makes a call to slot 0 of the [USDC contract](https://app.roninchai
 
 The `eth_getStorageAt` method returns the value stored at a specific position of the storage of a given address, expressed in hexadecimal. This method is useful for inspecting the state of smart contracts at specific storage slots.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/ronin-gettransactioncount.mdx
+++ b/reference/ronin-gettransactioncount.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/ronin_node_api/eth_getTransactionCount.json POST /3997273fc956
 
 The `eth_getTransactionCount` method returns the number of transactions sent from a specified address. This count includes the transaction index position in the block.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/zkevm-ethcall.mdx
+++ b/reference/zkevm-ethcall.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/polygon_zkevm_node_api/eth_call.json POST /942aad90bb6a0826764
 
 Polygon zkEVM API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain. This can be useful for testing and debugging by simulating transfers or smart contract transactions and retrieving data from the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/zkevm-getbalance.mdx
+++ b/reference/zkevm-getbalance.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/polygon_zkevm_node_api/eth_getBalance.json POST /942aad90bb6a0
 
 Polygon zkEVM API method that returns the balance of a specific account in [Wei](https://www.investopedia.com/terms/w/wei.asp), the smallest unit of ether. This method allows developers to retrieve the current balance of a zkEVM account for various purposes, such as checking available funds or displaying balance information.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/zkevm-getcode.mdx
+++ b/reference/zkevm-getcode.mdx
@@ -7,6 +7,10 @@ Polygon zkEVM API method that retrieves the compiled bytecode of a smart contrac
 
 Developers can use this bytecode to verify whether a smart contract is legitimate and ensure that it performs its intended functions.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 

--- a/reference/zkevm-getstorageat.mdx
+++ b/reference/zkevm-getstorageat.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/polygon_zkevm_node_api/eth_getStorageAt.json POST /942aad90bb6
 
 Polygon zkEVM API method that returns the data stored at a specific storage slot within a smart contract. It can help developers read a smart contract's internal state, like user data or balances, to inform decisions and build more advanced applications that interact with smart contracts on the blockchain.
 
+<Note>
+When called against a block older than the latest ~128 blocks, this method is treated as an archive request (2 RUs instead of 1 RU). See [request units](/docs/request-units#archive-state-methods).
+</Note>
+
 <Check>
 **Get you own node endpoint today**
 


### PR DESCRIPTION
## Summary

- Add "Archive state methods" section to `request-units.mdx` listing all 8 EVM methods that incur 2 RUs when targeting blocks older than ~128 from the tip
- Add `<Note>` block to 76 method reference files across all EVM chains explaining archive billing with link back to the RU docs
- Separate debug/trace methods into their own subsection in `request-units.mdx`
- Fix incorrect method name in `getstorageat` variants (referenced `eth_getProof` instead of `eth_getStorageAt`)

