### PR TITLE
Add dedicated page for the cpctl download excluded from navigation

### DIFF
--- a/docs/self-hosted/download-installer.mdx
+++ b/docs/self-hosted/download-installer.mdx
@@ -1,0 +1,98 @@
+---
+title: "Install Chainstack Self-Hosted"
+description: "Download and run the Chainstack Self-Hosted installer"
+noindex: true
+---
+
+To install Chainstack Self-Hosted, run the installer for your operating system:
+
+<Tabs>
+<Tab title="Linux / macOS">
+
+```bash
+curl -sSL https://install.chainstack.com/cpctl.sh | sh
+```
+
+</Tab>
+<Tab title="Windows">
+
+```powershell
+irm https://install.chainstack.com/cpctl.ps1 | iex
+```
+
+</Tab>
+</Tabs>
+
+This downloads and runs the `cpctl` installer script, which sets up the Chainstack Self-Hosted command-line tool on your system.
+
+## Supported platforms
+
+The installer automatically detects your operating system and architecture.
+
+| Operating system | Architectures |
+|---|---|
+| Linux | amd64 (x86_64), arm64 (aarch64) |
+| macOS | amd64 (x86_64), arm64 (aarch64) |
+| Windows | amd64 (x86_64), arm64 |
+
+<Note>
+32-bit systems (x86, ARM) are not supported.
+</Note>
+
+## Install a specific version
+
+<Tabs>
+<Tab title="Linux / macOS">
+
+Pass the version as an argument:
+
+```bash
+curl -sSL https://install.chainstack.com/cpctl.sh | sh -s v1.0.0
+```
+
+Or set the `CPCTL_VERSION` environment variable:
+
+```bash
+CPCTL_VERSION=v1.0.0 curl -sSL https://install.chainstack.com/cpctl.sh | sh
+```
+
+</Tab>
+<Tab title="Windows">
+
+```powershell
+iwr https://install.chainstack.com/cpctl.ps1 -OutFile cpctl.ps1
+.\cpctl.ps1 -Version v1.0.0
+```
+
+Or set the `CPCTL_VERSION` environment variable:
+
+```powershell
+$env:CPCTL_VERSION = "v1.0.0"
+irm https://install.chainstack.com/cpctl.ps1 | iex
+```
+
+</Tab>
+</Tabs>
+
+## Custom install directory
+
+<Tabs>
+<Tab title="Linux / macOS">
+
+By default, `cpctl` installs to `/usr/local/bin/`. To override the install directory, set the `CPCTL_INSTALL_DIR` environment variable:
+
+```bash
+CPCTL_INSTALL_DIR=/opt/bin curl -sSL https://install.chainstack.com/cpctl.sh | sh
+```
+
+</Tab>
+<Tab title="Windows">
+
+By default, `cpctl` installs to `%LOCALAPPDATA%\cpctl\` and is automatically added to the user `PATH`.
+
+</Tab>
+</Tabs>
+
+<Note>
+Make sure your server meets the [system requirements](/docs/self-hosted/requirements) before running the installer.
+</Note>


### PR DESCRIPTION
This page is created to send to the users via the email the instructions & curl to download the installer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new installation guide for the Chainstack Self‑Hosted installer with platform-specific installer instructions for Linux, macOS, and Windows.
  * Describes supported architectures (no 32‑bit support), how to install a specific CLI version, configuring a custom install directory, and references system requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->