### PR TITLE
Fix indentation on eth_call BNB Chain page

### DIFF
--- a/reference/bnb-ethcall.mdx
+++ b/reference/bnb-ethcall.mdx
@@ -34,11 +34,11 @@ The interactive example in this page uses `eth_call` to call the `getOwner()` me
   + `value` — (optional) the value sent with this transaction, encoded as hexadecimal.
   + `data` — (optional) additional data to be sent with the call, usually used to invoke functions from smart contracts as a string of the hash of the method signature and encoded parameters. See the [Ethereum Contract ABI](https://solidity.readthedocs.io/en/latest/abi-spec.html).
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
-* `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
-* `safe`—the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
-* `finalized`—the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
-* `earliest` — the earliest available or genesis block.
-* `pending`—the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
+  + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
+  + `safe` —the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
+  + `finalized` —the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
+  + `earliest` — the earliest available or genesis block.
+  + `pending` —the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
 See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).


### PR DESCRIPTION
## Summary

- Fixes broken indentation for block tag sub-items (`latest`, `safe`, `finalized`, `earliest`, `pending`) under `quantity or tag` on the `eth_call | BNB Chain` API reference page
- Items were rendered as top-level bullets instead of nested children — changed `*` to indented `+` to match the pattern used for `object` sub-items above

Reported by Ilias in #product-docs.

## Test plan

- [ ] Verify on Mintlify preview that the block tag options render as nested sub-items under `quantity or tag`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and structure of API parameter documentation for better readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->