### PR TITLE
Fix broken internal links across 93 files

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -1191,7 +1191,7 @@ Welcome to the developer hub and documentation for Chainstack Developer Portal!
 
 - **Protocols**. Ethereum Goerli support.
 - **Role management**
-	- You can now [assign roles](/docs/manage-your-organization#invite-a-user-to-the-organization) to your organization's users and [change roles](/docs/manage-your-organization#change-a-user-role-in-the-organization) of the existing users.
+	- You can now [assign roles](/docs/manage-your-organization) to your organization's users and [change roles](/docs/manage-your-organization#change-a-user-role-in-the-organization) of the existing users.
 	- There are now three roles: [Admin, Editor, Viewer](/docs/manage-your-organization#users-and-their-roles).
 
 <Button href="/changelog/chainstack-updates-april-14-2022">Read more</Button>

--- a/changelog/chainstack-updates-april-14-2022.mdx
+++ b/changelog/chainstack-updates-april-14-2022.mdx
@@ -3,5 +3,5 @@ title: "Chainstack updates: April 14, 2022"
 ---
 - **Protocols**. Ethereum Goerli support.
 - **Role management**
-	- You can now [assign roles](/docs/manage-your-organization#invite-a-user-to-the-organization) to your organization's users and [change roles](/docs/manage-your-organization#change-a-user-role-in-the-organization) of the existing users.
+	- You can now [assign roles](/docs/manage-your-organization) to your organization's users and [change roles](/docs/manage-your-organization#change-a-user-role-in-the-organization) of the existing users.
 	- There are now three roles: [Admin, Editor, Viewer](/docs/manage-your-organization#users-and-their-roles).

--- a/docs/aptos-tutorial-publish-a-module-to-save-and-retrieve-a-message-on-aptos.mdx
+++ b/docs/aptos-tutorial-publish-a-module-to-save-and-retrieve-a-message-on-aptos.mdx
@@ -53,7 +53,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Aptos testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get node access and credentials
 

--- a/docs/arbitrum-tutorial-l1-to-l2-messaging-smart-contract.mdx
+++ b/docs/arbitrum-tutorial-l1-to-l2-messaging-smart-contract.mdx
@@ -42,7 +42,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 Deploy a node on the Ethereum Goerli testnet and a node on the Arbitrum Goerli testnet.
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get the access and credentials to your deployed nodes
 

--- a/docs/avalanche-tutorial-aavev3-flash-loans-with-hardhat.mdx
+++ b/docs/avalanche-tutorial-aavev3-flash-loans-with-hardhat.mdx
@@ -53,7 +53,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Avalanche Fuji testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Avalanche node endpoint
 

--- a/docs/base-tutorial-deploy-an-erc-721-contract-with-hardhat.mdx
+++ b/docs/base-tutorial-deploy-an-erc-721-contract-with-hardhat.mdx
@@ -54,7 +54,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia Testnet and the Base Testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Base Testnet node endpoint
 

--- a/docs/bsc-tutorial-bep-1155-contract-with-truffle-and-openzeppelin.mdx
+++ b/docs/bsc-tutorial-bep-1155-contract-with-truffle-and-openzeppelin.mdx
@@ -49,7 +49,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the BNB Smart Chain testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your BNB Smart Chain node access and credentials
 

--- a/docs/corda-operations.mdx
+++ b/docs/corda-operations.mdx
@@ -18,7 +18,7 @@ Chainstack supports joining the following Corda networks:
 * [Corda Network](https://corda.network/) — the production Corda network
 * [Corda Pre-Production Network](https://corda.network/participation/preprod) — the pre-production Corda network
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 You can also deploy your own Corda network. See [Deploy a consortium network](/docs/deploy-a-consortium-network).
 

--- a/docs/cronos-tutorial-dutch-auction-smart-contracts-on-cronos-with-hardhat.mdx
+++ b/docs/cronos-tutorial-dutch-auction-smart-contracts-on-cronos-with-hardhat.mdx
@@ -54,7 +54,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Cronos testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Cronos node endpoint
 

--- a/docs/cryo-with-chainstack-and-python.mdx
+++ b/docs/cryo-with-chainstack-and-python.mdx
@@ -36,7 +36,7 @@ Follow these steps to deploy an Ethereum node:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 

--- a/docs/cryo-your-gateway-to-blockchain-data.mdx
+++ b/docs/cryo-your-gateway-to-blockchain-data.mdx
@@ -140,7 +140,7 @@ Cryo is a high-performing tool that can send many requests per second, and the C
 Follow these steps to deploy an Ethereum node:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 To follow this guide, deploy a global Ethereum node.
 

--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -28,7 +28,7 @@ To enable debug and trace APIs on your dedicated Ethereum node, you must have a 
 * With a node running on Geth, only `debug_*`namespace is exposed.
 * With a node running on Erigon, both `debug_*` and `trace_*`namespaces are exposed.
 
-Learn how to [deploy your dedicated Ethereum node run on different clients](/reference/enable-debug-trace-apis-for-your-ethereum-node#dedicated-ethereum-node) with debug and trace APIs enabled.
+Learn how to [deploy your dedicated Ethereum node run on different clients](/reference/enable-debug-trace-apis-for-your-ethereum-node) with debug and trace APIs enabled.
 
 For the full list of the available debug and trace API methods, see:
 

--- a/docs/deep-dive-into-merkle-proofs-and-eth-getproof-ethereum-rpc-method.mdx
+++ b/docs/deep-dive-into-merkle-proofs-and-eth-getproof-ethereum-rpc-method.mdx
@@ -255,7 +255,7 @@ You can sign up and get an Ethereum RPC endpoint for free:
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/deploy-a-consortium-network.mdx
+++ b/docs/deploy-a-consortium-network.mdx
@@ -34,7 +34,7 @@ To deploy a consortium network, do the following:
     For Hyperledger Fabric and Corda, under **Identity issuer**, select or add an identity issuer. See [Manage your organization identities](/docs/manage-your-organization-identities).
   </Step>
   <Step>
-    Under **Hosting**, select **Chainstack** or **Private**. See [Supported hosting options](/docs/platform-introduction#supported-hosting-options).
+    Under **Hosting**, select **Chainstack** or **Private**. See [Supported hosting options](/docs/platform-introduction).
 
    * For Chainstack hosting, select a cloud provider and a region.
    * For private hosting, select or add an integration. See [Manage your organization integrations](/docs/manage-your-consortium-network#manage-your-organization-integrations).

--- a/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
+++ b/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
@@ -115,7 +115,7 @@ Deploy a node with Chainstack:
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/enhancing-blockchain-data-reliability-with-ethers-fallbackprovider.mdx
+++ b/docs/enhancing-blockchain-data-reliability-with-ethers-fallbackprovider.mdx
@@ -60,7 +60,7 @@ Before diving into the implementation, ensure you have a Chainstack account. Dep
 Deploy 3 or mix Chainstack and public nodes for a good demonstration. Choose different geographical regions for each to maximize network uptime and reduce latency, which is crucial for a robust and efficient blockchain application.
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
+++ b/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
@@ -140,7 +140,7 @@ Pending transaction filters notify developers when a new transaction enters the 
 Access an Ethereum node:
 
 1. [Head over to Chainstack](https://console.chainstack.com/user/account/create) and create an account.
-2. [Deploy an Ethereum Mainnet node](/docs/manage-your-networks#join-a-public-network) in Chainstack.
+2. [Deploy an Ethereum Mainnet node](/docs/manage-your-networks) in Chainstack.
 
 Set up a Node project:
 

--- a/docs/ethereum-redundant-event-llstener-ethers-web3js.mdx
+++ b/docs/ethereum-redundant-event-llstener-ethers-web3js.mdx
@@ -52,7 +52,7 @@ To start with a JavaScript development project, you'll need to install `node.js`
 With `node.js` installed, you're ready to start using JavaScript. Now, you can set up your nodes.
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/ethereum-tutorial-academic-certificates-with-truffle.mdx
+++ b/docs/ethereum-tutorial-academic-certificates-with-truffle.mdx
@@ -44,7 +44,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Ethereum node access and credentials
 

--- a/docs/ethereum-tutorial-asset-tokenization-with-embark.mdx
+++ b/docs/ethereum-tutorial-asset-tokenization-with-embark.mdx
@@ -47,7 +47,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Deploy a Sepolia node
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get Sepolia testnet ether from a faucet
 

--- a/docs/ethereum-tutorial-trust-fund-account-with-remix.mdx
+++ b/docs/ethereum-tutorial-trust-fund-account-with-remix.mdx
@@ -65,7 +65,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Ethereum node access and credentials
 

--- a/docs/ethersjs-chainstackprovider-how-to-multi-chain-wallet-balance-aggregator.mdx
+++ b/docs/ethersjs-chainstackprovider-how-to-multi-chain-wallet-balance-aggregator.mdx
@@ -64,7 +64,7 @@ Follow these steps to sign up on Chainstack, deploy a node, and find your endpoi
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/expanding-your-blockchain-horizons-the-eth_getblockreceipts-emulator.mdx
+++ b/docs/expanding-your-blockchain-horizons-the-eth_getblockreceipts-emulator.mdx
@@ -33,7 +33,7 @@ With `node.js` installed, you're ready to start using JavaScript. However, you'l
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/exploring-bitcoin-transactions-with-getrawtransaction.mdx
+++ b/docs/exploring-bitcoin-transactions-with-getrawtransaction.mdx
@@ -17,7 +17,7 @@ Before you begin testing the **`getrawtransaction`** method, it's essential to h
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/fantom-tutorial-erc-721-collection-contract-with-truffle-and-openzeppelin.mdx
+++ b/docs/fantom-tutorial-erc-721-collection-contract-with-truffle-and-openzeppelin.mdx
@@ -44,7 +44,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Fantom testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Fantom node access and credentials
 

--- a/docs/fetching-transactions-to-and-from-a-specific-address-with-eth_getblockbynumber.mdx
+++ b/docs/fetching-transactions-to-and-from-a-specific-address-with-eth_getblockbynumber.mdx
@@ -57,7 +57,7 @@ You'll need access to an RPC node to interact with a blockchain. Chainstack prov
      Try out the new [social login](https://twitter.com/ChainstackHQ/status/1709988403893223599) feature.
    </Info>
 
-2. **Deploy a node**. Once your account is set up, you can deploy an Ethereum node. Follow the [Chainstack documentation](/docs/manage-your-networks#join-a-public-network) for a step-by-step guide on how to do this.
+2. **Deploy a node**. Once your account is set up, you can deploy an Ethereum node. Follow the [Chainstack documentation](/docs/manage-your-networks) for a step-by-step guide on how to do this.
 
 3. **Access node credentials**. After deploying your node, you'll need the RPC URL to interact with the Ethereum network. You can find this information in the Chainstack dashboard. For more details, see [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 

--- a/docs/fetching-transfer-events-with-getpastevents-for-a-bayc-nft.mdx
+++ b/docs/fetching-transfer-events-with-getpastevents-for-a-bayc-nft.mdx
@@ -46,7 +46,7 @@ Bored Ape Yacht Club (BAYC) is a well-known collection of NFTs on the Ethereum b
 <CardGroup>
   <Card title="Download Node.js" href="https://nodejs.org/en/download" icon="angle-right" horizontal />
   <Card title="Web3.js Library" href="https://docs.web3js.org/" icon="angle-right" horizontal />
-  <Card title="Chainstack Ethereum Node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Chainstack Ethereum Node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
 </CardGroup>
 <Info>
   Read [Web3 node.js: From zero to a full-fledged project](/docs/web3-nodejs-from-zero-to-a-full-fledged-project) to learn how to manage a node.js project.
@@ -57,7 +57,7 @@ Bored Ape Yacht Club (BAYC) is a well-known collection of NFTs on the Ethereum b
 Follow these steps to deploy an Ethereum node:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ## Setup

--- a/docs/gnosis-tutorial-simple-soulbound-token-with-remix-and-openzeppelin.mdx
+++ b/docs/gnosis-tutorial-simple-soulbound-token-with-remix-and-openzeppelin.mdx
@@ -44,7 +44,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Gnosis Chiado testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Gnosis Chain node access and credentials
 

--- a/docs/harmony-tutorial-a-simple-metaverse-contract-with-foundry.mdx
+++ b/docs/harmony-tutorial-a-simple-metaverse-contract-with-foundry.mdx
@@ -46,7 +46,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Harmony devnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Harmony node access and credentials
 

--- a/docs/harnessing-chainlink-oracles-with-chainstack-fetching-real-time-crypto-prices-from-ethereum.mdx
+++ b/docs/harnessing-chainlink-oracles-with-chainstack-fetching-real-time-crypto-prices-from-ethereum.mdx
@@ -36,7 +36,7 @@ For our purpose, we'll use node.js alongside the web3.js library, allowing us to
 Follow these steps to deploy an Ethereum node:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ### Install web3.js

--- a/docs/implementing-jwt-validation-in-golang-for-chainstack-marketplace-integration.mdx
+++ b/docs/implementing-jwt-validation-in-golang-for-chainstack-marketplace-integration.mdx
@@ -93,7 +93,7 @@ Using a `.env` file lets you separate your configuration variables from your cod
 
 ## The Chainstack Marketplace authentication flow
 
-Before diving into the code, it's important to understand the authentication flow in the Chainstack Marketplace. The user who has purchased the integration with your application will authorize requests using their Chainstack API key. Note that this API key is not the JWT token you need to validate. To validate the API key, you must call the [Retrieve Application Token](/reference/chainstack-platform-api-retrieve-token) API.
+Before diving into the code, it's important to understand the authentication flow in the Chainstack Marketplace. The user who has purchased the integration with your application will authorize requests using their Chainstack API key. Note that this API key is not the JWT token you need to validate. To validate the API key, you must call the [Retrieve Application Token](https://api.chainstack.com/reference/#operation/retrieveToken) API.
 
 Here's an example API call to retrieve the validated JWT:
 
@@ -306,7 +306,7 @@ This is the entry point of the program. It orchestrates the other functions:
 
 ### How to run the code
 
-1. **Validate a JWT**. To validate a JWT, you'll need an authorized API key. Use the [appropriate endpoint](/reference/chainstack-platform-api-retrieve-token) to validate the API key and obtain a JWT. Note that in a production setting, you'll either need to require users to validate and send the JWT first or implement a flow in your app that validates the API key dynamically.
+1. **Validate a JWT**. To validate a JWT, you'll need an authorized API key. Use the [appropriate endpoint](https://api.chainstack.com/reference/#operation/retrieveToken) to validate the API key and obtain a JWT. Note that in a production setting, you'll either need to require users to validate and send the JWT first or implement a flow in your app that validates the API key dynamically.
 
 2. **Add JWT and audience to the script**. Once you've validated the JWT, add it to the corresponding variable inside the `main` function, along with your expected audience.
 

--- a/docs/introducing-bun-the-future-of-javascript-runtimes.mdx
+++ b/docs/introducing-bun-the-future-of-javascript-runtimes.mdx
@@ -65,7 +65,7 @@ In this guide, we'll walk you through creating a DApp designed to fetch the bala
 * A Chainstack account to deploy an Ethereum node.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 ## Getting started with the project
 

--- a/docs/manage-your-project.mdx
+++ b/docs/manage-your-project.mdx
@@ -18,7 +18,7 @@ description: "Manage your Chainstack projects for blockchain network organizatio
 
  A <Tooltip tip="A project organizes your blockchain networks and nodes.">project</Tooltip> can have more than one network.
 
- To add a network to a project, see [Join a public network](/docs/manage-your-networks#join-a-public-network).
+ To add a network to a project, see [Join a public network](/docs/manage-your-networks).
 
  ## Edit a project
 

--- a/docs/mastering-multithreading-in-python-for-web3-requests-a-comprehensive-guide.mdx
+++ b/docs/mastering-multithreading-in-python-for-web3-requests-a-comprehensive-guide.mdx
@@ -62,7 +62,7 @@ Here's what you'll need:
 * **An Ethereum archive node**. We'll interact with the Ethereum network for this guide. We'll need access to an Ethereum archive node since we’ll query older states. To get an RPC endpoint, follow these steps:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ## Creating a simple Web3 script without multithreading

--- a/docs/mesc-and-chainstack.mdx
+++ b/docs/mesc-and-chainstack.mdx
@@ -101,7 +101,7 @@ To configure the MESC CLI you'll also need some endpoints. Follow these steps to
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/oasis-sapphire-tutorial-understanding-confidential-smart-contracts-with-oasis-sapphire.mdx
+++ b/docs/oasis-sapphire-tutorial-understanding-confidential-smart-contracts-with-oasis-sapphire.mdx
@@ -70,7 +70,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia Testnet and the Oasis Sapphire Testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get endpoints for your Ethereum Sepolia Testnet and Oasis Sapphire Testnet
 

--- a/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
+++ b/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
@@ -62,7 +62,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia testnet and Optimism Goerli testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get endpoints for your Ethereum Sepolia testnet and Optimism Sepolia testnet
 

--- a/docs/polygon-tutorial-bridging-erc20-from-ethereum-to-polygon.mdx
+++ b/docs/polygon-tutorial-bridging-erc20-from-ethereum-to-polygon.mdx
@@ -45,7 +45,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Goerli testnet and the Polygon Mumbai testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Ethereum node and Polygon node access and credentials
 

--- a/docs/polygon-zkevm-tutorial-deploy-a-smart-contract-using-hardhat.mdx
+++ b/docs/polygon-zkevm-tutorial-deploy-a-smart-contract-using-hardhat.mdx
@@ -52,7 +52,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia testnet and the Polygon zkEVM testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Polygon zkEVM node endpoint
 

--- a/docs/ponder-tutorial-building-blockchain-application-backends-with-chainstack.mdx
+++ b/docs/ponder-tutorial-building-blockchain-application-backends-with-chainstack.mdx
@@ -47,7 +47,7 @@ For this tutorial, we'll index data from multiple chains. Join the following net
 * **Polygon** - for high-volume, low-cost transactions
 * **Base** - for modern L2 applications
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your node access and credentials
 

--- a/docs/ronin-tutorial-making-a-game-contract.mdx
+++ b/docs/ronin-tutorial-making-a-game-contract.mdx
@@ -62,7 +62,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ronin Saigon testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Ronin node endpoint
 

--- a/docs/scroll-tutorial-deploy-the-uniswap-v3-smart-contracts-on-scroll.mdx
+++ b/docs/scroll-tutorial-deploy-the-uniswap-v3-smart-contracts-on-scroll.mdx
@@ -50,7 +50,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Scroll Sepolia Testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your Scroll Sepolia node endpoint
 

--- a/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
+++ b/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
@@ -28,7 +28,7 @@ This system effectively allows users to bid for transaction processing priority,
 Before getting started, deploy a Solana node on Chainstack so you are ready to play with the code and examples. This will provide direct blockchain access, which is essential for effectively exploring features like the getRecentPrioritizationFees method.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 ## Understand the \`getRecentPrioritizationFees method
 

--- a/docs/solana-getaccountinfo-getmultipleaccounts.mdx
+++ b/docs/solana-getaccountinfo-getmultipleaccounts.mdx
@@ -23,7 +23,7 @@ Understanding these two methods' nuanced differences and optimal applications is
 
 Before getting started, it's essential to have access to a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with-solana/). Chainstack offers a convenient and efficient way to deploy and manage Solana nodes. Follow these detailed steps to sign up on Chainstack, deploy your node, and access your endpoint credentials:
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ## Using `getAccountInfo`

--- a/docs/solana-gettokenlargestaccounts-rpc-method.mdx
+++ b/docs/solana-gettokenlargestaccounts-rpc-method.mdx
@@ -22,7 +22,7 @@ This guide is designed to walk you through the essentials of the `getTokenLarges
 Before diving into the practical applications of the `getTokenLargestAccounts` method, you must ensure access to a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with-solana/). Chainstack provides a seamless and effective platform to deploy and manage Solana nodes. Here's how you get started:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ## `getTokenLargestAccounts` RPC method

--- a/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
+++ b/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
@@ -31,7 +31,7 @@ Deploy a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/solana-how-to-priority-fees-faster-transactions.mdx
+++ b/docs/solana-how-to-priority-fees-faster-transactions.mdx
@@ -41,7 +41,7 @@ Deploy a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/solana-how-to-use-multiple-rpc-endpoints-optimize-dapp-performance.mdx
+++ b/docs/solana-how-to-use-multiple-rpc-endpoints-optimize-dapp-performance.mdx
@@ -49,7 +49,7 @@ To interact with the Solana blockchain and execute the scripts you'll write, cer
 Deploy multiple [reliable Solana RPC endpoints](https://chainstack.com/build-better-with-solana/). Note that you need to be on a [paid plan](https://chainstack.com/pricing/) to deploy multiple nodes.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ### Installing required packages

--- a/docs/solana-tutorial-creating-a-token-and-vesting-the-token-in-your-program.mdx
+++ b/docs/solana-tutorial-creating-a-token-and-vesting-the-token-in-your-program.mdx
@@ -53,7 +53,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the devnet
 
-See Join a [public network](/docs/manage-your-networks#join-a-public-network).
+See Join a [public network](/docs/manage-your-networks).
 
 ### Get your Solana node access and credentials
 

--- a/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
+++ b/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
@@ -51,7 +51,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the Ethereum Sepolia and Starknet testnets
 
-For the L1 \<-> L2 messaging, you need access to both an Ethereum network and a Starknet network. See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+For the L1 \<-> L2 messaging, you need access to both an Ethereum network and a Starknet network. See [Join a public network](/docs/manage-your-networks).
 
 ### Get the node access and credentials
 

--- a/docs/tempo-tutorial-dex-swap-foundry.mdx
+++ b/docs/tempo-tutorial-dex-swap-foundry.mdx
@@ -28,7 +28,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 ## Deploy a Tempo node
 
 1. [Sign up with Chainstack](https://console.chainstack.com/).
-1. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+1. [Deploy a node](/docs/manage-your-networks).
 
 See also [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 

--- a/docs/tempo-tutorial-first-payment-app.mdx
+++ b/docs/tempo-tutorial-first-payment-app.mdx
@@ -30,7 +30,7 @@ A simple payment app that can:
 ## Deploy a Tempo node
 
 1. [Sign up with Chainstack](https://console.chainstack.com/).
-1. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+1. [Deploy a node](/docs/manage-your-networks).
 
 See also [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 

--- a/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
+++ b/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
@@ -184,7 +184,7 @@ Alright, now all this looks nice, but how do we actually capture these logs? Wel
   One of the most crucial components that we need in order to capture the event logs is access to an Ethereum node. To set up your own node:
 
   1. [Head over to Chainstack and set up an account](https://console.chainstack.com/user/account/create).
-  2. Once you have your account, [deploy an Ethereum mainnet node in Chainstack](/docs/manage-your-networks#join-a-public-network).
+  2. Once you have your account, [deploy an Ethereum mainnet node in Chainstack](/docs/manage-your-networks).
 </Info>
 
 As with many other functionalities of Ethereum, the method for capturing the event logs includes a [curl](https://curl.se/) way and a code way.

--- a/docs/transferring-spl-tokens-on-solana-typescript.mdx
+++ b/docs/transferring-spl-tokens-on-solana-typescript.mdx
@@ -33,7 +33,7 @@ Before diving into the process of transferring SPL tokens on the Solana blockcha
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />
-  <Card title="Deploy a node" href="/docs/manage-your-networks#join-a-public-network" icon="angle-right" horizontal />
+  <Card title="Deploy a node" href="/docs/manage-your-networks" icon="angle-right" horizontal />
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 

--- a/docs/tutorial-on-how-to-make-your-dapp-reliable-and-scalable-with-kubernetes.mdx
+++ b/docs/tutorial-on-how-to-make-your-dapp-reliable-and-scalable-with-kubernetes.mdx
@@ -274,7 +274,7 @@ Using a pre-built Docker image simplifies the deployment process, as you don't h
 At this point, let's keep in mind that this app requires an Ethereum RPC node URL and port number as environment variables. Let's use Chainstack to get an RPC node URL:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 Get the RPC URL to use as an environment variable using the `--env` flag. Now, in the terminal, run the following command:

--- a/docs/understanding-eth-getlogs-limitations.mdx
+++ b/docs/understanding-eth-getlogs-limitations.mdx
@@ -135,7 +135,7 @@ Let’s take it a step further and show an example of how we can fetch and store
 
 * node.js
 * MongoDB Atlas account with database setup and dedicated account to it
-* [Chainstack Ethereum node](/docs/manage-your-networks#join-a-public-network)
+* [Chainstack Ethereum node](/docs/manage-your-networks)
 
 ### Setup
 

--- a/docs/zksync-tutorial-develop-a-custom-paymaster-contract.mdx
+++ b/docs/zksync-tutorial-develop-a-custom-paymaster-contract.mdx
@@ -71,7 +71,7 @@ See [Create a project](/docs/manage-your-project#create-a-project).
 
 ### Join the zkSync Era Sepolia Testnet
 
-See [Join a public network](/docs/manage-your-networks#join-a-public-network).
+See [Join a public network](/docs/manage-your-networks).
 
 ### Get your zkSync Era Sepolia Testnet node endpoint
 

--- a/recipes/extract-randao-value-from-the-ethereum-beacon-chain-using-the-block-details-method-1.mdx
+++ b/recipes/extract-randao-value-from-the-ethereum-beacon-chain-using-the-block-details-method-1.mdx
@@ -9,7 +9,7 @@ description: "This script extracts the 'randao' information from the Beacon chai
   You will need a Chainstack account and an Ethereum node to follow this recipe.
 
   1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-  2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+  2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
   3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
   </Accordion>

--- a/recipes/fetching-polygon-logs-for-an-address-from-a-block-using-eth_gettransactionreceiptsbyblock-and-web3py.mdx
+++ b/recipes/fetching-polygon-logs-for-an-address-from-a-block-using-eth_gettransactionreceiptsbyblock-and-web3py.mdx
@@ -21,7 +21,7 @@ Create a new directory for your project, then install the web3.py library:
 You will need a Chainstack account and a Polygon full node to run this code.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
 </Accordion>

--- a/recipes/how-to-get-erc-20-token-transfer-logs-using-ethersjs.mdx
+++ b/recipes/how-to-get-erc-20-token-transfer-logs-using-ethersjs.mdx
@@ -9,7 +9,7 @@ description: "This recipe shows you how to use the Ethers library with a Chainst
   You will need a Chainstack account and an Ethereum node to follow this recipe.
 
   1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
   </Accordion>

--- a/recipes/how-to-transfer-the-entire-account-balance-using-web3js.mdx
+++ b/recipes/how-to-transfer-the-entire-account-balance-using-web3js.mdx
@@ -27,7 +27,7 @@ To run this code, you will need a Chainstack account and an Ethereum Sepolia nod
 > The same code will work with any EVM-compatible chain.
 
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-[Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
 </Accordion>

--- a/recipes/identify-if-a-block-has-been-included-in-the-main-chain-or-was-forked-1.mdx
+++ b/recipes/identify-if-a-block-has-been-included-in-the-main-chain-or-was-forked-1.mdx
@@ -9,7 +9,7 @@ description: "This script uses web3.js to evaluate whether a specific block with
 You will need a Chainstack account and an EVM-compatible node to follow this recipe.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 </Accordion>
 <Accordion title="Environment setup" >

--- a/recipes/monitor-incoming-transactions-to-an-ethereum-address-in-real-time-using-subscriptions-and-web3js.mdx
+++ b/recipes/monitor-incoming-transactions-to-an-ethereum-address-in-real-time-using-subscriptions-and-web3js.mdx
@@ -23,7 +23,7 @@ Create a new directory for your project, then install the web3.js library:
 To run this code, you will need a Chainstack account and an Ethereum archive node.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
 </Accordion>

--- a/recipes/send-batch-requests-using-ethersjs.mdx
+++ b/recipes/send-batch-requests-using-ethersjs.mdx
@@ -53,7 +53,7 @@ The code does the following:
 You will need a Chainstack account and an Ethereum node to run this code.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 </Accordion>
 <Accordion title="Run the code">

--- a/recipes/send-simultaneous-blockchain-requests-using-web3js.mdx
+++ b/recipes/send-simultaneous-blockchain-requests-using-web3js.mdx
@@ -24,7 +24,7 @@ Create a new directory for your project, then install the web3.js library:
 To run this code, you will need a Chainstack account and an Ethereum archive node.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 </Accordion>
 <Accordion title="The code">

--- a/recipes/send-solana-transactions-using-solanaweb3js.mdx
+++ b/recipes/send-solana-transactions-using-solanaweb3js.mdx
@@ -21,7 +21,7 @@ Create a new directory for your project, then install the `solana/web3.js` and `
 To run this code, you will need a Chainstack account and a Solana Elastic node.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 3. [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
 </Accordion>

--- a/recipes/simulate-a-buy-swap-on-uniswap-using-web3js.mdx
+++ b/recipes/simulate-a-buy-swap-on-uniswap-using-web3js.mdx
@@ -14,7 +14,7 @@ description: "Learn how to use `eth_call` to simulate Uniswap swaps."
   Following this recipe, you will need a Chainstack account and an Ethereum node.
 
   [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-  [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+  [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
   [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
 
   </Accordion>

--- a/reference/arbitrum-getting-started.mdx
+++ b/reference/arbitrum-getting-started.mdx
@@ -44,7 +44,7 @@ Follow these steps to sign up on Chainstack, deploy an Arbitrum RPC node, and fi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/avalanche-getting-started.mdx
+++ b/reference/avalanche-getting-started.mdx
@@ -40,7 +40,7 @@ Follow these steps to sign up on Chainstack, deploy an Avalanche RPC node, and f
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/base-api-reference.mdx
+++ b/reference/base-api-reference.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy a BASE RPC node, and find yo
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/beacon-chain.mdx
+++ b/reference/beacon-chain.mdx
@@ -23,7 +23,7 @@ Follow these steps to sign up on Chainstack, deploy an Ethereum RPC node, and fi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/bitcoin-rpc-methods-postman-collection.mdx
+++ b/reference/bitcoin-rpc-methods-postman-collection.mdx
@@ -26,7 +26,7 @@ Follow these steps to sign up on Chainstack, deploy a Bitcoin RPC node, and find
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/blockchain-apis.mdx
+++ b/reference/blockchain-apis.mdx
@@ -67,7 +67,7 @@ Follow these steps to sign up on Chainstack, deploy a node, and find your endpoi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/ethereum-getting-started.mdx
+++ b/reference/ethereum-getting-started.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy an Ethereum RPC node, and fi
     [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
   </Step>
   <Step>
-    [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+    [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
   </Step>
   <Step>
     [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/ethereum-rpc-methods-postman-collection.mdx
+++ b/reference/ethereum-rpc-methods-postman-collection.mdx
@@ -26,7 +26,7 @@ Follow these steps to sign up on Chainstack, deploy an Ethereum RPC node, and fi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/ethersjs-chainstackprovider.mdx
+++ b/reference/ethersjs-chainstackprovider.mdx
@@ -76,7 +76,7 @@ Follow these steps to sign up on Chainstack, deploy a node, and find your endpoi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](https://docs.chainstack.com/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-aurora.mdx
+++ b/reference/getting-started-aurora.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on the Aurora platform, deploy an Aurora RPC node,
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-bnb-chain.mdx
+++ b/reference/getting-started-bnb-chain.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy a BNB Chain RPC node, and fi
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-cronos.mdx
+++ b/reference/getting-started-cronos.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy a Cronos RPC node, and obtai
 [Sign up with Chainstack](https://console.fantom.foundation/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-fantom.mdx
+++ b/reference/getting-started-fantom.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy a Fantom RPC node, and obtai
 [Sign up with Chainstack](https://console.fantom.foundation/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-ronin.mdx
+++ b/reference/getting-started-ronin.mdx
@@ -45,7 +45,7 @@ Follow these steps to sign up on Chainstack, deploy a Ronin RPC node, and find y
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-starknet.mdx
+++ b/reference/getting-started-starknet.mdx
@@ -105,7 +105,7 @@ Follow these steps to deploy a Starknet RPC node, and find your endpoint credent
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-ton.mdx
+++ b/reference/getting-started-ton.mdx
@@ -58,7 +58,7 @@ Follow these steps to sign up on Chainstack, deploy a TON node, and find your en
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/getting-started-zksync.mdx
+++ b/reference/getting-started-zksync.mdx
@@ -32,7 +32,7 @@ Follow these steps to sign up on Chainstack, deploy a ZKsync RPC node, and find 
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/gnosis-getting-started.mdx
+++ b/reference/gnosis-getting-started.mdx
@@ -31,7 +31,7 @@ Follow these steps to sign up on Chainstack, deploy a Gnosis Chain RPC node, and
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/hyperliquid-getting-started.mdx
+++ b/reference/hyperliquid-getting-started.mdx
@@ -44,7 +44,7 @@ To use the Hyperliquid API, you need access to a Hyperliquid node endpoint.
 Follow these steps to sign up on Chainstack, deploy a Hyperliquid node, and find your endpoint credentials:
 
 1. [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
-2. [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+2. [Deploy a node](/docs/manage-your-networks).
 3. [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 Now you are ready to connect to the Hyperliquid blockchain and use the Hyperliquid API to build trading applications.

--- a/reference/monad-getting-started.mdx
+++ b/reference/monad-getting-started.mdx
@@ -35,7 +35,7 @@ Follow these steps to sign up on Chainstack, deploy a Monad RPC node, and find y
     [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
   </Step>
   <Step>
-    [Deploy a node](/docs/manage-your-networks#join-a-public-network).
+    [Deploy a node](/docs/manage-your-networks).
   </Step>
   <Step>
     [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/polygon-getting-started.mdx
+++ b/reference/polygon-getting-started.mdx
@@ -37,7 +37,7 @@ Follow these steps to sign up on Chainstack, deploy a Polygon RPC node, and find
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/solana-getprogramaccounts.mdx
+++ b/reference/solana-getprogramaccounts.mdx
@@ -300,7 +300,7 @@ A practical use case for `getProgramAccounts` is to retrieve the current state o
 * Building a local index of program state for analytics or monitoring
 * Tracking account changes over time by combining `getProgramAccounts` with `withContext` for slot-consistent snapshots
 
-For real-time account monitoring, consider [Solana Geyser with Yellowstone gRPC](/docs/solana-listening-for-pump-fun-migrations-to-raydium-using-geyser) as a streaming alternative.
+For real-time account monitoring, consider [Solana Geyser with Yellowstone gRPC](/docs/yellowstone-grpc-geyser-plugin) as a streaming alternative.
 
 ## Performance tips
 

--- a/reference/solana-getting-started.mdx
+++ b/reference/solana-getting-started.mdx
@@ -45,7 +45,7 @@ Follow these steps to sign up on Chainstack, deploy a Solana RPC node, and find 
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/tempo-getting-started.mdx
+++ b/reference/tempo-getting-started.mdx
@@ -62,7 +62,7 @@ Tempo supports all standard Ethereum JSON-RPC methods plus Tempo-specific extens
 To use the Tempo API, you need access to a Tempo RPC node.
 
 1. [Sign up with Chainstack](https://console.chainstack.com/).
-1. [Deploy a Tempo node](/docs/manage-your-networks#join-a-public-network).
+1. [Deploy a Tempo node](/docs/manage-your-networks).
 1. Use your Chainstack endpoint in your applications.
 
 See also [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/tron-api-reference.mdx
+++ b/reference/tron-api-reference.mdx
@@ -43,7 +43,7 @@ Follow these steps to sign up on Chainstack, deploy a TRON RPC node, and find yo
 [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).

--- a/reference/zkevm-getting-started.mdx
+++ b/reference/zkevm-getting-started.mdx
@@ -39,7 +39,7 @@ Follow these steps to sign up on Chainstack, deploy a zkEVM RPC node, and find y
 [Sign up with Chainstack]().
 </Step>
 <Step>
-[Deploy a node](/docs/manage-your-networks#join-a-public-network).
+[Deploy a node](/docs/manage-your-networks).
 </Step>
 <Step>
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).


### PR DESCRIPTION
## Summary

- Remove dead `#join-a-public-network` anchor from 87 files — heading was removed from `manage-your-networks.mdx` during a page restructure
- Remove 3 other dead anchors: `#invite-a-user-to-the-organization`, `#supported-hosting-options`, `#dedicated-ethereum-node`
- Fix 2 broken page links: `/reference/chainstack-platform-api-retrieve-token` → external API reference URL; wrong Geyser slug → `/docs/yellowstone-grpc-geyser-plugin`

## Test plan

- [x] `mintlify broken-links` returns **0 broken links** (was 3)
- [x] `mintlify broken-links --check-anchors` drops from 87 → 4 (remaining 4 are false positives from Mintlify dots-in-headings bug [#178](https://github.com/mintlify/docs/issues/178))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation hyperlinks throughout tutorials, guides, and reference pages to point to broader page destinations instead of specific section anchors, improving navigation consistency.
  * Adjusted external API reference links in select documentation files to use direct URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->