### PR TITLE
Add Codex instructions to Developer Portal MCP server page

### DIFF
--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -53,10 +53,15 @@ Add the following configuration to `~/.codeium/windsurf/mcp_config.json`:
 
 ### Codex
 
-To add the Chainstack MCP server to OpenAI Codex, use the following commands:
+To add the Chainstack MCP server to OpenAI Codex, first set a dummy environment variable:
 
 ```bash
 export PASTE_THIS_OR_ANY_DUMMY_TOKEN=paste_this_or_any_dummy_token
+```
+
+Then add the MCP server:
+
+```bash
 codex mcp add devportal --url https://docs.chainstack.com/mcp --bearer-token-env-var "PASTE_THIS_OR_ANY_DUMMY_TOKEN"
 ```
 

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -51,12 +51,6 @@ Add the following configuration to `~/.codeium/windsurf/mcp_config.json`:
 5. Save the configuration and click **"Refresh Servers"** in the Cascade settings
 6. Verify the integration by clicking the Hammer Icon in the Cascade toolbar — the Chainstack documentation search tool should appear
 
-### Kiro
-
-<Note>
-Kiro does not currently support streamable HTTP MCP servers. Support is being tracked in [this feature request](https://github.com/kirodotdev/Kiro/issues/23). Once streamable HTTP support is added, the Chainstack Developer Portal MCP server will be compatible with Kiro.
-</Note>
-
 ### Codex
 
 To add the Chainstack MCP server to OpenAI Codex, use the following commands:

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -59,20 +59,15 @@ Kiro does not currently support streamable HTTP MCP servers. Support is being tr
 
 ### Codex
 
-To add the Chainstack MCP server to OpenAI Codex, use the following command:
+To add the Chainstack MCP server to OpenAI Codex, use the following commands:
 
-```
-codex mcp add devportal --url https://docs.chainstack.com/mcp --bearer-token-env-var "DEVPORTAL_TOKEN"
-```
-
-Then set the environment variable to any value:
-
-```
-export DEVPORTAL_TOKEN=public
+```bash
+export PASTE_THIS_OR_ANY_DUMMY_TOKEN=paste_this_or_any_dummy_token
+codex mcp add devportal --url https://docs.chainstack.com/mcp --bearer-token-env-var "PASTE_THIS_OR_ANY_DUMMY_TOKEN"
 ```
 
 <Note>
-Codex proactively discovers OAuth metadata on every HTTP MCP connection. Since the Chainstack Developer Portal MCP server is public and requires no authentication, the `bearer-token-env-var` flag tells Codex to skip the OAuth flow and connect directly.
+The Developer Portal MCP server is public and requires no authentication. However, Codex proactively discovers OAuth metadata on every HTTP MCP connection and attempts an OAuth flow that fails. The `bearer-token-env-var` flag with any dummy token value tells Codex to skip the OAuth flow and connect directly.
 </Note>
 
 ## Manual configuration

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -67,7 +67,7 @@ codex mcp add devportal --url https://docs.chainstack.com/mcp --bearer-token-env
 ```
 
 <Note>
-The Developer Portal MCP server is public and requires no authentication. However, Codex proactively discovers OAuth metadata on every HTTP MCP connection and attempts an OAuth flow that fails. The `bearer-token-env-var` flag with any dummy token value tells Codex to skip the OAuth flow and connect directly.
+The Developer Portal MCP server is public and requires no authentication. The dummy token is a workaround for a [known Codex OAuth issue](https://github.com/openai/codex/issues/5588).
 </Note>
 
 ## Manual configuration

--- a/docs/developer-portal-mcp-server.mdx
+++ b/docs/developer-portal-mcp-server.mdx
@@ -57,6 +57,24 @@ Add the following configuration to `~/.codeium/windsurf/mcp_config.json`:
 Kiro does not currently support streamable HTTP MCP servers. Support is being tracked in [this feature request](https://github.com/kirodotdev/Kiro/issues/23). Once streamable HTTP support is added, the Chainstack Developer Portal MCP server will be compatible with Kiro.
 </Note>
 
+### Codex
+
+To add the Chainstack MCP server to OpenAI Codex, use the following command:
+
+```
+codex mcp add devportal --url https://docs.chainstack.com/mcp --bearer-token-env-var "DEVPORTAL_TOKEN"
+```
+
+Then set the environment variable to any value:
+
+```
+export DEVPORTAL_TOKEN=public
+```
+
+<Note>
+Codex proactively discovers OAuth metadata on every HTTP MCP connection. Since the Chainstack Developer Portal MCP server is public and requires no authentication, the `bearer-token-env-var` flag tells Codex to skip the OAuth flow and connect directly.
+</Note>
+
 ## Manual configuration
 
 For other AI tools that support streamable HTTP MCP, use the following URL:


### PR DESCRIPTION
## Summary

- Add OpenAI Codex installation instructions with a dummy bearer token workaround for the [known OAuth discovery issue](https://github.com/openai/codex/issues/5588)
- Remove Kiro section (no streamable HTTP support)

## Context

A customer migrating from QuickNode reported that Codex fails to connect to our Mintlify-hosted MCP server — Codex proactively triggers an OAuth flow that fails because the server is public and requires no auth. The `--bearer-token-env-var` flag bypasses this.

## Test plan

- [ ] Verify page renders correctly with `mintlify dev`
- [ ] Confirm Codex connects using the documented commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Developer Portal MCP server documentation with Codex installation instructions and setup steps, replacing previous Kiro integration details. Added explicit guidance for environment variables and MCP server registration. Clarified that the Developer Portal MCP server requires no authentication and documented a token workaround for Codex OAuth compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->