### PR TITLE
Clean up dead platform API endpoints and restructure sidebar for v2

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3392,6 +3392,32 @@
               "reference/platform-api-getting-started",
               "reference/quick-tutorial",
               {
+                "group": "Deployment options",
+                "pages": [
+                  "reference/chainstack-platform-api-v2-list-deployment-options"
+                ]
+              },
+              {
+                "group": "Project v2",
+                "pages": [
+                  "reference/chainstack-platform-api-v2-list-all-projects",
+                  "reference/chainstack-platform-api-v2-create-project",
+                  "reference/chainstack-platform-api-v2-retrieve-project",
+                  "reference/chainstack-platform-api-v2-update-project",
+                  "reference/chainstack-platform-api-v2-delete-project"
+                ]
+              },
+              {
+                "group": "Node v2",
+                "pages": [
+                  "reference/chainstack-platform-api-v2-list-all-nodes",
+                  "reference/chainstack-platform-api-v2-create-node",
+                  "reference/chainstack-platform-api-v2-retrieve-node",
+                  "reference/chainstack-platform-api-v2-update-node",
+                  "reference/chainstack-platform-api-v2-delete-node"
+                ]
+              },
+              {
                 "group": "Organization",
                 "pages": [
                   "reference/chainstack-platform-api-get-organizaton-info",
@@ -3399,7 +3425,7 @@
                 ]
               },
               {
-                "group": "Project",
+                "group": "Project v1",
                 "pages": [
                   "reference/chainstack-platform-api-list-all-projects",
                   "reference/chainstack-platform-api-create-project",
@@ -3420,7 +3446,7 @@
                 ]
               },
               {
-                "group": "Node",
+                "group": "Node v1",
                 "pages": [
                   "reference/chainstack-platform-api-list-all-nodes",
                   "reference/chainstack-platform-api-create-node",
@@ -3430,15 +3456,8 @@
                 ]
               },
               {
-                "group": "Marketplace",
-                "pages": [
-                  "reference/chainstack-platform-api-retrieve-token"
-                ]
-              },
-              {
                 "group": "Faucet",
                 "pages": [
-                  "reference/faucetgoerli",
                   "reference/chainstack-platform-api-faucet-sepolia"
                 ]
               }

--- a/openapi/chainstack_platform.yml
+++ b/openapi/chainstack_platform.yml
@@ -6,7 +6,7 @@ info:
     backgroundColor: "#F5F8FC"
     altText: Chainstack
   title: "\U0001F499 CHAINSTACK PLATFORM API"
-  version: v1
+  version: v2
   contact:
     name: API Support
     email: support@chainstack.com
@@ -810,66 +810,6 @@ paths:
           description: No response body
         '404':
           "$ref": "#/components/responses/NotFoundError"
-  "/v1/marketplace/applications/{slug}/token/":
-    parameters:
-    - "$ref": "#/components/parameters/Slug"
-    post:
-      operationId: retrieveToken
-      summary: Retrieve Application Token
-      description: Retrieve a token required to access a third-party application from
-        Chainstack Marketplace.
-      tags:
-      - Marketplace
-      security:
-      - APIKeyAuthentication: []
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/AccessToken"
-              examples:
-                token:
-                  value:
-                    access_token: eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJSRy04MzctMzgwIiwiaXNzIjoiY2hhaW5zdGFjayIsImV4cCI6MTY3NTQzNjM0OSwibmJmIjoxNjc1NDMyNjg5LCJpYXQiOjE2NzU0MzI3NDl9.udMCKIV7y6XlNwfsvwwGm47R55yDdw9FeOR_Zb_14oVTi5ipPH3NPiJukB4mBR81aHfr1mIA2wtQM3jf7wDSAw
-        '404':
-          "$ref": "#/components/responses/NotFoundError"
-  "/v1/faucet/goerli":
-    post:
-      operationId: faucetGoerli
-      summary: Goerli Faucet
-      description: Request test tokens.
-      tags:
-      - Faucet
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/FaucetGoerliRequest"
-            examples:
-              value:
-                value:
-                  address: '0x1111111111111111111111111111111111111111'
-        required: true
-      security:
-      - APIKeyAuthentication: []
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/FaucetGoerliResponse"
-              examples:
-                value:
-                  value:
-                    amountSent: 500000000000000000
-                    transaction: https://goerli.etherscan.io/tx/0x1111111111111111111111111111111111111111111111111111111111111111
-        '400':
-          "$ref": "#/components/responses/ValidationError"
-        '429':
-          "$ref": "#/components/responses/TooManyRequestsError"
   "/v1/faucet/sepolia":
     post:
       operationId: sepoliaGoerli
@@ -905,6 +845,525 @@ paths:
           "$ref": "#/components/responses/ValidationError"
         '429':
           "$ref": "#/components/responses/TooManyRequestsError"
+  "/v2/deployment-options/":
+    get:
+      operationId: listDeploymentOptions
+      summary: List deployment options
+      description: |
+        List all available deployment options for your organization.
+        Returns the deployable nodes matrix filtered to shared node types on global clouds.
+        Each option includes the blockchain ID, cloud ID, protocol, network, and available features.
+      tags:
+      - Deployment Options
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeploymentOptionsResponse"
+              examples:
+                list:
+                  value:
+                    options:
+                    - blockchain: BC-000-000-008
+                      cloud: CC-0016
+                      region: us-east-1
+                      provider: aws
+                      protocol: ethereum
+                      network: ethereum-mainnet
+                      features:
+                      - full
+                    - blockchain: BC-000-000-017
+                      cloud: CC-0016
+                      region: us-east-1
+                      provider: aws
+                      protocol: ethereum
+                      network: ethereum-sepolia-testnet
+                      features:
+                      - full
+                    - blockchain: BC-000-000-015
+                      cloud: CC-0016
+                      region: us-east-1
+                      provider: aws
+                      protocol: solana
+                      network: solana-mainnet
+                      features:
+                      - full
+                    - blockchain: BC-000-000-006
+                      cloud: CC-0016
+                      region: us-east-1
+                      provider: aws
+                      protocol: bsc
+                      network: bsc-mainnet
+                      features:
+                      - full
+                    - blockchain: BC-000-000-010
+                      cloud: CC-0016
+                      region: us-east-1
+                      provider: aws
+                      protocol: polygon-pos
+                      network: polygon-pos-mainnet
+                      features:
+                      - full
+          description: ''
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+  "/v2/projects/":
+    get:
+      operationId: listAllProjectsV2
+      summary: List all projects
+      description: List all projects your organization is part of.
+      parameters:
+      - "$ref": "#/components/parameters/ProjectOrdering"
+      - "$ref": "#/components/parameters/Pagination"
+      - "$ref": "#/components/parameters/OrganizationIdFilter"
+      - "$ref": "#/components/parameters/NameFilter"
+      - "$ref": "#/components/parameters/ProjectTypeFilter"
+      tags:
+      - Project V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/Pagination"
+                - type: object
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/Project"
+              examples:
+                list:
+                  value:
+                    count: 1
+                    next:
+                    previous:
+                    results:
+                    - id: PR-123-456-789
+                      name: My project
+                      description: My project description
+                      type: public
+                      members: 0
+                      networks: 1
+                      creator:
+                        id: UR-111-111-111
+                        email: user@example.com
+                        first_name: John
+                        last_name: Smith
+                        organization:
+                          id: RG-123-456
+                          name: My organization
+                      created_at: '2023-01-01T00:00:00.000000Z'
+          description: ''
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+    post:
+      operationId: createProjectV2
+      summary: Create project
+      description: Create a project.
+      tags:
+      - Project V2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProjectCreate"
+            examples:
+              project:
+                value:
+                  name: My project
+                  description: My project description
+        required: true
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Project"
+              examples:
+                project:
+                  value:
+                    id: PR-123-456-789
+                    name: My project
+                    description: My project description
+                    type: public
+                    members: 0
+                    networks: 0
+                    creator:
+                      id: UR-111-111-111
+                      email: user@example.com
+                      first_name: John
+                      last_name: Smith
+                      organization:
+                        id: RG-123-456
+                        name: My organization
+                    created_at: '2023-01-01T00:00:00.000000Z'
+          description: ''
+        '400':
+          "$ref": "#/components/responses/ValidationError"
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+  "/v2/projects/{id}/":
+    parameters:
+    - "$ref": "#/components/parameters/Id"
+    get:
+      operationId: retrieveProjectV2
+      summary: Retrieve project
+      description: Retrieve the project details.
+      tags:
+      - Project V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Project"
+              examples:
+                project:
+                  value:
+                    id: PR-123-456-789
+                    name: My project
+                    description: My project description
+                    type: public
+                    members: 0
+                    networks: 1
+                    creator:
+                      id: UR-111-111-111
+                      email: user@example.com
+                      first_name: John
+                      last_name: Smith
+                      organization:
+                        id: RG-123-456
+                        name: My organization
+                    created_at: '2023-01-01T00:00:00.000000Z'
+          description: ''
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
+    patch:
+      operationId: updateProjectV2
+      summary: Update project
+      description: Change project name and project description.
+      tags:
+      - Project V2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProjectUpdate"
+            examples:
+              project:
+                value:
+                  name: My updated project
+                  description: Updated description
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Project"
+              examples:
+                project:
+                  value:
+                    id: PR-123-456-789
+                    name: My updated project
+                    description: Updated description
+                    type: public
+                    members: 0
+                    networks: 1
+                    creator:
+                      id: UR-111-111-111
+                      email: user@example.com
+                      first_name: John
+                      last_name: Smith
+                      organization:
+                        id: RG-123-456
+                        name: My organization
+                    created_at: '2023-01-01T00:00:00.000000Z'
+          description: ''
+        '400':
+          "$ref": "#/components/responses/ValidationError"
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
+    delete:
+      operationId: deleteProjectV2
+      summary: Delete project
+      description: Delete the project.
+      tags:
+      - Project V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '204':
+          description: No response body
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
+  "/v2/nodes/":
+    get:
+      operationId: listAllNodesV2
+      summary: List all nodes
+      description: List all nodes in the networks your organization is part of.
+      parameters:
+      - "$ref": "#/components/parameters/NodeOrdering"
+      - "$ref": "#/components/parameters/Pagination"
+      tags:
+      - Node V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/Pagination"
+                - type: object
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/NodeV2"
+              examples:
+                list:
+                  value:
+                    count: 1
+                    next:
+                    previous:
+                    results:
+                    - id: ND-123-456-789
+                      name: My Ethereum node
+                      network: mainnet
+                      protocol: ethereum
+                      project: PR-123-456-789
+                      cloud: CC-0001
+                      region: us-east-1
+                      provider: aws
+                      status: running
+                      details:
+                        api_namespaces:
+                        - net
+                        - eth
+                        - web3
+                        - txpool
+                        - debug
+                        https_endpoint: https://nd-123-456-789.p2pify.com
+                        wss_endpoint: wss://ws-nd-123-456-789.p2pify.com
+                        beacon_endpoint: https://beacon-nd-123-456-789.p2pify.com
+                        graphql_endpoint: https://nd-123-456-789.p2pify.com/graphql
+                      blockchain: BC-000-000
+          description: ''
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+    post:
+      operationId: createNodeV2
+      summary: Create node
+      description: Create a new node in the specified project and blockchain.
+      tags:
+      - Node V2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NodeCreateV2"
+            examples:
+              node:
+                value:
+                  name: My Ethereum node
+                  project: PR-123-456-789
+                  cloud: CC-0001
+                  blockchain: BC-000-000
+        required: true
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NodeV2"
+              examples:
+                node:
+                  value:
+                    id: ND-123-456-789
+                    name: My Ethereum node
+                    network: mainnet
+                    protocol: ethereum
+                    project: PR-123-456-789
+                    cloud: CC-0001
+                    region: us-east-1
+                    provider: aws
+                    status: running
+                    details:
+                      api_namespaces:
+                      - net
+                      - eth
+                      - web3
+                      - txpool
+                      - debug
+                      https_endpoint: https://nd-123-456-789.p2pify.com
+                      wss_endpoint: wss://ws-nd-123-456-789.p2pify.com
+                      beacon_endpoint: https://beacon-nd-123-456-789.p2pify.com
+                      graphql_endpoint: https://nd-123-456-789.p2pify.com/graphql
+                    blockchain: BC-000-000
+          description: ''
+        '400':
+          "$ref": "#/components/responses/ValidationError"
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+  "/v2/nodes/{id}/":
+    parameters:
+    - "$ref": "#/components/parameters/Id"
+    get:
+      operationId: retrieveNodeV2
+      summary: Retrieve node
+      description: Retrieve node details.
+      tags:
+      - Node V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NodeV2"
+              examples:
+                node:
+                  value:
+                    id: ND-123-456-789
+                    name: My Ethereum node
+                    network: mainnet
+                    protocol: ethereum
+                    project: PR-123-456-789
+                    cloud: CC-0001
+                    region: us-east-1
+                    provider: aws
+                    status: running
+                    details:
+                      api_namespaces:
+                      - net
+                      - eth
+                      - web3
+                      - txpool
+                      - debug
+                      https_endpoint: https://nd-123-456-789.p2pify.com
+                      wss_endpoint: wss://ws-nd-123-456-789.p2pify.com
+                      beacon_endpoint: https://beacon-nd-123-456-789.p2pify.com
+                      graphql_endpoint: https://nd-123-456-789.p2pify.com/graphql
+                    blockchain: BC-000-000
+          description: ''
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
+    patch:
+      operationId: updateNodeV2
+      summary: Update node
+      description: Change the node name.
+      tags:
+      - Node V2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/NodeUpdateV2"
+            examples:
+              node:
+                value:
+                  name: My new node name
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NodeV2"
+              examples:
+                node:
+                  value:
+                    id: ND-123-456-789
+                    name: My new node name
+                    network: mainnet
+                    protocol: ethereum
+                    project: PR-123-456-789
+                    cloud: CC-0001
+                    region: us-east-1
+                    provider: aws
+                    status: running
+                    details:
+                      api_namespaces:
+                      - net
+                      - eth
+                      - web3
+                      - txpool
+                      - debug
+                      https_endpoint: https://nd-123-456-789.p2pify.com
+                      wss_endpoint: wss://ws-nd-123-456-789.p2pify.com
+                      beacon_endpoint: https://beacon-nd-123-456-789.p2pify.com
+                      graphql_endpoint: https://nd-123-456-789.p2pify.com/graphql
+                    blockchain: BC-000-000
+          description: ''
+        '400':
+          "$ref": "#/components/responses/ValidationError"
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
+    delete:
+      operationId: deleteNodeV2
+      summary: Delete node
+      description: Delete the node.
+      tags:
+      - Node V2
+      security:
+      - APIKeyAuthentication: []
+      responses:
+        '204':
+          description: No response body
+        '401':
+          "$ref": "#/components/responses/UnauthorizedError"
+        '403':
+          "$ref": "#/components/responses/ForbiddenError"
+        '404':
+          "$ref": "#/components/responses/NotFoundError"
 components:
   securitySchemes:
     APIKeyAuthentication:
@@ -2218,30 +2677,6 @@ components:
             readOnly: true
           network:
             readOnly: true
-    AccessToken:
-      type: object
-      description: Token required to access an application from Chainstack Marketplace.
-      readOnly: true
-      properties:
-        access_token:
-          type: string
-          readOnly: true
-          description: Token required to access an application from Chainstack Marketplace.
-    FaucetGoerliRequest:
-      type: object
-      properties:
-        address:
-          type: string
-          description: Address to send tokens to.
-    FaucetGoerliResponse:
-      type: object
-      properties:
-        amountSent:
-          type: number
-          description: Amount sent.
-        transaction:
-          type: string
-          description: Transaction details URL.
     FaucetSepoliaRequest:
       type: object
       properties:
@@ -2257,6 +2692,144 @@ components:
         transaction:
           type: string
           description: Transaction details URL.
+    DeploymentOption:
+      type: object
+      description: A single deployable node option.
+      properties:
+        blockchain:
+          type: string
+          description: The unique identifier of the blockchain configuration.
+          example: BC-000-000-008
+        cloud:
+          type: string
+          description: The unique identifier of the cloud provider.
+          example: CC-0016
+        region:
+          type: string
+          description: Cloud region identifier.
+          example: us-east-1
+        provider:
+          type: string
+          description: Cloud provider name.
+          example: aws
+        protocol:
+          type: string
+          description: The blockchain protocol name.
+          example: ethereum
+        network:
+          type: string
+          description: The network name.
+          example: ethereum-mainnet
+        features:
+          type: array
+          description: List of available features for this deployment option.
+          items:
+            type: string
+          example:
+          - full
+      required:
+      - blockchain
+      - cloud
+      - region
+      - provider
+      - protocol
+      - network
+      - features
+    DeploymentOptionsResponse:
+      type: object
+      description: Response containing the list of available deployment options.
+      properties:
+        options:
+          type: array
+          description: List of available deployment options.
+          items:
+            "$ref": "#/components/schemas/DeploymentOption"
+      required:
+      - options
+    NodeV2:
+      type: object
+      required:
+      - id
+      - name
+      - network
+      - protocol
+      - project
+      - cloud
+      - region
+      - provider
+      - status
+      - details
+      - blockchain
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Name of the node.
+        network:
+          type: string
+          readOnly: true
+          description: Network name.
+        protocol:
+          type: string
+          readOnly: true
+          description: Protocol name.
+        project:
+          type: string
+          description: ID of the project.
+        cloud:
+          type: string
+          description: ID of the cloud.
+        region:
+          type: string
+          readOnly: true
+          description: Cloud region.
+        provider:
+          type: string
+          readOnly: true
+          description: Cloud provider.
+        status:
+          type: string
+          readOnly: true
+          description: Status of the node.
+        details:
+          type: object
+          readOnly: true
+          description: Protocol-specific attributes.
+        blockchain:
+          type: string
+          description: Blockchain identifier.
+          example: BC-000-000
+    NodeCreateV2:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the node.
+        project:
+          type: string
+          description: ID of the project.
+          example: PR-123-123
+        cloud:
+          type: string
+          description: ID of the cloud.
+          example: CC-0016
+        blockchain:
+          type: string
+          description: Blockchain identifier.
+          example: BC-000-000
+      required:
+      - name
+      - project
+      - cloud
+      - blockchain
+    NodeUpdateV2:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the node.
   responses:
     ValidationError:
       description: Validation error.
@@ -2281,6 +2854,38 @@ components:
                       items:
                         type: string
                     description: Optional. Field-level validation errors.
+    UnauthorizedError:
+      description: Authentication credentials were missing or incorrect.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    description: A string indicating the kind of error.
+                  message:
+                    type: string
+                    description: A human-readable description of the error.
+    ForbiddenError:
+      description: The request is not allowed with the current permissions.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    description: A string indicating the kind of error.
+                  message:
+                    type: string
+                    description: A human-readable description of the error.
     NotFoundError:
       description: Object does not exist or caller has insufficient permissions to
         access it.
@@ -2507,13 +3112,6 @@ components:
         and Tezos nodes by the archive mode flag.
       schema:
         type: boolean
-    Slug:
-      name: slug
-      in: path
-      required: true
-      description: A unique value identifying the marketplace application.
-      schema:
-        type: string
   examples:
     PublicProjectCreate:
       value:

--- a/reference/chainstack-platform-api-retrieve-token.mdx
+++ b/reference/chainstack-platform-api-retrieve-token.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v1/marketplace/applications/{slug}/token/
----

--- a/reference/chainstack-platform-api-v2-create-node.mdx
+++ b/reference/chainstack-platform-api-v2-create-node.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v2/nodes/
+---

--- a/reference/chainstack-platform-api-v2-create-project.mdx
+++ b/reference/chainstack-platform-api-v2-create-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v2/projects/
+---

--- a/reference/chainstack-platform-api-v2-delete-node.mdx
+++ b/reference/chainstack-platform-api-v2-delete-node.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v2/nodes/{id}/
+---

--- a/reference/chainstack-platform-api-v2-delete-project.mdx
+++ b/reference/chainstack-platform-api-v2-delete-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v2/projects/{id}/
+---

--- a/reference/chainstack-platform-api-v2-list-all-nodes.mdx
+++ b/reference/chainstack-platform-api-v2-list-all-nodes.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/nodes/
+---

--- a/reference/chainstack-platform-api-v2-list-all-projects.mdx
+++ b/reference/chainstack-platform-api-v2-list-all-projects.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/projects/
+---

--- a/reference/chainstack-platform-api-v2-list-deployment-options.mdx
+++ b/reference/chainstack-platform-api-v2-list-deployment-options.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/deployment-options/
+---

--- a/reference/chainstack-platform-api-v2-retrieve-node.mdx
+++ b/reference/chainstack-platform-api-v2-retrieve-node.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/nodes/{id}/
+---

--- a/reference/chainstack-platform-api-v2-retrieve-project.mdx
+++ b/reference/chainstack-platform-api-v2-retrieve-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/projects/{id}/
+---

--- a/reference/chainstack-platform-api-v2-update-node.mdx
+++ b/reference/chainstack-platform-api-v2-update-node.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v2/nodes/{id}/
+---

--- a/reference/chainstack-platform-api-v2-update-project.mdx
+++ b/reference/chainstack-platform-api-v2-update-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /v2/projects/{id}/
+---

--- a/reference/faucetgoerli.mdx
+++ b/reference/faucetgoerli.mdx
@@ -1,3 +1,0 @@
----
-openapi: post /v1/faucet/goerli
----

--- a/reference/platform-api-getting-started.mdx
+++ b/reference/platform-api-getting-started.mdx
@@ -2,17 +2,12 @@
 title: "Getting started"
 ---
 
-<Info>
-  [Download the OpenAPI yaml schema file](https://raw.githubusercontent.com/chainstack/dev-portal/refs/heads/main/openapi/chainstack_platform.yml).
-</Info>
+The Chainstack platform API allows you to manage your infrastructure programmatically.
 
-The Chainstack platform API allows you to interact with:
+The API has two versions:
 
-* Your organization
-* Your projects
-* Your networks
-* Your nodes
-* Your identities
+* **v2 (recommended)** — manage deployment options, projects, and nodes.
+* **v1** — manage organizations, projects, networks, nodes, and faucets.
 
 ## Create API key
 

--- a/reference/quick-tutorial.mdx
+++ b/reference/quick-tutorial.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quick tutorial"
-description: "This tutorial will walk you through creating a consortium network through the Chainstack API."
+description: "This tutorial walks you through deploying a node using the Chainstack platform API v2."
 ---
 
 ## Overview
 
-To get from zero to a running consortium network through the Chainstack API, do the following:
+To get from zero to a running node through the Chainstack API, do the following:
 
 <Steps>
 <Step>
@@ -15,13 +15,13 @@ Get your API key.
 Export your API variables.
 </Step>
 <Step>
+Get deployment options.
+</Step>
+<Step>
 Create a project.
 </Step>
 <Step>
-Create a network.
-</Step>
-<Step>
-Add a node to the network.
+Create a node.
 </Step>
 <Step>
 Get the node access and credentials.
@@ -40,12 +40,44 @@ To save time when interacting with the API, export your API variables:
 
 <CodeGroup>
   ```sh Shell
-  export APIURL="https://api.chainstack.com/v1"
+  export APIURL="https://api.chainstack.com/v2"
   export APIKEY="YOUR_CHAINSTACK_API_KEY"
   export HDR_AUTH="Authorization: Bearer $APIKEY"
   export HDR_CT="Content-Type: application/json"
   ```
 </CodeGroup>
+
+### Get deployment options
+
+The v2 API uses opaque identifiers for blockchains and clouds. To find the right `blockchain` and `cloud` values for your node, list the available deployment options:
+
+<CodeGroup>
+  ```curl cURL
+  curl -X GET "$APIURL/deployment-options/" --header "$HDR_AUTH"
+  ```
+</CodeGroup>
+
+Each option in the response includes the human-readable `protocol`, `network`, `provider`, and `region` alongside the identifiers you need:
+
+```json
+{
+  "options": [
+    {
+      "blockchain": "BC-000-000-008",
+      "cloud": "CC-0016",
+      "region": "us-east-1",
+      "provider": "aws",
+      "protocol": "ethereum",
+      "network": "ethereum-mainnet",
+      "features": ["full"]
+    }
+  ]
+}
+```
+
+Find the option matching your desired protocol, network, and region, then use its `blockchain` and `cloud` values when creating a node.
+
+See also API reference: [List deployment options](/reference/chainstack-platform-api-v2-list-deployment-options).
 
 ### Create a project
 
@@ -55,110 +87,32 @@ To save time when interacting with the API, export your API variables:
   ```
 </CodeGroup>
 
-See also API reference: [Create Project](/reference/chainstack-platform-api-create-project).
+See also API reference: [Create project](/reference/chainstack-platform-api-v2-create-project).
 
-### Create a network
-
-You create a network with one peer node and service nodes.
-
-The service nodes are created automatically with no input from you.
-
-You must provide the node details for your peer node.
+### Create a node
 
 <CodeGroup>
   ```curl cURL
-  curl -X POST "$APIURL/networks/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"NETWORK_NAME","project":"PROJECT_ID","protocol":"PROTOCOL","configuration":{"consensus":"CONSENSUS"},"nodes":[{"name":"NODE_NAME","type":"NODE_TYPE","role":"NODE_ROLE","provider":"CLOUD_PROVIDER","region":"LOCATION","configuration":{}}]}'
-  ```
-</CodeGroup>
-
-where
-
-* NETWORK\_NAME — any name you want to give to your network.
-
-* PROJECT\_ID — the ID of the project where the network will be deployed. You can get project IDs by running `curl -X GET "$APIURL/projects/" --header "$HDR_AUTH"`.
-
-* PROTOCOL — the protocol of the network you want to deploy:
-
-  * `corda` — Corda
-  * `fabric` — Hyperledger Fabric
-  * `quorum` — Quorum
-  * `multichain` — MultiChain
-
-* CONSENSUS — the consensus of the protocol you want to deploy:
-
-  * [Corda Single Notary](/docs/about-corda#consensus) — `single-notary`
-  * [Hyperledger Fabric Raft](/docs/about-hyperledger-fabric#consensus) — `raft`
-  * [Quorum Raft](/docs/about-quorum#raft) — `raft`
-  * [Quorum IBFT](/docs/about-quorum#ibft) — `ibft`
-  * [MultiChain round-robin](/docs/about-multichain#consensus) — `round-robin`.
-
-* NODE\_NAME — any name you want to give to your first peer node deployed as part of the network.
-
-* NODE\_TYPE — `dedicated` is the only available option for consortium networks.
-
-* NODE\_ROLE — use the `peer` value for the role since you are providing node details for your peer node.
-
-* CLOUD\_PROVIDER — choose the cloud provider for your node:
-
-  * `aws` — Amazon Web Services
-  * `azure` — Microsoft Azure
-  * `gcloud` — Google Cloud Platform
-
-* LOCATION — choose the location for your network:
-
-  * `ap-southeast-1` — Singapore. Available only for Amazon Web Services (`aws`).
-  * `us-east-1` — the United States, Northern Virginia. Available only for Amazon Web Services (`aws`).
-  * `us-west-2` — the United States, Oregon. Available only for Amazon Web Services (`aws`).
-  * `uksouth` — the United Kingdom, London. Available only for Microsoft Azure (`azure`).
-  * `asia-southeast1` — Singapore. Available only for Google Cloud Platform (`gcloud`).
-
-Example to create a Corda network on Google Cloud Platform in Singapore:
-
-<CodeGroup>
-  ```curl cURL
-  curl -X POST "$APIURL/networks/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"NETWORK_NAME","project":"PR-123-456","protocol":"corda","configuration":{"consensus":"single-notary"},"nodes":[{"name":"My node name","type":"dedicated","role":"peer","provider":"gcloud","region":"asia-southeast1","configuration":{}}]}'
-  ```
-</CodeGroup>
-
-See also API reference: [Create Network](/reference/chainstack-platform-api-create-network).
-
-### Add a peer node to the network
-
-<CodeGroup>
-  ```curl cURL
-  curl -X POST "$APIURL/nodes/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"NODE_NAME","network":"NETWORK_ID","type": "dedicated","role":"peer","provider":"CLOUD_PROVIDER","region":"LOCATION","configuration":{}}'
+  curl -X POST "$APIURL/nodes/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"NODE_NAME","project":"PROJECT_ID","blockchain":"BLOCKCHAIN_ID","cloud":"CLOUD_ID"}'
   ```
 </CodeGroup>
 
 where
 
 * NODE\_NAME — any name you want to give to your node.
+* PROJECT\_ID — the ID of the project. You can get project IDs by running `curl -X GET "$APIURL/projects/" --header "$HDR_AUTH"`.
+* BLOCKCHAIN\_ID — the `blockchain` value from the deployment options matching your desired protocol and network.
+* CLOUD\_ID — the `cloud` value from the deployment options matching your desired provider and region.
 
-* NETWORK\_ID — the ID of the network where the node will be deployed. You can get network IDs by running `curl -X GET "$APIURL/networks/" --header "$HDR_AUTH"`.
-
-* CLOUD\_PROVIDER — choose the cloud provider for your node:
-
-  * `aws` — Amazon Web Services
-  * `azure` — Microsoft Azure
-  * `gcloud` — Google Cloud Platform
-
-* LOCATION — choose the location for your network:
-
-  * `ap-southeast-1` — Singapore. Available only for Amazon Web Services (`aws`).
-  * `us-east-1` — the United States, Northern Virginia. Available only for Amazon Web Services (`aws`).
-  * `us-west-2` — the United States, Oregon. Available only for Amazon Web Services (`aws`).
-  * `uksouth` — the United Kingdom, London. Available only for Microsoft Azure (`azure`).
-  * `asia-southeast1` — Singapore. Available only for Google Cloud Platform (`gcloud`).
-
-Example to add a node on Microsoft Azure in London:
+Example to create an Ethereum Mainnet node on AWS us-east-1 (using identifiers from the deployment options response above):
 
 <CodeGroup>
   ```curl cURL
-  curl -X POST "$APIURL/nodes/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"My node name","network":"NW-123-456-7","type": "dedicated","role":"peer","provider":"azure","region":"uksouth","configuration":{}}'
+  curl -X POST "$APIURL/nodes/" --header "$HDR_AUTH" --header "$HDR_CT" --data '{"name":"My Ethereum node","project":"PR-123-456-789","blockchain":"BC-000-000-008","cloud":"CC-0016"}'
   ```
 </CodeGroup>
 
-See also API reference: [Create Node](/reference/chainstack-platform-api-create-node).
+See also API reference: [Create node](/reference/chainstack-platform-api-v2-create-node).
 
 ### Get the node access and credentials
 
@@ -170,6 +124,6 @@ See also API reference: [Create Node](/reference/chainstack-platform-api-create-
 
 where NODE\_ID — the ID of the node. You can get node IDs by running `curl -X GET "$APIURL/nodes/" --header "$HDR_AUTH"`.
 
-See also API reference: [Retrieve Node](/reference/chainstack-platform-api-retrieve-node).
+See also API reference: [Retrieve node](/reference/chainstack-platform-api-v2-retrieve-node).
 
-You have created a consortium project, deployed a consortium network, added a node to the network, and retrived the node's access and credentials.
+You have created a project, deployed a node, and retrieved the node's access and credentials.


### PR DESCRIPTION
## Summary

- Remove dead Marketplace token (`/v1/marketplace/applications/{slug}/token/`) and Faucet Goerli (`/v1/faucet/goerli`) endpoints — both return 404 on prod
- Delete corresponding MDX stubs and unused OpenAPI schemas (`AccessToken`, `FaucetGoerliRequest`, `FaucetGoerliResponse`, `Slug`)
- Reorder platform API sidebar: v2 groups listed first, consistent version labels (`Project v2`/`Project v1` instead of `Project (v2)`/`Project`)
- Add v2 endpoint MDX stubs for deployment options, projects, and nodes
- Update getting-started page: remove identities reference and YAML download link, add v2/v1 version overview
- Rewrite quick tutorial for v2 API: remove deprecated consortium network content (Corda, Fabric, Quorum, MultiChain), use v2 endpoints with deployment options workflow



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Chainstack Platform API v2 with new endpoints for managing deployment options, projects, and nodes
  
* **Documentation**
  * Added comprehensive v2 API reference guides
  * Updated platform API getting started guide to highlight v2 and v1 availability

* **Changes**
  * Existing v1 Project and Node endpoints relabeled for clarity
  * Removed Marketplace functionality
  * Deprecated Goerli faucet; Sepolia faucet remains available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->