### PR TITLE
Add missing error codes to API errors reference

### DIFF
--- a/reference/node-api-errors-reference.mdx
+++ b/reference/node-api-errors-reference.mdx
@@ -12,7 +12,9 @@ description: "Below you can find possible error codes that can occur while worki
 | 404 | Not Found | [Contact support](https://support.chainstack.com/) to check if you are accessing the correct node and if the node is healthy. |
 | 404 | DEPTH\_ZERO\_SELF\_SIGNED\_CERT | [Contact support](https://support.chainstack.com/) to check if the gateway is healthy. |
 | 413 | Request Entity Too Large | The default limit of the request body size is 1 MB. Reduce the request body size. |
-| 429 | Too Many Requests | You hit the default node [HTTP connections limit](https://docs.chainstack.com/docs/handle-real-time-data-using-websockets-with-javascript-and-python#http-and-websocket-connection-limitations). Reduce the number of requests.   Or you hit the rate limit on your plan. Upgrade the plan. |
+| 429 | Too Many Requests | You hit the default node [HTTP connections limit](https://docs.chainstack.com/docs/handle-real-time-data-using-websockets-with-javascript-and-python#http-and-websocket-connection-limitations). Reduce the number of requests. |
+| 429 | You've exceeded the RPS limit available on the current plan | You hit the [rate limit on your plan](https://docs.chainstack.com/docs/pricing-introduction#rate-limits). Reduce the request rate or upgrade to a higher plan. See also [RPS plan limits](https://docs.chainstack.com/docs/rps-plan-limits). |
+| 429 | You've reached your monthly quota of Request Units (RUs) | You exhausted the monthly RU quota on your plan. [Enable pay-as-you-go](https://console.chainstack.com/user/settings/billing) to continue beyond the quota or upgrade for more RUs. See also [Quotas](https://docs.chainstack.com/docs/quotas). |
 | 499 | No Response From Node | Increase the client-side time-out. [Contact support](https://support.chainstack.com/) if the issue persists. |
 | 500 | Internal Server Error | [Contact support](https://support.chainstack.com/) to check if you are accessing the correct node and if the gateway is healthy. |
 | 500 | ECONNREFUSED | [Contact support](https://support.chainstack.com/). |
@@ -24,6 +26,7 @@ description: "Below you can find possible error codes that can occur while worki
 | Code | Message | Solution |
 | --- | --- | --- |
 | 1006 | Socket Error: read ECONNRESET | [Implement a reconnect](https://docs.chainstack.com/docs/handle-real-time-data-using-websockets-with-javascript-and-python) in your code or get a [dedicated gateway](https://docs.chainstack.com/docs/trader-node#dedicated-gateways). |
+| 1009 | MESSAGE\_TOO\_BIG | The incoming WebSocket message exceeded the maximum allowed size. Increase or disable `max_size` in your WebSocket client configuration. |
 
 ## JSON-RPC status codes
 | Code | Message | Solution |
@@ -33,5 +36,6 @@ description: "Below you can find possible error codes that can occur while worki
 | \-32601 | Method Not Found | The method you are trying to call is not available on the node. See also [API namespaces](https://support.chainstack.com/hc/en-us/articles/360024806051). |
 | \-32602 | Invalid Params | Your request has invalid parameters. See [node API reference](https://docs.chainstack.com/reference/chainstack-platform-api-list-all-nodes). |
 | \-32603 | Internal Error | A JSON-RPC error that means your request cannot be processed and usually has a -32000 error with details on why the request cannot be processed. |
+| \-32005 | Rate Limit Exceeded | You exceeded the RPS limit or monthly RU quota on your plan. The `message` field contains details on which limit was hit. The response may include a `data.try_again_in` field indicating when to retry. See [RPS plan limits](https://docs.chainstack.com/docs/rps-plan-limits) and [Quotas](https://docs.chainstack.com/docs/quotas). |
 | \-32000 | Server Error | The implementation-defined error on the server. The node implementation shows why it cannot process the request. For example, see [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474). |
 


### PR DESCRIPTION
## Summary

- Split the generic 429 entry into three distinct rows: HTTP connections limit, RPS plan limit, and monthly RU quota exceeded
- Add WebSocket `1009` MESSAGE_TOO_BIG error
- Add JSON-RPC `-32005` Rate Limit Exceeded error (covers both RPS limit and monthly quota, includes `data.try_again_in` field)

Triggered by a customer request in Slack asking for a complete list of error codes for monitoring — Eugene flagged that quota errors were missing from the docs.

## Test plan

- [ ] Verify the page renders correctly on Mintlify preview
- [ ] Confirm all internal links resolve (RPS plan limits, quotas, billing, pricing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced HTTP status code reference with additional 429 variants covering connections limit, RPS limit, and monthly quota constraints
  * Added WebSocket error documentation for oversized message handling
  * Added JSON-RPC rate limit exceeded error documentation with retry guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->