### PR TITLE
Add Flashblocks WS subscription method docs for Base

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1977,6 +1977,15 @@
                   "reference/base-trace-get",
                   "reference/base-trace-block"
                 ]
+              },
+              {
+                "group": "Subscriptions | Base",
+                "pages": [
+                  "reference/base-subscribe-newflashblocktransactions",
+                  "reference/base-subscribe-pendinglogs",
+                  "reference/base-subscribe-newflashblocks",
+                  "reference/base-unsubscribe"
+                ]
               }
             ]
           },

--- a/docs/base-methods.mdx
+++ b/docs/base-methods.mdx
@@ -41,6 +41,9 @@ See also [interactive Base API call examples](/reference/base-api-reference).
 | eth\_newPendingTransactionFilter         | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_signTransaction                     | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_subscribe                           | <Icon icon="square-check"  iconType="solid" />            |                       |
+| eth\_subscribe newFlashblockTransactions | <Icon icon="square-check"  iconType="solid" />            | Flashblocks WS only   |
+| eth\_subscribe pendingLogs               | <Icon icon="square-check"  iconType="solid" />            | Flashblocks WS only   |
+| eth\_subscribe newFlashblocks            | <Icon icon="square-check"  iconType="solid" />            | Flashblocks WS only   |
 | eth\_syncing                             | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_uninstallFilter                     | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_unsubscribe                         | <Icon icon="square-check"  iconType="solid" />            |                       |

--- a/docs/flashblocks-on-base.mdx
+++ b/docs/flashblocks-on-base.mdx
@@ -26,6 +26,11 @@ This two-side architecture implements the following Flashblocks flow:
   * `eth_sendRawTransactionSync`
 * The transaction ordering is done at the Flashblocks level instead of the block level.
 
+Additionally, the following WebSocket subscription methods are available exclusively on Flashblocks-enabled endpoints:
+  * [`eth_subscribe newFlashblockTransactions`](/reference/base-subscribe-newflashblocktransactions) — stream individual transactions as they are pre-confirmed (~200ms each)
+  * [`eth_subscribe pendingLogs`](/reference/base-subscribe-pendinglogs) — stream filtered event logs from pre-confirmed transactions
+  * [`eth_subscribe newFlashblocks`](/reference/base-subscribe-newflashblocks) — stream full Flashblock payload objects from the sequencer
+
 Each 2-second block on the Base chain is formed after 10 different Flashblocks have been processed—each Flashblock with its own transaction ordering.
 
 ## Quick Flashblock vs. full block data comparison

--- a/reference/base-subscribe-newflashblocks.mdx
+++ b/reference/base-subscribe-newflashblocks.mdx
@@ -1,0 +1,159 @@
+---
+title: "eth_subscribe newFlashblocks | Base"
+description: "Base API method that streams full Flashblock state as standard block objects from the sequencer, delivering the accumulated pre-confirmed state approximately every 200ms."
+---
+
+Base API method that streams the accumulated pre-confirmed block state approximately every 200ms. Each notification delivers a standard Ethereum block object representing the current Flashblock snapshot—including all transactions pre-confirmed so far.
+
+This subscription type is exclusive to Flashblocks-enabled endpoints. See [Flashblocks on Base](/docs/flashblocks-on-base) for background on how Flashblocks work.
+
+<Check>
+  ### Get you own node endpoint today
+
+  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+  You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `string` — the subscription type, `newFlashblocks` in this case.
+
+## Response
+
+* `subscription` — the subscription ID.
+
+Each notification delivers a block object with the following fields:
+
+* `hash` — the block hash. Set to `0x0000...0000` because the block is still being formed (pre-confirmed).
+* `parentHash` — hash of the parent block.
+* `sha3Uncles` — hash of the list of uncles included in the block.
+* `miner` — the address of the fee recipient (coinbase), typically `0x4200000000000000000000000000000000000011`.
+* `stateRoot` — root of the state trie. Set to `0x0000...0000` because the block is not yet finalized.
+* `transactionsRoot` — root of the transaction trie of the block.
+* `receiptsRoot` — root of the receipts trie of the block.
+* `logsBloom` — bloom filter for the logs in this Flashblock.
+* `difficulty` — always `0x0` on Base.
+* `number` — the block number, encoded as hexadecimal.
+* `gasLimit` — maximum gas allowed in this block (hex).
+* `gasUsed` — cumulative gas used up to and including this Flashblock (hex).
+* `timestamp` — Unix timestamp of block creation (hex).
+* `extraData` — arbitrary data field set by the sequencer.
+* `mixHash` — the previous RANDAO value.
+* `nonce` — always `0x0000000000000000` on Base.
+* `baseFeePerGas` — EIP-1559 base fee per gas (hex).
+* `withdrawalsRoot` — Merkle root of withdrawals.
+* `blobGasUsed` — cumulative blob gas used, EIP-4844 (hex).
+* `excessBlobGas` — excess blob gas (hex).
+* `parentBeaconBlockRoot` — parent beacon block root.
+* `uncles` — always empty on Base.
+* `transactions` — array of full transaction objects included in this Flashblock so far. Each object includes standard transaction fields (`type`, `from`, `to`, `value`, `input`, `hash`, etc.).
+* `withdrawals` — always empty on Base L2.
+
+<Note>
+  The `hash` and `stateRoot` fields are zeroed because the block is still being assembled. Once the full 2-second block seals, these values are computed and finalized. See [Flashblocks on Base](/docs/flashblocks-on-base#quick-flashblock-vs-full-block-data-comparison) for a comparison.
+</Note>
+
+## `eth_subscribe("newFlashblocks")` code examples
+
+<Info>
+  Note that subscriptions require a WebSocket connection and [WebSocket cat](https://www.npmjs.com/package/wscat) for you to use this method in the console.
+
+  Install WebSocket cat with:
+
+  `npm install -g wscat`
+</Info>
+
+<CodeGroup>
+  ```shell wscat
+  $ wscat -c YOUR_CHAINSTACK_WEBSOCKET_ENDPOINT
+  # Wait for the connection to be established
+
+  Connected (press CTRL+C to quit)
+
+  > {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newFlashblocks"]}
+  ```
+
+  ```javascript javascript
+  const WebSocket = require('ws');
+
+  const webSocket = new WebSocket('CHAINSTACK_WSS_URL');
+
+  async function subscribeToNewFlashblocks() {
+
+    const request = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_subscribe',
+      params: ['newFlashblocks'],
+    };
+
+    const onOpen = (event) => {
+      webSocket.send(JSON.stringify(request));
+    };
+
+    const onMessage = (event) => {
+      const response = JSON.parse(event.data);
+      console.log(response);
+    };
+
+    try {
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('message', onMessage);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  subscribeToNewFlashblocks();
+  ```
+</CodeGroup>
+
+This will generate a continuous stream of block objects as new Flashblocks are produced by the sequencer (~every 200ms).
+
+<Warning>
+  Each notification can be large (hundreds of KB) because it includes the full `transactions` array. If your handler performs heavy processing per event, throttle or debounce it to avoid blocking the WebSocket connection.
+</Warning>
+
+### Example notification
+
+```json
+{
+  "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x6d98f3e9368562605c063467030f8c6ab47ff606da890b879316a14f9841b3a7",
+  "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+  "miner": "0x4200000000000000000000000000000000000011",
+  "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "transactionsRoot": "0xf671d9e31238c090e32742144d05b5230b06b80af0a8611cbdac89cb79eae5b6",
+  "receiptsRoot": "0x739875b7b5439ff233106142f0a74ca134ec51e4d4e61bed0884cbd60c83c7ac",
+  "logsBloom": "0x00000000...",
+  "difficulty": "0x0",
+  "number": "0x2a13e81",
+  "gasLimit": "0x17d78400",
+  "gasUsed": "0x3f923ca",
+  "timestamp": "0x69ccd9e5",
+  "extraData": "0x01000000640000000500000000004c4b40",
+  "mixHash": "0x54389ec106a631ccd44c4b3b59a5b01e1647d039ae6cf7893fb8286d451fdceb",
+  "nonce": "0x0000000000000000",
+  "baseFeePerGas": "0x4c4b40",
+  "withdrawalsRoot": "0x7d152b4dc9c65e113c7498ce4c255d9d6740185dbd81dbcb6d7b8a4ac72ba13a",
+  "blobGasUsed": "0xc82ab0",
+  "excessBlobGas": "0x0",
+  "parentBeaconBlockRoot": "0x77c576c8b150f4cc43c9df655988983a309b63b0339ca27a752f2811ad5cae53",
+  "uncles": [],
+  "transactions": ["...full transaction objects..."],
+  "withdrawals": []
+}
+```
+
+Use [eth\_unsubscribe | Base](/reference/base-unsubscribe) to remove the subscription.
+
+## Use case
+
+The `eth_subscribe("newFlashblocks")` method is useful when you need the complete pre-confirmed block state rather than individual transactions or logs:
+
+* Block building and state reconstruction. Applications that need to reconstruct the full pending block state—such as custom block explorers or analytics platforms—can consume the Flashblock stream directly instead of polling `eth_getBlockByNumber` with `pending`.
+
+* MEV strategy development. Searchers can observe the sequencer's transaction ordering in real time across each ~200ms Flashblock, gaining insight into how the pending block is being constructed.
+
+* Infrastructure monitoring. Node operators and RPC providers can use the Flashblock stream to monitor sequencer health, block production cadence, and gas usage patterns with sub-second granularity.

--- a/reference/base-subscribe-newflashblocktransactions.mdx
+++ b/reference/base-subscribe-newflashblocktransactions.mdx
@@ -1,0 +1,168 @@
+---
+title: "eth_subscribe newFlashblockTransactions | Base"
+description: "Base API method that streams individual transactions as they are pre-confirmed into Flashblocks, delivering events approximately every 200ms."
+---
+
+Base API method that streams individual transactions as they are pre-confirmed into a Flashblock. Events arrive approximately every 200ms—one item per WebSocket message.
+
+This subscription type is exclusive to Flashblocks-enabled endpoints. See [Flashblocks on Base](/docs/flashblocks-on-base) for background on how Flashblocks work.
+
+<Check>
+  ### Get you own node endpoint today
+
+  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+  You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `string` — the subscription type, `newFlashblockTransactions` in this case.
+* `boolean` — (optional) when `true`, includes complete transaction objects and associated logs in each notification. Defaults to `false` (minimal data only).
+
+## Response
+
+* `subscription` — the subscription ID.
+
+Each notification delivers pre-confirmed transaction data. When `full` is `false` (default), the `result` is the transaction hash as a hex string. When `full` is `true`, the `result` is a complete transaction object with the following fields:
+
+* `type` — the transaction type (`0x0` Legacy, `0x1` Access List, `0x2` EIP-1559, `0x7e` Deposit).
+* `chainId` — the chain ID (hex).
+* `nonce` — the sender's nonce (hex).
+* `from` — the sender address.
+* `to` — the recipient address.
+* `value` — the ether value transferred (hex).
+* `input` — the call data.
+* `gas` — the gas limit (hex).
+* `maxFeePerGas` — the maximum fee per gas, EIP-1559 (hex).
+* `maxPriorityFeePerGas` — the maximum priority fee per gas, EIP-1559 (hex).
+* `gasPrice` — the effective gas price (hex).
+* `hash` — the transaction hash.
+* `blockHash` — `null` because the transaction is pre-confirmed (not yet in a finalized block).
+* `blockNumber` — the pending block number (hex).
+* `transactionIndex` — the transaction's index position in the block (hex).
+* `accessList` — the EIP-2930 access list (if applicable).
+* `r`, `s`, `v`, `yParity` — signature values.
+* `logs` — array of event logs emitted by the transaction. Each log includes `address`, `topics`, `data`, `blockHash`, `blockNumber`, `blockTimestamp`, `transactionHash`, `transactionIndex`, `logIndex`, and `removed`.
+
+## `eth_subscribe("newFlashblockTransactions")` code examples
+
+<Info>
+  Note that subscriptions require a WebSocket connection and [WebSocket cat](https://www.npmjs.com/package/wscat) for you to use this method in the console.
+
+  Install WebSocket cat with:
+
+  `npm install -g wscat`
+</Info>
+
+### Minimal data (default)
+
+<CodeGroup>
+  ```shell wscat
+  $ wscat -c YOUR_CHAINSTACK_WEBSOCKET_ENDPOINT
+  # Wait for the connection to be established
+
+  Connected (press CTRL+C to quit)
+
+  > {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newFlashblockTransactions"]}
+  ```
+
+  ```javascript javascript
+  const WebSocket = require('ws');
+
+  const webSocket = new WebSocket('CHAINSTACK_WSS_URL');
+
+  async function subscribeToFlashblockTransactions() {
+
+    const request = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_subscribe',
+      params: ['newFlashblockTransactions'],
+    };
+
+    const onOpen = (event) => {
+      webSocket.send(JSON.stringify(request));
+    };
+
+    const onMessage = (event) => {
+      const response = JSON.parse(event.data);
+      console.log(response);
+    };
+
+    try {
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('message', onMessage);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  subscribeToFlashblockTransactions();
+  ```
+</CodeGroup>
+
+### Full transaction objects and logs
+
+<CodeGroup>
+  ```shell wscat
+  $ wscat -c YOUR_CHAINSTACK_WEBSOCKET_ENDPOINT
+  # Wait for the connection to be established
+
+  Connected (press CTRL+C to quit)
+
+  > {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newFlashblockTransactions",true]}
+  ```
+
+  ```javascript javascript
+  const WebSocket = require('ws');
+
+  const webSocket = new WebSocket('CHAINSTACK_WSS_URL');
+
+  async function subscribeToFlashblockTransactionsFull() {
+
+    const request = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_subscribe',
+      params: ['newFlashblockTransactions', true],
+    };
+
+    const onOpen = (event) => {
+      webSocket.send(JSON.stringify(request));
+    };
+
+    const onMessage = (event) => {
+      const response = JSON.parse(event.data);
+      console.log(response);
+    };
+
+    try {
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('message', onMessage);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  subscribeToFlashblockTransactionsFull();
+  ```
+</CodeGroup>
+
+This will generate a continuous stream of data displaying pre-confirmed transactions as they are included in Flashblocks.
+
+<Note>
+  If your handler performs heavy processing per event, throttle or debounce it to avoid blocking the WebSocket connection.
+</Note>
+
+Use [eth\_unsubscribe | Base](/reference/base-unsubscribe) to remove the subscription.
+
+## Use case
+
+The `eth_subscribe("newFlashblockTransactions")` method is useful in scenarios where sub-second transaction visibility matters:
+
+* Latency-sensitive trading. DEX aggregators and MEV searchers can observe individual transactions as soon as the Base sequencer pre-confirms them—up to ~1.8 seconds before the full block seals—enabling faster reaction to on-chain events.
+
+* Real-time transaction monitoring. Wallet providers and block explorers can show users their transaction status within ~200ms of submission instead of waiting for the next 2-second block, significantly improving perceived confirmation speed.
+
+* Event-driven automation. Applications that trigger downstream actions on specific transactions—such as bridge relayers or liquidation bots—can act on pre-confirmed data instead of polling `eth_getBlockByNumber` with `pending`.

--- a/reference/base-subscribe-pendinglogs.mdx
+++ b/reference/base-subscribe-pendinglogs.mdx
@@ -1,0 +1,121 @@
+---
+title: "eth_subscribe pendingLogs | Base"
+description: "Base API method that streams filtered event logs from pre-confirmed Flashblock transactions, delivering events approximately every 200ms."
+---
+
+Base API method that streams event logs from pre-confirmed transactions matching an optional filter. Events arrive approximately every 200ms—one item per WebSocket message.
+
+This subscription type is exclusive to Flashblocks-enabled endpoints. See [Flashblocks on Base](/docs/flashblocks-on-base) for background on how Flashblocks work.
+
+<Check>
+  ### Get you own node endpoint today
+
+  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+  You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `string` — the subscription type, `pendingLogs` in this case.
+
+* `object` — (optional) the log filter options:
+
+  * `address` — the contract address from which the logs should be fetched. It can be a single address or an array of addresses.
+
+  * `topics` — an array of `DATA` topics. The event topics for which the logs should be fetched. It can be a single topic or an array of topics. Uses the same topic filter format as [eth\_getLogs](/reference/base-getlogs).
+
+    <Info>
+      Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial) to learn more about topics and event logs.
+    </Info>
+
+## Response
+
+* `subscription` — the subscription ID.
+
+* `object` — a log object matching the specified filter:
+
+  * `address` — the contract address from which the event originated.
+  * `topics` — an array of 32-byte data fields containing indexed event parameters.
+  * `data` — the non-indexed data that was emitted along with the event.
+  * `blocknumber` — the block number in which the event was included. `null` if it is pending.
+  * `transactionhash` — the hash of the transaction that triggered the event. `null` if pending.
+  * `transactionindex` — the integer index of the transaction within the block's list of transactions. `null` if it is pending.
+  * `blockhash` — the hash of the block in which the event was included. Set to `0x0000...0000` for pre-confirmed events.
+  * `blocktimestamp` — the Unix timestamp of the block (hex).
+  * `logindex` — the integer identifying the index of the event within the block's list of events. `null` if pending.
+  * `removed` — the boolean value indicating if the event was removed from the blockchain due to a chain reorganization. `True` if the log was removed. `False` if it is a valid log.
+
+## `eth_subscribe("pendingLogs")` code examples
+
+<Info>
+  Note that subscriptions require a WebSocket connection and [WebSocket cat](https://www.npmjs.com/package/wscat) for you to use this method in the console.
+
+  Install WebSocket cat with:
+
+  `npm install -g wscat`
+</Info>
+
+In the following examples, we subscribe to USDC transfer events on Base. The address `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` is the Base USDC contract and `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef` is the `Transfer(address,address,uint256)` event signature.
+
+<CodeGroup>
+  ```shell wscat
+  $ wscat -c YOUR_CHAINSTACK_WEBSOCKET_ENDPOINT
+  # Wait for the connection to be established
+
+  Connected (press CTRL+C to quit)
+
+  > {"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["pendingLogs",{"address":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}]}
+  ```
+
+  ```javascript javascript
+  const WebSocket = require('ws');
+
+  const webSocket = new WebSocket('CHAINSTACK_WSS_URL');
+
+  async function subscribeToPendingLogs() {
+
+    const request = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_subscribe',
+      params: ['pendingLogs', {
+        address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        topics: ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef']
+      }],
+    };
+
+    const onOpen = (event) => {
+      webSocket.send(JSON.stringify(request));
+    };
+
+    const onMessage = (event) => {
+      const response = JSON.parse(event.data);
+      console.log(response);
+    };
+
+    try {
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('message', onMessage);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  subscribeToPendingLogs();
+  ```
+</CodeGroup>
+
+This will generate a continuous stream of data displaying event logs from pre-confirmed transactions matching the filter.
+
+Use [eth\_unsubscribe | Base](/reference/base-unsubscribe) to remove the subscription.
+
+## Use case
+
+The `eth_subscribe("pendingLogs")` method is useful in scenarios where you need to react to specific smart contract events with sub-second latency:
+
+* DeFi monitoring. Track swap events on DEXs like Uniswap or Aerodrome as soon as they are pre-confirmed, giving you ~1.8 seconds of advance notice compared to waiting for the full 2-second block to seal. This is valuable for arbitrage detection, liquidity monitoring, and price feed updates.
+
+* Real-time token transfer tracking. Monitor ERC-20 transfers (such as USDC or WETH) for specific addresses or contracts as they happen, enabling faster notifications for wallets, payment processors, and compliance tools.
+
+* Smart contract event indexing. Event indexers can begin processing logs from pre-confirmed transactions instead of waiting for finalized blocks, reducing the end-to-end latency of on-chain data pipelines.

--- a/reference/base-unsubscribe.mdx
+++ b/reference/base-unsubscribe.mdx
@@ -1,0 +1,85 @@
+---
+title: "eth_unsubscribe | Base"
+description: "Base API method that allows a client to unsubscribe from a specific subscription."
+---
+
+When a client subscribes to a particular event, the Base node will send updates as soon as they occur. However, in some cases, the client may no longer be interested in receiving updates for a particular event. The `eth_unsubscribe` method can be used to cancel the following subscriptions:
+
+<CardGroup>
+<Card title="eth_subscribe('newFlashblockTransactions')" href="/reference/base-subscribe-newflashblocktransactions" icon="angle-right" iconType="solid" horizontal />
+<Card title="eth_subscribe('pendingLogs')" href="/reference/base-subscribe-pendinglogs" icon="angle-right" iconType="solid" horizontal />
+<Card title="eth_subscribe('newFlashblocks')" href="/reference/base-subscribe-newflashblocks" icon="angle-right" iconType="solid" horizontal />
+</CardGroup>
+
+<Check>
+  ### Get you own node endpoint today
+
+  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+  You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `string` — the ID of the subscription that you want to cancel.
+
+## Response
+
+* `boolean` — the boolean value indicating if the subscription was removed successfully. `true` if removed successfully, `false` if not.
+
+## `eth_unsubscribe` code examples
+
+<Info>
+  Note that subscriptions require a WebSocket connection and [WebSocket cat](https://www.npmjs.com/package/wscat) for you to use this method in the console.
+
+  Install WebSocket cat with:
+
+  `npm install -g wscat`
+</Info>
+
+<CodeGroup>
+  ```shell wscat
+  $ wscat -c YOUR_CHAINSTACK_WEBSOCKET_ENDPOINT
+  # Wait for the connection to be established
+
+  Connected (press CTRL+C to quit)
+
+  > {"jsonrpc":"2.0","id":1,"method":"eth_unsubscribe","params":["0x7529626735859f32962b10b19ee2e3eb"]}
+  ```
+
+  ```javascript javascript
+  const WebSocket = require('ws');
+
+  const webSocket = new WebSocket('CHAINSTACK_WSS_URL');
+
+  async function removeSubscription() {
+
+    const request = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_unsubscribe',
+      params: ['0x9de3135dd3dd6c6b99bd104061a5af4f'],
+    };
+
+    const onOpen = (event) => {
+      webSocket.send(JSON.stringify(request));
+    };
+
+    const onMessage = (event) => {
+      const response = JSON.parse(event.data);
+      console.log(response);
+    };
+
+    try {
+      webSocket.addEventListener('open', onOpen);
+      webSocket.addEventListener('message', onMessage);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  removeSubscription();
+  ```
+</CodeGroup>
+
+This will remove the subscription matching the ID passed as a parameter.


### PR DESCRIPTION
## Summary

- Add reference pages for 3 new Flashblocks-exclusive WebSocket subscription methods on Base: `eth_subscribe newFlashblockTransactions`, `eth_subscribe pendingLogs`, `eth_subscribe newFlashblocks`
- Add `eth_unsubscribe` reference page for Base with links to all 3 subscription pages
- Add "Subscriptions | Base" group in docs.json navigation
- Update `base-methods.mdx` with the 3 new methods (marked "Flashblocks WS only")
- Update `flashblocks-on-base.mdx` guide with links to the new WS subscription methods

All 3 methods tested live against `wss://base-mainnet.core.chainstack.com` and confirmed working.

Context: [#protocols-base Slack thread](https://chainstackhq.slack.com/archives/C05EKHS8HRS/p1772551329713169) — Harsh confirmed Flashblocks WS support is deployed and tested on elastic.

## Test plan

- [ ] Verify all 4 new reference pages render correctly on Mintlify preview
- [ ] Verify "Subscriptions | Base" group appears in the sidebar under "Base node API"
- [ ] Verify internal links between subscription pages, unsubscribe page, and flashblocks-on-base guide
- [ ] Verify base-methods.mdx table renders the 3 new rows correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for four WebSocket subscription methods available on Flashblocks-enabled Base endpoints: subscribe to new flashblock transactions, pending logs, and new flashblocks, plus unsubscribe functionality. Includes parameter specifications, response structures, code examples, and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->