### PR TITLE
Add Hyperliquid testnet archive, WS, and D&T support

### DIFF
--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -150,9 +150,9 @@ For the full list of the available debug and trace API methods, see [Debug names
 
 ### Hyperliquid
 
-To enable debug and trace APIs on your Hyperliquid HyperEVM mainnet node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [global node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Hyperliquid HyperEVM node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [global node](/docs/global-elastic-node).
 
-The HyperEVM supports standard Ethereum debug and trace APIs, allowing you to debug smart contracts and trace transactions on Hyperliquid's EVM-compatible layer.
+Debug and trace APIs are available on both mainnet and testnet. The HyperEVM supports standard Ethereum debug and trace APIs, allowing you to debug smart contracts and trace transactions on Hyperliquid's EVM-compatible layer.
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 

--- a/docs/hyperliquid-tooling.mdx
+++ b/docs/hyperliquid-tooling.mdx
@@ -98,7 +98,7 @@ Use your Chainstack Hyperliquid JSON-RPC endpoint to retrieve the EVM chain stat
 
 ### Debug & Trace APIs
 
-Hyperliquid HyperEVM mainnet supports debug and trace APIs for smart contract debugging and transaction tracing. To enable these APIs, deploy a [global node](/docs/global-elastic-node) with debug & trace APIs enabled. See [Debug & Trace APIs](/docs/debug-and-trace-apis#hyperliquid) for more information.
+Hyperliquid HyperEVM supports debug and trace APIs on both mainnet and testnet for smart contract debugging and transaction tracing. To enable these APIs, deploy a [global node](/docs/global-elastic-node) with debug & trace APIs enabled. See [Debug & Trace APIs](/docs/debug-and-trace-apis#hyperliquid) for more information.
 
 ## Hyperliquid system transactions
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -37,7 +37,7 @@ description: "This page lists all the supported networks that you can use to dep
 | Hashkey | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-hashkey/#request) |
 | Hedera | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Hemi | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Hyperliquid | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Hyperliquid | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Ink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-ink/#request) |
 | Kaia | Elastic, Dedicated | Full | Full | Kairos Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Katana | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-katana/#request) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1100,6 +1100,11 @@
                   "mode": "Full",
                   "debug_trace": false,
                   "warp_transactions": false
+                },
+                {
+                  "mode": "Archive",
+                  "debug_trace": true,
+                  "warp_transactions": false
                 }
               ]
             }

--- a/reference/hyperliquid-getting-started.mdx
+++ b/reference/hyperliquid-getting-started.mdx
@@ -49,3 +49,11 @@ Follow these steps to sign up on Chainstack, deploy a Hyperliquid node, and find
 
 Now you are ready to connect to the Hyperliquid blockchain and use the Hyperliquid API to build trading applications.
 
+## Networks
+
+Chainstack supports both Hyperliquid mainnet and testnet with full and archive node modes, WebSocket connections, and debug & trace APIs.
+
+<Note>
+On testnet, archive data is available starting from block `34112653`. Queries for blocks before this height will not return historical state.
+</Note>
+


### PR DESCRIPTION
## Summary

- Hyperliquid testnet now supports **archive** mode, **WebSocket** connections, and **debug & trace** APIs — matching mainnet capabilities
- First supported archive block on testnet: `34112653`
- Tracks [CORE-14034](https://chainstack.myjetbrains.com/youtrack/issue/CORE-14034)

### Files changed

- `protocols-networks.mdx` — testnet elastic support: Full → Full, Archive
- `node-options-master-list.json` — added Archive + D&T deployment option for testnet
- `debug-and-trace-apis.mdx` — removed mainnet-only qualifier, noted both networks
- `hyperliquid-tooling.mdx` — same mainnet-only qualifier fix
- `hyperliquid-getting-started.mdx` — new Networks section with testnet archive note

## Test plan

- [ ] Verify protocols-networks table renders correctly with the new Archive column value
- [ ] Confirm the Note component renders on the getting-started reference page
- [ ] Check debug-and-trace-apis anchor link `#hyperliquid` still resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hyperliquid HyperEVM documentation terminology
  * Debug and trace APIs now available on both mainnet and testnet
  * Testnet now supports Full, Archive, and Testnet node modes
  * Added Networks section documenting available node configurations and connectivity options
  * Added note clarifying testnet archive state availability starting at block 34,112,653

<!-- end of auto-generated comment: release notes by coderabbit.ai -->