### PR TITLE
Fix Self-Hosted release notes navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3747,7 +3747,9 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
-              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-4-6-april-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-0-0-january-28-2026"
             ]
           }


### PR DESCRIPTION
## Summary

- Add missing v1.6.0 and v1.5.0 changelog entries to the Self-Hosted Release notes tab in `docs.json`
- Fix v1.4.6 slug: `april-2026` → `april-6-2026` (was causing a 404 on "Read more" click-through)

## Test plan

- [ ] Verify the Self-Hosted Release notes sidebar shows all four entries (v1.6.0, v1.5.0, v1.4.6, v1.0.0)
- [ ] Verify clicking "Read more" on each entry resolves to the correct changelog page (no 404s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Self-Hosted Release notes page with new changelog entries for versions 1.6.0, 1.5.0, and 1.4.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->