### PR TITLE
PROD1378-self-hosted-v1.6.0 changelog, add day to the release notes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3746,8 +3746,9 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-2026",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-0-0-january-28-2026"
             ]
           }

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chainstack Self-Hosted v1.4.6: April 2026"
+title: "Chainstack Self-Hosted v1.4.6: April 6, 2026"
 description: "Snapshot bootstrapping, integrated monitoring, cpctl improvements, and more"
 ---
 

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chainstack Self-Hosted v1.5.0: April 2026"
+title: "Chainstack Self-Hosted v1.5.0: April 10, 2026"
 description: "Unified deployment progress view, dark mode for the Control Panel, reduced frontend bundle size, and Reth v1.11.3 support."
 ---
 

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026.mdx
@@ -1,0 +1,18 @@
+---
+title: "Chainstack Self-Hosted v1.6.0: April 10, 2026"
+description: "Named deployments let you assign a human-readable label to each node deployment, making multi-node installations easier to manage."
+---
+
+## Named deployments
+
+Node deployments now support a human-readable name. In installations running many nodes across different networks or environments, the name gives you a stable, recognizable label to distinguish deployments beyond their auto-generated identifiers. The name is stored with the deployment and surfaced through the API, and forms the groundwork for richer labeling and filtering in future releases.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v2.2.0 |
+| cp-deployments-api | v0.31.0 |
+| cp-workflows | v1.11.0 |
+| cp-auth | v0.4.2 |
+| cp-bolt | v1.8.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,18 +6,25 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
-<Update label="Chainstack Self-Hosted v1.5.0: April 2026" description="">
+<Update label="Chainstack Self-Hosted v1.6.0: April 10, 2026" description="">
+
+This release adds a human-readable name field to node deployments, making it easier to identify and manage nodes in multi-node installations.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack Self-Hosted v1.5.0: April 10, 2026" description="">
 
 This release redesigns node deployment progress into a unified timeline, adds dark mode to the Control Panel, reduces the frontend bundle size from roughly 1,900 KiB to 57 KiB, and adds support for Reth v1.11.3.
 
-<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-2026">Read more</Button>
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026">Read more</Button>
 </Update>
 
-<Update label="Chainstack Self-Hosted v1.4.6: April 2026" description="">
+<Update label="Chainstack Self-Hosted v1.4.6: April 6, 2026" description="">
 
 Snapshot-based node bootstrapping, integrated monitoring stack (VictoriaMetrics, Grafana, blockchain-node-exporter), cpctl interactive shell and upgrade command.
 
-<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-2026">Read more</Button>
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026">Read more</Button>
 </Update>
 
 <Update label="Chainstack Self-Hosted v1.0.0: January 28, 2026" description="">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated Chainstack Self-Hosted release notes with specific release dates for v1.4.6 (April 6) and v1.5.0 (April 10)

## New Features
- Added Chainstack Self-Hosted v1.6.0 release with named deployments feature, enabling node deployments to store and expose human-readable names via API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->