### PR TITLE
Link limits page to getProgramAccounts reference

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -77,7 +77,7 @@ The following limits are applied:
   - Chainstack Global Network Worldwide `global1` RPS: 100
   - Chainstack Cloud London `lon1` RPS: 100
   - Chainstack Cloud New York City `nyc1` RPS: 100
-- `getProgramAccounts`:
+- [`getProgramAccounts`](/reference/solana-getprogramaccounts) — unfiltered requests to large programs are blocked; always use `dataSize` or `memcmp` filters:
   - Chainstack Global Network `global1` RPS: 3
   - Chainstack Cloud London `lon1` RPS: 10
   - Chainstack Cloud New York City `nyc1` RPS: 3
@@ -100,10 +100,10 @@ The following limits are applied:
 
 ## Solana accounts excluded from indexing
 
-The following Solana accounts are unavailable for querying:
+The following Solana accounts are excluded from the `program-id` secondary index and cannot be queried with [`getProgramAccounts`](/reference/solana-getprogramaccounts). Use [`getTokenAccountsByOwner`](/reference/solana-gettokenaccountsbyowner) instead:
 
-- `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`
-- `kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6`
+- `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` — SPL Token Program
+- `kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6` — Kin
 
 ## Solana method availability
 


### PR DESCRIPTION
## Summary

- Follow-up to #306 (merged)
- Adds cross-links from the limits page to the updated `getProgramAccounts` reference so customers hitting rate limits or excluded-program errors land on actionable guidance

## Changes in `docs/limits.mdx`

- `getProgramAccounts` RPS entry now links to the reference page and notes that unfiltered requests are blocked
- Excluded accounts section explains they can't be used with `getProgramAccounts`, links to `getTokenAccountsByOwner` as the alternative, and labels each address (SPL Token Program, Kin)

## Test plan

- [ ] Verify Mintlify preview renders the links correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `getProgramAccounts` documentation to clarify that unfiltered requests to large programs are blocked; users must apply `dataSize` or `memcmp` filters.
  * Revised `getProgramAccounts` rate limits by region.
  * Expanded excluded accounts documentation with human-readable labels and alternative query recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->