### PR TITLE
Solana docs: P0 fixes, complete API reference, enriched methods table

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1133,6 +1133,7 @@
                   "docs/solana-estimate-priority-fees-getrecentprioritizationfees",
                   "docs/solana-how-to-use-multiple-rpc-endpoints-optimize-dapp-performance",
                   "docs/solana-how-to-handle-the-transaction-expiry-error",
+                  "docs/solana-address-lookup-tables",
                   "docs/solana-agave-20-upgrade-reference",
                   "docs/understanding-the-difference-between-blocks-and-slots-on-solana",
                   "docs/solana-optimize-your-getblock-performance",

--- a/docs/enhancing-solana-spl-token-transfers-with-retry-logic.mdx
+++ b/docs/enhancing-solana-spl-token-transfers-with-retry-logic.mdx
@@ -11,14 +11,14 @@ description: Add retry logic to Solana SPL token transfers using transaction con
 
 ## Main article
 
-The [previous article](https://dash.readme.com/project/chainstack/v1.0/docs/transferring-spl-tokens-on-solana-typescript) explored transferring SPL tokens on the Solana blockchain using TypeScript. While the provided code successfully demonstrated the token transfer process, it lacked retry logic—a crucial aspect for handling potential failures and retrying failed transactions in blockchain applications.
+The [previous article](/docs/transferring-spl-tokens-on-solana-typescript) explored transferring SPL tokens on the Solana blockchain using TypeScript. While the provided code successfully demonstrated the token transfer process, it lacked retry logic—a crucial aspect for handling potential failures and retrying failed transactions in blockchain applications.
 
 Retry logic helps mitigate the impact of transient network issues or node overload by automatically retrying failed transactions multiple times. This approach increases the likelihood of successful execution, ensuring better reliability and improving the overall user experience.
 
 This guide will extend the existing codebase by adding a simple retry logic to the token transfer process. We will discuss why retries are needed, explore different error scenarios, and implement a straightforward retry mechanism. Incorporating retry logic will make our application more resilient to temporary network problems, laying the foundation for further improvements in robustness and performance.
 
 <Info>
-  Read [Transferring SPL tokens on Solana: A step-by-step TypeScript tutorial](https://dash.readme.com/project/chainstack/v1.0/docs/transferring-spl-tokens-on-solana-typescript) to find the full code base and learn how it works.
+  Read [Transferring SPL tokens on Solana: A step-by-step TypeScript tutorial](/docs/transferring-spl-tokens-on-solana-typescript) to find the full code base and learn how it works.
 </Info>
 
 ## Understanding the need for retry logic

--- a/docs/solana-address-lookup-tables.mdx
+++ b/docs/solana-address-lookup-tables.mdx
@@ -1,0 +1,287 @@
+---
+title: "Solana: Address lookup tables"
+description: Use address lookup tables to fit more accounts into Solana transactions and overcome the 1232-byte size limit when building complex multi-instruction transactions.
+---
+
+**TLDR:**
+* Solana transactions are capped at 1232 bytes, which limits the number of accounts a single transaction can reference.
+* Address lookup tables (ALTs) let you store frequently used addresses on-chain and reference them by index instead of including the full 32-byte public key in every transaction.
+* With ALTs, a versioned transaction (v0) can reference up to 256 accounts per table—enough for complex DeFi interactions, Jupiter swaps, and multi-program calls.
+* This guide walks you through creating a lookup table, adding addresses, and using it in a versioned transaction.
+
+## Why you need address lookup tables
+
+Every Solana transaction has a hard 1232-byte size limit. Each account address takes 32 bytes, so a transaction with ~30 accounts already exhausts most of the budget before adding instructions. You will hit this limit when:
+
+* Performing Jupiter or Raydium swaps that route through multiple pools
+* Building multi-instruction transactions (swap + transfer + memo)
+* Interacting with programs that require many accounts (Serum/OpenBook order books, Meteora DLMM)
+
+The error looks like:
+
+```
+Transaction too large: XXXX > 1232
+```
+
+Address lookup tables solve this by storing addresses on-chain. Instead of embedding the full 32-byte key, the transaction references a table address and a 1-byte index—saving 31 bytes per account.
+
+<Check>
+### Get your own node endpoint today
+
+  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+  You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Prerequisites
+
+* A Chainstack Solana node endpoint. [Deploy one](https://console.chainstack.com/).
+* Node.js 18+
+* A funded Solana wallet (creating a lookup table costs ~0.003 SOL in rent)
+
+### Project setup
+
+```bash
+mkdir solana-alt && cd solana-alt
+npm init -y
+npm install @solana/web3.js dotenv
+npm install --save-dev ts-node typescript
+npx tsc --init
+touch main.ts .env
+```
+
+Add your credentials to `.env`:
+
+```
+SOLANA_RPC=YOUR_CHAINSTACK_ENDPOINT
+PRIVATE_KEY=your_base58_private_key
+```
+
+## Create a lookup table
+
+A lookup table is an on-chain account that holds a list of public keys. You create one with `createLookupTable`, which returns the table address and a creation instruction.
+
+<CodeGroup>
+  ```typescript TypeScript
+  import {
+    Connection,
+    Keypair,
+    AddressLookupTableProgram,
+    TransactionMessage,
+    VersionedTransaction,
+  } from "@solana/web3.js";
+  import bs58 from "bs58";
+  import "dotenv/config";
+
+  const connection = new Connection(process.env.SOLANA_RPC!);
+  const payer = Keypair.fromSecretKey(bs58.decode(process.env.PRIVATE_KEY!));
+
+  async function createLookupTable(): Promise<string> {
+    const slot = await connection.getSlot();
+
+    const [createInstruction, lookupTableAddress] =
+      AddressLookupTableProgram.createLookupTable({
+        authority: payer.publicKey,
+        payer: payer.publicKey,
+        recentSlot: slot,
+      });
+
+    const latestBlockhash = await connection.getLatestBlockhash();
+
+    const message = new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions: [createInstruction],
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(message);
+    transaction.sign([payer]);
+
+    const txid = await connection.sendTransaction(transaction);
+    await connection.confirmTransaction({
+      signature: txid,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    console.log("Lookup table created:", lookupTableAddress.toBase58());
+    console.log("Transaction:", txid);
+
+    return lookupTableAddress.toBase58();
+  }
+
+  createLookupTable();
+  ```
+</CodeGroup>
+
+Run with:
+
+```bash
+ts-node main.ts
+```
+
+## Extend the lookup table
+
+After creation, add the addresses you need to reference in your transactions. You can add up to 30 addresses per `extendLookupTable` instruction (limited by transaction size), and a table can hold up to 256 entries total.
+
+<CodeGroup>
+  ```typescript TypeScript
+  import {
+    Connection,
+    Keypair,
+    PublicKey,
+    AddressLookupTableProgram,
+    TransactionMessage,
+    VersionedTransaction,
+  } from "@solana/web3.js";
+  import bs58 from "bs58";
+  import "dotenv/config";
+
+  const connection = new Connection(process.env.SOLANA_RPC!);
+  const payer = Keypair.fromSecretKey(bs58.decode(process.env.PRIVATE_KEY!));
+
+  // Replace with your lookup table address from the previous step
+  const LOOKUP_TABLE_ADDRESS = new PublicKey("YOUR_LOOKUP_TABLE_ADDRESS");
+
+  async function extendLookupTable() {
+    // Add the addresses you frequently use in transactions
+    const addressesToAdd = [
+      new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),     // Token Program
+      new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),    // Associated Token Program
+      new PublicKey("11111111111111111111111111111111"),                   // System Program
+      new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),    // USDC mint
+      new PublicKey("So11111111111111111111111111111111111111112"),        // Wrapped SOL
+      // Add more addresses as needed for your use case
+    ];
+
+    const extendInstruction = AddressLookupTableProgram.extendLookupTable({
+      payer: payer.publicKey,
+      authority: payer.publicKey,
+      lookupTable: LOOKUP_TABLE_ADDRESS,
+      addresses: addressesToAdd,
+    });
+
+    const latestBlockhash = await connection.getLatestBlockhash();
+
+    const message = new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions: [extendInstruction],
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(message);
+    transaction.sign([payer]);
+
+    const txid = await connection.sendTransaction(transaction);
+    await connection.confirmTransaction({
+      signature: txid,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    console.log("Lookup table extended with", addressesToAdd.length, "addresses");
+    console.log("Transaction:", txid);
+  }
+
+  extendLookupTable();
+  ```
+</CodeGroup>
+
+<Warning>
+  After extending a lookup table, you must **wait for the next slot** before using it in a transaction. The newly added addresses are not available in the same slot they were added.
+</Warning>
+
+## Use the lookup table in a transaction
+
+Once the table is populated, pass it as an address lookup table when compiling your versioned transaction message. The runtime resolves the indices at execution time.
+
+<CodeGroup>
+  ```typescript TypeScript
+  import {
+    Connection,
+    Keypair,
+    PublicKey,
+    SystemProgram,
+    TransactionMessage,
+    VersionedTransaction,
+  } from "@solana/web3.js";
+  import bs58 from "bs58";
+  import "dotenv/config";
+
+  const connection = new Connection(process.env.SOLANA_RPC!);
+  const payer = Keypair.fromSecretKey(bs58.decode(process.env.PRIVATE_KEY!));
+
+  const LOOKUP_TABLE_ADDRESS = new PublicKey("YOUR_LOOKUP_TABLE_ADDRESS");
+
+  async function sendWithLookupTable() {
+    // Fetch the lookup table account
+    const lookupTableAccount = (
+      await connection.getAddressLookupTable(LOOKUP_TABLE_ADDRESS)
+    ).value;
+
+    if (!lookupTableAccount) {
+      throw new Error("Lookup table not found");
+    }
+
+    console.log(
+      "Lookup table has",
+      lookupTableAccount.state.addresses.length,
+      "addresses"
+    );
+
+    // Build your instructions as usual
+    const instructions = [
+      SystemProgram.transfer({
+        fromPubkey: payer.publicKey,
+        toPubkey: payer.publicKey,
+        lamports: 1000,
+      }),
+      // Add more instructions that reference accounts in the lookup table
+    ];
+
+    const latestBlockhash = await connection.getLatestBlockhash();
+
+    // Pass the lookup table when compiling — this is the key step
+    const message = new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions,
+    }).compileToV0Message([lookupTableAccount]);
+
+    const transaction = new VersionedTransaction(message);
+    transaction.sign([payer]);
+
+    const txid = await connection.sendTransaction(transaction);
+    await connection.confirmTransaction({
+      signature: txid,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    console.log("Transaction with lookup table:", txid);
+  }
+
+  sendWithLookupTable();
+  ```
+</CodeGroup>
+
+The critical line is `.compileToV0Message([lookupTableAccount])` — this tells the runtime to resolve account references from the lookup table instead of embedding full public keys.
+
+## When to use address lookup tables
+
+| Scenario | Without ALT | With ALT |
+| -------- | ----------- | -------- |
+| Simple SOL transfer (2 accounts) | Works fine | Not needed |
+| SPL token transfer (5–7 accounts) | Usually fits | Not needed |
+| Jupiter swap (15–25 accounts) | Likely exceeds 1232 bytes | Required |
+| Multi-hop swap + transfer + memo (30+ accounts) | Always exceeds 1232 bytes | Required |
+
+<Tip>
+  If you use the same set of accounts repeatedly (e.g., the same token pair, the same DEX pool), create the lookup table once and reuse it across all your transactions. The table persists on-chain until you explicitly close it.
+</Tip>
+
+## Additional resources
+
+* [Solana documentation on address lookup tables](https://solana.com/docs/advanced/lookup-tables)
+* [Versioned transactions](/docs/solana-how-to-priority-fees-faster-transactions) — priority fees guide uses v0 transactions
+* [Transaction expiry handling](/docs/solana-how-to-handle-the-transaction-expiry-error) — retry logic for transactions using ALTs

--- a/docs/solana-agave-20-upgrade-reference.mdx
+++ b/docs/solana-agave-20-upgrade-reference.mdx
@@ -33,7 +33,7 @@ See:
 | getSignatureStatus                | [getSignatureStatuses](/reference/solana-getsignaturestatuses)                                                                                                                                                          |
 | getSignatureConfirmation          | [getSignatureStatuses](/reference/solana-getsignaturestatuses)                                                                                                                                                          |
 | getConfirmedSignaturesForAddress  | [getSignaturesForAddress](/reference/solana-getsignaturesforaddress)                                                                                                                                                    |
-| getConfirmedBlock                 | [getBlock](/reference/solana-getblocks)                                                                                                                                                                                  |
+| getConfirmedBlock                 | [getBlock](/reference/solana-getblock)                                                                                                                                                                                  |
 | getConfirmedBlocks                | [getBlocks](/reference/solana-getblocks)                                                                                                                                                                                |
 | getConfirmedBlocksWithLimit       | [getBlocksWithLimit](/reference/getblockswithlimit)                                                                                                                                                                     |
 | getConfirmedTransaction           | [getTransaction](/reference/gettransaction)                                                                                                                                                                             |
@@ -45,7 +45,7 @@ See:
 | getSnapshotSlot                   | [getHighestSnapshotSlot](/reference/solana-gethighestsnapshotslot)                                                                                                                                                      |
 | getStakeActivation                | [getAccountInfo \| Solana](/reference/solana-getaccountinfo) ([alternative approach](https://solana.stackexchange.com/questions/15710/the-alternative-method-to-get-the-stake-account-status-since-getstakeactivation)) |
 
-## Replacing `confirmTransaction` with `getSignaturesStatuses`
+## Replacing `confirmTransaction` with `getSignatureStatuses`
 
 <CodeGroup>
   ```javascript @solana/web3.js
@@ -127,7 +127,7 @@ See:
 
   ```python solana.py
   from solana.rpc.api import Client
-  from solana.transaction import Transaction
+  from solders.transaction import Transaction
   from solana.rpc.commitment import Commitment
   from typing import Optional, List, Union
   import time
@@ -164,15 +164,15 @@ See:
 
       # Send the transaction
       try:
+          from solana.rpc.types import TxOpts
           response = client.send_transaction(
               transaction,
-              *signers,
-              opts={
-                  "skip_preflight": False,
-                  "preflight_commitment": commitment
-              }
+              opts=TxOpts(
+                  skip_preflight=False,
+                  preflight_commitment=commitment
+              )
           )
-          signature = response["result"]
+          signature = str(response.value)
       except Exception as e:
           raise TransactionConfirmationError(f"Failed to send transaction: {str(e)}")
 
@@ -189,21 +189,21 @@ See:
                   # Get transaction status
                   response = client.get_signature_statuses([signature])
 
-                  if response["result"]["value"][0] is None:
+                  if response.value[0] is None:
                       # Transaction not yet processed, wait and retry
                       await asyncio.sleep(1)
                       continue
 
-                  status = response["result"]["value"][0]
+                  status = response.value[0]
 
                   # Check if transaction failed
-                  if status.get("err"):
+                  if status.err:
                       raise TransactionConfirmationError(
-                          f"Transaction failed: {status['err']}"
+                          f"Transaction failed: {status.err}"
                       )
 
                   # Check confirmation status
-                  conf_status = status.get("confirmationStatus")
+                  conf_status = status.confirmation_status
                   if conf_status == "finalized":
                       return signature
 

--- a/docs/solana-analyzing-adjacent-transactions-for-priority-fees.mdx
+++ b/docs/solana-analyzing-adjacent-transactions-for-priority-fees.mdx
@@ -52,7 +52,7 @@ The script itself:
   ```python Python
   from solana.rpc.api import Client
   from solana.rpc.commitment import Commitment
-  from solana.transaction import Signature
+  from solders.signature import Signature
   import base58
   import json
   from typing import List, Optional, Tuple

--- a/docs/solana-gettokenlargestaccounts-rpc-method.mdx
+++ b/docs/solana-gettokenlargestaccounts-rpc-method.mdx
@@ -162,7 +162,7 @@ Before proceeding, ensure you have Node.js installed for JavaScript development 
    To interact with Solana's JSON RPC API in Python, install the necessary library using `pip`:
 
    <Info>
-     It is highly recommended to create a new Python virtual environment for this project; create one with `python3 -m venv solana-project`, then activate it with `source/solana-project/bin/activate`.
+     It is highly recommended to create a new Python virtual environment for this project; create one with `python3 -m venv solana-project`, then activate it with `source solana-project/bin/activate`.
    </Info>
 
 <CodeGroup>

--- a/docs/solana-how-to-build-actions-and-blinks.mdx
+++ b/docs/solana-how-to-build-actions-and-blinks.mdx
@@ -124,6 +124,7 @@ Please see the example below, where we define two buttons with their respective 
       links: {
         actions: [
           {
+            type: "transaction",
             label: "Deposit SOL",
             href: `${pathActions}?action=deposit&amount={amount}`,
             parameters: [
@@ -134,6 +135,7 @@ Please see the example below, where we define two buttons with their respective 
             ],
           },
           {
+            type: "transaction",
             label: "Withdraw SOL",
             href: `${pathActions}?action=withdraw&amount={amount}`,
             parameters: [
@@ -370,6 +372,7 @@ The complete `route.ts` includes both GET and POST handlers, along with the vali
       links: {
         actions: [
           {
+            type: "transaction",
             label: "Deposit SOL",
             href: `${pathActions}?action=deposit&amount={amount}`,
             parameters: [
@@ -380,6 +383,7 @@ The complete `route.ts` includes both GET and POST handlers, along with the vali
             ],
           },
           {
+            type: "transaction",
             label: "Withdraw SOL",
             href: `${pathActions}?action=withdraw&amount={amount}`,
             parameters: [

--- a/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
+++ b/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
@@ -8,7 +8,7 @@ description: "Perform Solana token swaps with Raydium SDK and Chainstack. Learn 
 </Frame>
 
 **TLDR:**
-* Using the Raydium SDK on Solana allows you to swap tokens efficiently while leveraging Serum’s order book for ample liquidity.
+* Using the Raydium SDK on Solana allows you to swap tokens efficiently while leveraging OpenBook’s order book for ample liquidity.
 * This TypeScript project sets up the Solana Connection (with your own node endpoint), loads trimmed pool data, and constructs a transaction for a token pair (e.g., SOL → USDC).
 * Configuration lives in `swapConfig.ts` for easy adjustments (e.g., token amounts, slippage, versioned transaction usage).
 * You can simulate swaps first or execute them immediately, with built-in transaction logging and debugging.
@@ -17,7 +17,7 @@ description: "Perform Solana token swaps with Raydium SDK and Chainstack. Learn 
 
 The Solana blockchain is at the forefront of DeFi, known for its remarkable speed and cost-efficiency. This has positioned Solana as a highly sought-after platform for users and developers interested in DeFi activities.
 
-Central to this ecosystem's appeal is Raydium, an automated market maker (AMM) that integrates seamlessly with Serum's central order book, enabling quick and cost-effective token transactions. Raydium's integration with Solana facilitates immediate swaps with minimal slippage and maintains liquidity at optimal levels.
+Central to this ecosystem's appeal is Raydium, an automated market maker (AMM) that integrates seamlessly with OpenBook's central order book, enabling quick and cost-effective token transactions. Raydium's integration with Solana facilitates immediate swaps with minimal slippage and maintains liquidity at optimal levels.
 
 In this guide, we'll walk you through using the Raydium SDK and Solana Chainstack nodes to swap tokens in TypeScript.
 

--- a/docs/solana-how-to-priority-fees-faster-transactions.mdx
+++ b/docs/solana-how-to-priority-fees-faster-transactions.mdx
@@ -123,11 +123,13 @@ Follow these steps to install the required packages:
 <CodeGroup>
   ```bash Bash
   npm install bs58 dotenv
+  npm install --save-dev ts-node
   ```
 </CodeGroup>
 
 * The `bs58` package is a base58 encoding/decoding library for Solana addresses and keypairs.
 * The `dotenv` package allows us to load environment variables from a `.env` file, which helps store sensitive information like private keys.
+* The `ts-node` package lets you run TypeScript files directly without a separate compilation step.
 
 After running these commands, your `package.json` file should have the following dependencies:
 
@@ -202,7 +204,7 @@ Now that we have set up the project, installed the required packages, and config
 2. Paste the following code into the `main.ts` file:
 
 <CodeGroup>
-  ```solidity solidity
+  ```typescript TypeScript
   import { ComputeBudgetProgram, Connection, Keypair, LAMPORTS_PER_SOL, SystemProgram, TransactionInstruction, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
   import bs58 from "bs58";
   import 'dotenv/config';
@@ -236,7 +238,7 @@ Now that we have set up the project, installed the required packages, and config
 
     // Get the latest blockhash
     let latestBlockhash = await SOLANA_CONNECTION.getLatestBlockhash('confirmed');
-    console.log(" <Icon icon="square-check"  iconType="solid" /> - Fetched latest blockhash. Last Valid Height:", latestBlockhash.lastValidBlockHeight);
+    console.log(" ✅ - Fetched latest blockhash. Last Valid Height:", latestBlockhash.lastValidBlockHeight);
 
     // Generate the transaction message
     const messageV0 = new TransactionMessage({
@@ -244,19 +246,19 @@ Now that we have set up the project, installed the required packages, and config
       recentBlockhash: latestBlockhash.blockhash,
       instructions: instructions
     }).compileToV0Message();
-    console.log(" <Icon icon="square-check"  iconType="solid" /> - Compiled Transaction Message");
+    console.log(" ✅ - Compiled Transaction Message");
 
     // Create a VersionedTransaction and sign it
     const transaction = new VersionedTransaction(messageV0);
     transaction.sign([FROM_KEYPAIR]);
-    console.log(" <Icon icon="square-check"  iconType="solid" /> - Transaction Signed");
+    console.log(" ✅ - Transaction Signed");
 
     console.log(`Sending ${AMOUNT_TO_TRANSFER / LAMPORTS_PER_SOL} SOL from ${FROM_KEYPAIR.publicKey} to ${FROM_KEYPAIR.publicKey} with priority fee rate ${PRIORITY_RATE} microLamports`);
 
     try {
       // Send the transaction to the network
       const txid = await SOLANA_CONNECTION.sendTransaction(transaction, { maxRetries: 15 });
-      console.log(" <Icon icon="square-check"  iconType="solid" /> - Transaction sent to network");
+      console.log(" ✅ - Transaction sent to network");
 
       // Confirm the transaction
       const confirmation = await SOLANA_CONNECTION.confirmTransaction({
@@ -342,7 +344,7 @@ This will initiate the transaction with the applied priority fee, logging the pr
 
 <CodeGroup>
   ```jsx jsx
-  $ ts-node app.ts
+  $ ts-node main.ts
 
 Connected to Solana RPC at https://solana-mainnet.core.chainstack.
 Initial Setup: Public Key - CzNGm14nMopjGYyycMbWqEF2e1aEHcJLKk2CHw9BiZwC

--- a/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
+++ b/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
@@ -18,8 +18,8 @@ See also [Solana: Listening to pump.fun token mint using only logsSubscribe](/do
 This article is an add-on for two scripts:
 
 <CardGroup>
-  <Card title="check_boding_curve_status.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/check_boding_curve_status.py" icon="angle-right" horizontal />
-  <Card title="listen_to_raydium_migration.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/listen_to_raydium_migration.py" icon="angle-right" horizontal />
+  <Card title="get_bonding_curve_status.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/bonding-curve-progress/get_bonding_curve_status.py" icon="angle-right" horizontal />
+  <Card title="listen_logsubscribe.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/listen-migrations/listen_logsubscribe.py" icon="angle-right" horizontal />
 </CardGroup>
 
 This guide shows you how to track the lifecycle of pump.fun tokens from their initial bonding curve state through migration to Raydium using Python scripts.
@@ -60,18 +60,18 @@ After migration, trading moves from the bonding curve mechanism to Raydium's tra
 
 This guide covers two essential scripts for tracking this migration process:
 
-1. `check_boding_curve_status.py` - Checks if a token is still on the bonding curve or ready for migration
-2. `listen_to_raydium_migration.py` - Monitors real-time migrations to Raydium
+1. `get_bonding_curve_status.py` — checks if a token is still on the bonding curve or ready for migration
+2. `listen_logsubscribe.py` — monitors real-time migrations to Raydium
 
 ### Checking bonding curve status
 
-The `check_boding_curve_status.py` script lets you check if a token's bonding curve is still active or has completed and is ready for Raydium migration.
+The `get_bonding_curve_status.py` script lets you check if a token's bonding curve is still active or has completed and is ready for Raydium migration.
 
 #### Usage
 
 <CodeGroup>
   ```shell Shell
-  python check_boding_curve_status.py TOKEN_ADDRESS
+  python get_bonding_curve_status.py TOKEN_ADDRESS
   ```
 </CodeGroup>
 
@@ -117,7 +117,7 @@ For a completed bonding curve:
 
 ### Monitoring Raydium migrations
 
-The `listen_to_raydium_migration.py` script uses WebSocket subscriptions to monitor real-time migrations of tokens from pump.fun to Raydium DEX.
+The `listen_logsubscribe.py` script uses WebSocket subscriptions to monitor real-time migrations of tokens from pump.fun to Raydium DEX.
 
 The pump.fun migration account is [39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg](https://solscan.io/account/39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg).
 
@@ -133,7 +133,7 @@ Our script uses the [blockSubscribe | Solana](/reference/blocksubscribe-solana) 
 
 <CodeGroup>
   ```shell Shell
-  python listen_to_raydium_migration.py
+  python listen_logsubscribe.py
   ```
 </CodeGroup>
 

--- a/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
@@ -13,7 +13,7 @@ description: Capture newly created pump.fun tokens in real time by subscribing t
 
 This guide shows you how to listen for pump.fun token creation events in real time using only the [logsSubscribe](/reference/logssubscribe-solana) method.
 
-In the [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot), there is the `learning-examples/listen_new_direct_full_details.py` script demonstrates how to capture the new token’s name, symbol, mint address, user (creator), bonding curve address, and associated bonding curve address—no methods like [blockSubscribe](/reference/blocksubscribe-solana) extra RPC calls like [getTransaction](/reference/gettransaction) are required.
+In the [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot), the `learning-examples/listen-new-tokens/listen_logsubscribe.py` script demonstrates how to capture the new token’s name, symbol, mint address, user (creator), bonding curve address, and associated bonding curve address—no methods like [blockSubscribe](/reference/blocksubscribe-solana) or extra RPC calls like [getTransaction](/reference/gettransaction) are required.
 
 There's difference in speed in how `blockSubscribe` and `logsSubscribe` work. Also, `blockSubscribe` is available on all Chainstack plans, but with other providers, it may not be available on the free tier plans or even lower tier paid plans.
 
@@ -22,7 +22,7 @@ There is also difference in how `blockSubscribe` and `logsSubscribe` work, hence
 * `blockSubscribe` — extracts and decodes transactions as the are streamed in the blocks produced. And the script in the bot decodes them on the fly. This means that we get all the necessary data to do our sniping using the `blockSubscribe` method.
 * `logsSubscribe` — only prints the pump.fun program logs, in our case—for token mints. The problem is we can get and decode from the logs the new token’s name, symbol, mint address, user (creator), and bonding curve address. But the logs do not contain the associated bonding curve address, which we need to do a sniping/buying transaction.
 
-The script discussed in this article and that is the `learning-examples/listen_new_direct_full_details.py` script solves the issue by computing the associated bonding curve address from the bonding curve address on the fly and prints it. This way it makes it possible to snipe tokens on pump.fun using the `logsSubscribe` method only. which in general has better availability across providers and may work faster for you.
+The script discussed in this article (`learning-examples/listen-new-tokens/listen_logsubscribe.py`) solves the issue by computing the associated bonding curve address from the bonding curve address on the fly and prints it. This way it makes it possible to snipe tokens on pump.fun using the `logsSubscribe` method only. which in general has better availability across providers and may work faster for you.
 
 <Warning>
   **Note on blockSubscribe limitations:** While `blockSubscribe` provides transaction data, it has known stability issues with high-traffic programs—including connection errors (1006, 1009) and data skipping. For the most reliable real-time data streaming, [Geyser is recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) for the fastest and most stable implementation. Learn more about [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
@@ -74,7 +74,7 @@ By using `logsSubscribe`, you can get new token details almost immediately, whic
 
    <CodeGroup>
      ```bash Bash
-     python listen_new_direct_full_details.py
+     python listen_logsubscribe.py
      ```
    </CodeGroup>
 

--- a/docs/solana-optimize-your-getblock-performance.mdx
+++ b/docs/solana-optimize-your-getblock-performance.mdx
@@ -11,7 +11,7 @@ description: Optimize getBlock call performance on Solana by tuning maxSupported
 
 ## Main article
 
-Solana's [getBlock](/reference/solana-getblocks) RPC method is a fundamental method that can be tricky and will screw up your application performance in a jiffy if you are not paying attention.
+Solana's [getBlock](/reference/solana-getblock) RPC method is a fundamental method that can be tricky and will screw up your application performance in a jiffy if you are not paying attention.
 
 This guide provides a comprehensive overview of how to use `getBlock` efficiently, with practical examples in Python and curl.
 
@@ -104,7 +104,8 @@ If you're only interested in transaction signatures (hashes), which is much ligh
       {
         "encoding": "json",
         "transactionDetails": "signatures",
-        "commitment": "finalized"
+        "commitment": "finalized",
+        "maxSupportedTransactionVersion": 0
       }
     ]
   }'

--- a/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
+++ b/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
@@ -17,7 +17,7 @@ In this tutorial, we are going to have a look at how add our own prioritization 
 
 As Jupiter does not have a Python SDK at the time of this tutorial, it's more fun doing this in Python.
 
-For JavaScript, check out their [Jupiter SDK](https://betastation.jup.ag/docs/apis/swap-sdk).
+For JavaScript, check out the [Jupiter developer docs](https://developers.jup.ag/docs/swap).
 
 ## Transaction fees on Solana
 
@@ -59,10 +59,10 @@ Here's how it's going to work:
 
 Now let's implement our flow as outlined above.
 
-Have a look at the [Jupiter API endpoints](https://station.jup.ag/api-v6), and you will see that there are a few of them. The two that we need are:
+Have a look at the [Jupiter swap API](https://developers.jup.ag/docs/swap), and you will see that there are a few endpoints. The two that we need are:
 
-* [quote](https://station.jup.ag/api-v6/get-quote) — to get the quote for the trade
-* [swap](https://station.jup.ag/api-v6/post-swap) — to prepare the swap transaction
+* quote — to get the quote for the trade
+* swap — to prepare the swap transaction
 
 For everything else we are using our own Solana node.
 

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -46,7 +46,7 @@ Get started with a [reliable Solana RPC endpoint](https://chainstack.com/build-b
 
 ## JSON-RPC API
 
-Interact with your Solana network using [JSON-RPC API](https://docs.solana.com/developing/clients/jsonrpc-api).
+Interact with your Solana network using [JSON-RPC API](https://solana.com/docs/rpc).
 
 Use [curl](https://curl.haxx.se) or [Postman](https://www.getpostman.com).
 
@@ -64,7 +64,7 @@ where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS or WSS endpoint protected ei
 
 ## Solana web3.js
 
-1. Install Solana web3.js. See [Solana web3.js guide](https://docs.solana.com/developing/clients/javascript-api).
+1. Install Solana web3.js. See [Solana web3.js guide](https://solana.com/docs/clients/javascript-reference).
 
 2. Use `Connection` to connect to your Solana node and get account balance:
 
@@ -88,9 +88,9 @@ where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS or WSS endpoint protected ei
 
    ```python
    from solana.rpc.api import Client
-   from solana.publickey import PublicKey
+   from solders.pubkey import Pubkey
    client = Client('YOUR_CHAINSTACK_ENDPOINT')
-   print(client.get_balance(PublicKey('23dQfKhhsZ9RA5AAn12KGk21MB784PmTB3gfKRwdBNHr')))
+   print(client.get_balance(Pubkey.from_string('23dQfKhhsZ9RA5AAn12KGk21MB784PmTB3gfKRwdBNHr')))
    ```
 
    where YOUR_CHAINSTACK_ENDPOINT is your node HTTPS or WSS endpoint protected either with the key or password. See [node access details](/docs/manage-your-node#view-node-access-and-credentials).

--- a/docs/solana-understanding-block-time.mdx
+++ b/docs/solana-understanding-block-time.mdx
@@ -49,7 +49,7 @@ Retrieve block details including block time and hash:
   ```shell Shell
   curl -X POST \
     -H "Content-Type: application/json" \
-    --data '{"jsonrpc":"2.0","id":1,"method":"getBlock","params":[SLOT_NUMBER, {"encoding":"json"}]}' \
+    --data '{"jsonrpc":"2.0","id":1,"method":"getBlock","params":[SLOT_NUMBER, {"encoding":"json","maxSupportedTransactionVersion":0}]}' \
     CHAINSTACK_SOLANA_URL
   ```
 </CodeGroup>

--- a/docs/transferring-spl-tokens-on-solana-typescript.mdx
+++ b/docs/transferring-spl-tokens-on-solana-typescript.mdx
@@ -265,7 +265,7 @@ Now that we have set up the project, installed the required packages, and config
         "CzNGm14nMopjGYyycMbWqEF2e1aEHcJLKk2CHw9BiZwC"
       );
 
-      // The SLP token being transferred, this is the address for USDC
+      // The SPL token being transferred, this is the address for USDC
       const mintAddress = new PublicKey(
         "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
       );
@@ -383,7 +383,7 @@ Let's break down the code and understand how it works:
 
 ### Running the script
 
-Now that we have the code and understand how it works, it’s time to send some SPL tokens. The script, by default, transfers 1 USDC to the destination wallet. You can edit the destination, token address, and amount from this portion of the code in the `main` function:
+Now that we have the code and understand how it works, it’s time to send some SPL tokens. The script, by default, transfers 0.01 USDC to the destination wallet. You can edit the destination, token address, and amount from this portion of the code in the `main` function:
 
 <CodeGroup>
   ```typescript TypeScript


### PR DESCRIPTION
## Summary

Three-part Solana documentation overhaul for the Colosseum Frontier hackathon, verified against the Agave source code and live Chainstack Solana mainnet endpoint.

### 1. P0 defect fixes (14 files)

Systematic audit found 25 P0 defects blocking hackathon builders:
- Migrate broken solana-py imports to solders (3 files)
- Add `maxSupportedTransactionVersion:0` to getBlock calls (2 files)
- Replace dead links: Jupiter, pump-fun-bot, readme.com (5 files)
- Fix wrong internal refs, defunct Serum references, LinkedAction types, Icon components in code, language tags, missing deps, typos

### 2. Complete API reference coverage (32 files, +1050 lines)

**9 new reference pages** with OpenAPI specs (verified live):
- sendTransaction, getTokenSupply, getTokenAccountsByDelegate, getHealth, getTransactionCount, getVersion, getVoteAccounts, getSlotLeaders, minimumLedgerSlot

**9 existing pages annotated** with Chainstack-specific notes:
- Archive data support (7 pages)
- Per-method RPS limits (4 pages)
- Range limits (2 pages)

**Cleanup** — removed from Agave, confirmed `Method not found` on live endpoint:
- Deleted getStakeActivation reference + OpenAPI spec
- Removed getConfirmedBlock from limits table + added Agave 2.0 removal note
- Updated getRecentBlockhash: deprecated → removed

### 3. Enriched methods table

- Filled Comment column: RPS limits, plan restrictions, archive support, range limits, filter requirements, unavailability reasons
- Linked all method names to reference pages
- Marked voteSubscribe/voteUnsubscribe unavailable (confirmed live)
- Marked requestAirdrop unavailable with reason

### 4. New ALT guide

- Address lookup tables guide for builders hitting the 1232-byte transaction size limit
- Covers: create, extend, use in v0 transactions
- TypeScript examples, compilation verified

## Test plan

- [x] All 9 new methods return valid responses on live Chainstack endpoint
- [x] getStakeActivation, getConfirmedBlock, getRecentBlockhash return `Method not found` (confirms removal)
- [x] voteSubscribe returns `Method not found`; blockSubscribe works
- [x] All new external URLs return 200
- [x] All internal link targets exist as files
- [x] ALT guide TypeScript compiles
- [ ] Mintlify preview renders all new pages
- [ ] "Try it" buttons work on new OpenAPI-backed pages