### PR TITLE
Fix block tag indentation on 4 more reference pages

### DIFF
--- a/reference/aurora-ethcall.mdx
+++ b/reference/aurora-ethcall.mdx
@@ -36,11 +36,11 @@ You can use the [Chainstack EVM Knife](https://web3tools.chainstacklabs.com/gene
   + `value` — (optional) the value sent with this transaction, encoded as hexadecimal.
   + `data` — (optional) additional data to be sent with the call, usually used to invoke functions from smart contracts as a string of the hash of the method signature and encoded parameters. See the [Ethereum Contract ABI](https://solidity.readthedocs.io/en/latest/abi-spec.html).
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
-* `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
-* `safe`—the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
-* `finalized`—the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
-* `earliest` — the earliest available or genesis block.
-* `pending`—the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
+  + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
+  + `safe` —the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
+  + `finalized` —the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
+  + `earliest` — the earliest available or genesis block.
+  + `pending` —the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
 See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).

--- a/reference/bnb-getblocktransactioncountbynumber.mdx
+++ b/reference/bnb-getblocktransactioncountbynumber.mdx
@@ -17,11 +17,11 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 ## Parameters
 
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
-* `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
-* `safe`—the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
-* `finalized`—the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
-* `earliest` — the earliest available or genesis block.
-* `pending`—the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
+  + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
+  + `safe` —the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
+  + `finalized` —the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
+  + `earliest` — the earliest available or genesis block.
+  + `pending` —the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
 See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).

--- a/reference/cronos-ethcall.mdx
+++ b/reference/cronos-ethcall.mdx
@@ -36,11 +36,11 @@ You can use the [Chainstack EVM Knife](https://web3tools.chainstacklabs.com/gene
   + `value` — (optional) the value sent with this transaction, encoded as hexadecimal.
   + `data` — (optional) additional data to be sent with the call, usually used to invoke functions from smart contracts as a string of the hash of the method signature and encoded parameters. See the [Ethereum Contract ABI](https://solidity.readthedocs.io/en/latest/abi-spec.html).
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
-* `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
-* `safe`—the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
-* `finalized`—the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
-* `earliest` — the earliest available or genesis block.
-* `pending`—the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
+  + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
+  + `safe` —the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
+  + `finalized` —the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
+  + `earliest` — the earliest available or genesis block.
+  + `pending` —the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
 See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).

--- a/reference/fantom-ethcall.mdx
+++ b/reference/fantom-ethcall.mdx
@@ -34,11 +34,11 @@ The interactive example in this page uses `eth_call` to call the `totalSupply()`
   + `value` — (optional) the value sent with this transaction, encoded as hexadecimal.
   + `data` — (optional) additional data to be sent with the call, usually used to invoke functions from smart contracts as a string of the hash of the method signature and encoded parameters. See the [Ethereum Contract ABI](https://solidity.readthedocs.io/en/latest/abi-spec.html).
 * `quantity or tag` — the integer of a block encoded as hexadecimal or the string with:
-* `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
-* `safe`—the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
-* `finalized`—the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
-* `earliest` — the earliest available or genesis block.
-* `pending`—the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
+  + `latest` — the most recent block in the blockchain and the current state of the blockchain at the most recent block. A chain reorganization is to be expected.
+  + `safe` —the block that received justification from the beacon chain. Although this block could be involved in a chain reorganization, it would necessitate either a coordinated attack by the majority of validators or severe propagation latency.
+  + `finalized` —the block accepted as canonical by more than 2/3 of the validators. A chain reorganization is extremely unlikely, requiring burning at least 1/3 of the staked amount.
+  + `earliest` — the earliest available or genesis block.
+  + `pending` —the pending state and transactions block. This is the current state of transactions that have been broadcast to the network but have not yet been included in a block.
 
 <Note>
 See the [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block).


### PR DESCRIPTION
## Summary

- Follow-up to #314 — fixes the same broken indentation for block tag sub-items (`latest`, `safe`, `finalized`, `earliest`, `pending`) under `quantity or tag`
- Affected pages: `eth_call` (Fantom, Cronos, Aurora), `eth_getBlockTransactionCountByNumber` (BNB Chain)

## Test plan

- [ ] Verify on Mintlify preview that block tag options render as nested sub-items under `quantity or tag` on all 4 pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference documentation formatting across multiple API reference pages to improve consistency and readability of parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->