### PR TITLE
Update self-hosted introduction page title

### DIFF
--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: "Introduction to Chainstack Self-Hosted"
 description: "Deploy and manage blockchain infrastructure in your own environment with complete control over your data"
 ---
 


### PR DESCRIPTION
## Summary
- Expands the self-hosted introduction page title from "Introduction" to "Introduction to Chainstack Self-Hosted" for better clarity and discoverability

## Test plan
- [ ] Verify the title renders correctly on the docs site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the title of the self-hosted introduction documentation for improved clarity and specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->