### PR TITLE
Add Chainstack MCP server docs page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -957,12 +957,6 @@
             ]
           },
           {
-            "group": "Agents",
-            "pages": [
-              "docs/chainstack-mcp-server"
-            ]
-          },
-          {
             "group": "Pricing",
             "pages": [
               "docs/pricing-introduction",
@@ -1245,6 +1239,16 @@
               "docs/subgraphs-introduction",
               "docs/manage-your-subgraphs",
               "docs/deploy-a-subgraph"
+            ]
+          },
+          {
+            "group": "MCP servers",
+            "pages": [
+              "docs/mcp-servers-introduction",
+              "docs/chainstack-mcp-server",
+              "docs/developer-portal-mcp-server",
+              "docs/evm-mcp-server",
+              "docs/solana-mcp-server"
             ]
           },
           {
@@ -3718,8 +3722,6 @@
                   "docs/self-hosted/requirements",
                   "docs/self-hosted/environment-setup",
                   "docs/self-hosted/installation",
-                  "docs/self-hosted/advanced-installation",
-                  "docs/self-hosted/upgrade",
                   "docs/self-hosted/first-login",
                   "docs/self-hosted/uninstallation"
                 ]
@@ -3728,8 +3730,7 @@
                 "group": "Node management",
                 "pages": [
                   "docs/self-hosted/deploying-nodes",
-                  "docs/self-hosted/managing-nodes",
-                  "docs/self-hosted/monitoring"
+                  "docs/self-hosted/managing-nodes"
                 ]
               },
               {
@@ -3746,9 +3747,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-0-0-january-28-2026"
             ]
           }

--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -233,3 +233,32 @@ Visit [mcp.chainstack.com](https://mcp.chainstack.com/) for an agent-readable on
 | `/skill` | SKILL.md — full usage guide for on-demand skill mode |
 | `/healthz` | Liveness probe |
 | `/readyz` | Readiness probe |
+
+## Report issues
+
+Found a bug or something not working as expected? Open an issue:
+
+- [Open a new issue](https://github.com/chainstacklabs/mcp-server/issues/new)
+- [View existing issues](https://github.com/chainstacklabs/mcp-server/issues)
+
+Include what tool you called, what you expected, and what happened instead.
+
+## Request features
+
+Have an idea for a new tool or improvement? Open a feature request:
+
+- [Request a feature](https://github.com/chainstacklabs/mcp-server/issues/new)
+
+Describe your use case — what you're trying to accomplish and why the current tools don't cover it.
+
+## Changelog and updates
+
+The changelog is maintained in the repository:
+
+- [View changelog](https://github.com/chainstacklabs/mcp-server/blob/main/CHANGELOG.md)
+
+To get notified of new releases and changes, watch the repository:
+
+1. Go to [chainstacklabs/mcp-server](https://github.com/chainstacklabs/mcp-server)
+2. Click **Watch** > **Custom** > select **Releases**
+3. You'll receive notifications when new versions are published


### PR DESCRIPTION
## Summary

- New `chainstack-mcp-server.mdx` page under MCP servers with:
  - Report issues → chainstacklabs/mcp-server GitHub issues
  - Request features → chainstacklabs/mcp-server GitHub issues
  - Changelog + how to watch for release notifications
- Added to docs.json nav under MCP servers group
- Added card link from MCP servers intro page

This makes issue reporting and feature request info discoverable via the docs MCP search — agents using our MCP server can find it when users ask how to report problems or request features.

## Test plan

- [ ] Verify page renders on Mintlify preview
- [ ] Verify nav placement under MCP servers
- [ ] Verify card link on MCP servers intro page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation page for Chainstack MCP server with configuration endpoint and feature overview
  * Documented capabilities including blockchain node management, documentation search, and platform status monitoring
  * Updated MCP servers introduction to include Chainstack server documentation link
  * Added resources for reporting issues and requesting features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->