### PR TITLE
Add Sui Testnet GEN support

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: March 27, 2026" description=" by Ake">
+
+**Protocols**. Sui Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) for Sui Testnet with JSON-RPC and gRPC endpoint support. See also [Sui tooling](/docs/sui-tooling).
+
+<Button href="/changelog/chainstack-updates-march-27-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: March 18, 2026" description=" by Vladimir">
 
 **Protocols**. Tempo Mainnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Tempo Mainnet. See also [Tempo tooling](/docs/tempo-tooling) and [Tempo API reference](/reference/tempo-getting-started).

--- a/changelog/chainstack-updates-march-27-2026.mdx
+++ b/changelog/chainstack-updates-march-27-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: March 27, 2026"
+description: "Sui Testnet support for Global Nodes"
+---
+
+**Protocols**. Sui Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) for Sui Testnet with JSON-RPC and gRPC endpoint support. See also [Sui tooling](/docs/sui-tooling).

--- a/docs.json
+++ b/docs.json
@@ -3504,6 +3504,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-march-27-2026",
           "changelog/chainstack-updates-march-18-2026",
           "changelog/chainstack-updates-march-5-2026",
           "changelog/chainstack-updates-january-22-2026",

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -160,6 +160,7 @@ description: "Explore Chainstack's available clouds, regions, and locations for 
 | Network | Cloud                      | Region    | Location  | Mode      |
 | ------- | -------------------------- | --------- | --------- | --------- |
 | Mainnet | Chainstack Partner Network | global2   | Worldwide | Full      |
+| Testnet | Chainstack Global Network  | global1   | Worldwide | Archive   |
 
 ## Berachain
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -69,7 +69,7 @@ description: "This page lists all the supported networks that you can use to dep
 | Soneium | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Elastic, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Sui | Elastic, Dedicated | Full | - | - | No | [Deploy through platform](https://console.chainstack.com) |
+| Sui | Elastic, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Taiko | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
 | Tempo | Elastic, Dedicated | Full, Archive | Full, Archive | Moderato Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -67,6 +67,7 @@ Your Sui gRPC endpoint is available at:
 
 ```
 sui-mainnet.core.chainstack.com:443
+sui-testnet.core.chainstack.com:443
 ```
 
 ### Authentication

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1196,10 +1196,11 @@
     "Sui": {
       "protocol_name": "Sui",
       "supported_modes": [
-        "Full"
+        "Full",
+        "Archive"
       ],
       "full_mode_query_limit": "N/A",
-      "archive_mode_available": false,
+      "archive_mode_available": true,
       "debug_trace_available": false,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Platform",
@@ -1222,7 +1223,27 @@
           }
         ]
       },
-      "testnets": [],
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "https://faucet.sui.io/",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Archive",
+                  "debug_trace": false,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
       "additional_notes": "N/A"
     },
     "Berachain": {


### PR DESCRIPTION
## Summary
- Sui Testnet launched in production (Mar 27, 2026) with Archive mode on Chainstack Global Network (global1)
- Added testnet entry to `node-options-master-list.json` with Archive mode, updated `supported_modes` and `archive_mode_available`
- Updated `protocols-networks.mdx` and `nodes-clouds-regions-and-locations.mdx` tables
- Added `sui-testnet.core.chainstack.com:443` gRPC endpoint to `sui-tooling.mdx`
- Added changelog entry for Mar 27, 2026

## Test plan
- [ ] Verify Mintlify preview renders all updated tables correctly
- [ ] Confirm Sui Testnet row appears in protocols-networks and nodes-clouds-regions pages
- [ ] Check changelog entry links work
- [ ] Verify gRPC endpoint format section in sui-tooling shows both mainnet and testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sui Testnet is now available on Chainstack with JSON-RPC and gRPC endpoint support
  * Archive mode now supported for Sui Testnet

* **Documentation**
  * Added release notes documenting Sui Testnet availability
  * Updated protocol and tooling documentation with Sui Testnet configurations and endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->