### PR TITLE
Add Tempo Mainnet release notes

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: March 18, 2026" description=" by Vladimir">
+
+**Protocols**. Tempo Mainnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Mainnet. See also [Tempo tooling](/docs/tempo-tooling) and [Tempo API reference](/reference/tempo-getting-started).
+
+<Button href="/changelog/chainstack-updates-march-18-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: March 5, 2026" description=" by Vladimir">
 
 **Protocols**. MegaETH is now available on Chainstack:

--- a/changelog/chainstack-updates-march-18-2026.mdx
+++ b/changelog/chainstack-updates-march-18-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: March 18, 2026"
+description: "Tempo Mainnet support for Global Nodes and Dedicated Nodes"
+---
+
+**Protocols**. Tempo Mainnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Mainnet. See also [Tempo tooling](/docs/tempo-tooling) and [Tempo API reference](/reference/tempo-getting-started).

--- a/docs.json
+++ b/docs.json
@@ -3488,6 +3488,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-march-18-2026",
           "changelog/chainstack-updates-march-5-2026",
           "changelog/chainstack-updates-january-22-2026",
           "changelog/chainstack-updates-january-21-2026",


### PR DESCRIPTION
## Summary
- Add release notes for Tempo Mainnet availability on Global Nodes and Dedicated Nodes
- Create changelog entry `chainstack-updates-march-18-2026.mdx`
- Update `changelog.mdx` with new Update entry at the top
- Add new page to Release notes navigation in `docs.json`

## Test plan
- [x] Verified page renders correctly on local Mintlify dev server (port 3333)
- [x] Verified page title and meta description
- [ ] Review changelog page and individual entry on Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new changelog entry announcing Tempo Mainnet support on Chainstack, detailing deployment options through Global Nodes and Dedicated Nodes, with links to Tempo tooling and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->