### PR TITLE
Add reference repos section to Solana guides

### DIFF
--- a/docs/solana-anchor-development.mdx
+++ b/docs/solana-anchor-development.mdx
@@ -901,3 +901,11 @@ anchor test --validator legacy
 ```
 
 Surfpool is faster but less feature-complete than `solana-test-validator`. Use the legacy validator when you need full RPC method support or when cloning accounts from mainnet.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [solana-foundation/anchor](https://github.com/solana-foundation/anchor) — Anchor 1.0 source; macros, `anchor build`, `anchor keys sync`, and `anchor deploy` behavior verified against master
+- [solana-foundation/solana-bootcamp-2026](https://github.com/solana-foundation/solana-bootcamp-2026) — bootcamp's Anchor projects used as a correctness reference
+- [txtx/surfpool](https://github.com/txtx/surfpool) — local validator used in the Anchor mainnet-fork workflow

--- a/docs/solana-escrow-pattern.mdx
+++ b/docs/solana-escrow-pattern.mdx
@@ -965,3 +965,12 @@ On the client, `seed.toArrayLike(Buffer, "le", 8)` produces the 8-byte little-en
 - [`solana-foundation/solana-bootcamp-2026` `04-escrow`](https://github.com/solana-foundation/solana-bootcamp-2026/tree/main/04-escrow) — maker/take/refund with LiteSVM tests
 - [`solana-developers/program-examples` `tokens/escrow`](https://github.com/solana-developers/program-examples/tree/main/tokens/escrow) — parallel native Rust and Anchor implementations
 - [`solana-program/escrow`](https://github.com/solana-program/escrow) — an alternative production-grade escrow program maintained by the Solana Program Library. It uses a different architecture (TLV-encoded state with pluggable Timelock, Hook, Arbiter, and Block-Token-Extensions modules) and is admin-controlled rather than peer-to-peer; consider it when you need those lifecycle hooks or an arbitrator role. The Anchor maker/taker pattern in this guide is simpler and more suitable when two parties swap directly without governance.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [solana-developers/program-examples](https://github.com/solana-developers/program-examples) — canonical escrow examples (`tokens/escrow`); instruction flow and account layout verified here
+- [solana-program/escrow](https://github.com/solana-program/escrow) — SPL escrow reference; canonical for the vault-PDA ownership pattern
+- [solana-foundation/anchor](https://github.com/solana-foundation/anchor) — Anchor 1.0 test suite includes `tests/escrow`; check for Anchor-idiomatic patterns
+- [solana-foundation/solana-bootcamp-2026](https://github.com/solana-foundation/solana-bootcamp-2026) — bootcamp's `04-escrow` project cross-checked the maker, take, and refund flow

--- a/docs/solana-litesvm-testing.mdx
+++ b/docs/solana-litesvm-testing.mdx
@@ -630,3 +630,13 @@ Reach for a different tool if any of these apply:
 - [anchor-litesvm on crates.io](https://crates.io/crates/anchor-litesvm).
 - [Mollusk](https://github.com/anza-xyz/mollusk) — Anza's single-instruction harness.
 - [Surfpool](https://github.com/txtx/surfpool) — integration-tier SVM with mainnet-fork support.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [LiteSVM/litesvm](https://github.com/LiteSVM/litesvm) — test-harness source; API surface, error paths, and feature-gate behavior verified against this
+- [brimigs/anchor-litesvm](https://github.com/brimigs/anchor-litesvm) — Anchor ↔ LiteSVM bridge used in the Rust examples
+- [anza-xyz/mollusk](https://github.com/anza-xyz/mollusk) — alternative lightweight runtime evaluated and cited for contrast
+- [kevinheavey/solders](https://github.com/kevinheavey/solders) — Python bindings used by the LiteSVM Python harness
+- [kevinheavey/solana-bankrun](https://github.com/kevinheavey/solana-bankrun) — predecessor test runtime; useful for understanding migration paths

--- a/docs/solana-program-derived-addresses-and-cross-program-invocations.mdx
+++ b/docs/solana-program-derived-addresses-and-cross-program-invocations.mdx
@@ -687,3 +687,11 @@ When working with PDAs and CPIs, follow these practices:
 - [Anchor documentation: CPIs](https://www.anchor-lang.com/docs/basics/cpi)
 - [Solana program examples: PDA](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses)
 - [Solana program examples: CPI](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [solana-developers/program-examples](https://github.com/solana-developers/program-examples) — canonical PDA and CPI worked examples; account derivations and seed patterns verified here
+- [solana-foundation/anchor](https://github.com/solana-foundation/anchor) — `find_program_address` and `invoke_signed` implementation; check here when bump or CPI authority rules look off
+- [solana-foundation/solana-bootcamp-2026](https://github.com/solana-foundation/solana-bootcamp-2026) — bootcamp projects that exercise PDA and CPI patterns end-to-end

--- a/docs/solana-surfpool.mdx
+++ b/docs/solana-surfpool.mdx
@@ -329,3 +329,11 @@ Running `anchor deploy` against a running Surfpool sometimes fails with `Failed 
 - [Anchor v1.0.0 release notes](https://github.com/solana-foundation/anchor/releases/tag/v1.0.0) — the PR that made Surfpool default.
 - [Helius: Introducing Surfpool](https://www.helius.dev/blog/surfpool) — conceptual intro and lazy-fork explanation.
 - [Blueshift: Surfpool 101](https://learn.blueshift.gg/en/courses/testing-with-surfpool/surfpool-101) — interactive course.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [txtx/surfpool](https://github.com/txtx/surfpool) — Surfpool source; `crates/core/src/rpc/surfnet_cheatcodes.rs` is the authoritative cheatcode surface — check here when signatures look off
+- [solana-foundation/anchor](https://github.com/solana-foundation/anchor) — Anchor 1.0 is Surfpool-native; `[surfpool]` section semantics and `online = true` behavior live here
+- [anza-xyz/mollusk](https://github.com/anza-xyz/mollusk) — alternative lightweight runtime referenced when Surfpool's overlay model isn't the right fit

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -200,3 +200,13 @@ To point Backpack at your Chainstack Solana node:
 2. Click the account icon > **Settings**.
 3. Click **Solana** > **RPC connection** > **Custom**.
 4. Enter your Chainstack Solana HTTPS endpoint and click **Update**.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [anza-xyz/kit](https://github.com/anza-xyz/kit) — `@solana/kit` v6 source; canonical for RPC types and transaction-builder semantics
+- [solana-foundation/anchor](https://github.com/solana-foundation/anchor) — Anchor 1.0 source; framework behavior cross-checked against master
+- [solana-foundation/solana-dev-skill](https://github.com/solana-foundation/solana-dev-skill) — Solana Foundation's Claude Code skill; opinionated stack defaults cross-checked against
+- [solana-foundation/templates](https://github.com/solana-foundation/templates) — `create-solana-dapp` scaffolder templates
+- [codama-idl/codama](https://github.com/codama-idl/codama) — IDL → typed-client codegen referenced in the "generate clients from IDL" section

--- a/docs/solana-zk-proofs.mdx
+++ b/docs/solana-zk-proofs.mdx
@@ -731,3 +731,13 @@ Custom Groth16 verification on Solana is an emerging area — there is no active
 - [Noir Discord](https://discord.gg/aztec) — circuit-writing and Noir-language questions (Aztec-run, not Solana-specific).
 - [Solana Stack Exchange](https://solana.stackexchange.com/) — has a small but growing corpus of Groth16 / alt_bn128 / stack-overflow-during-verify questions. Searching for `alt_bn128` turns up the most useful prior answers.
 - [Light Protocol Discord](https://discord.gg/J3zB8ZgnJv) — ZK Compression and the broader Groth16-on-Solana community.
+
+## Reference repos
+
+These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
+
+- [solana-foundation/noir-examples](https://github.com/solana-foundation/noir-examples) — Solana Foundation's Noir + Solana examples; the reference we built the guide against
+- [Lightprotocol/groth16-solana](https://github.com/Lightprotocol/groth16-solana) — on-chain Groth16 verifier; verification-key serialization and proof formats verified here
+- [Lightprotocol/light-poseidon](https://github.com/Lightprotocol/light-poseidon) — Solana Poseidon syscall wrapper and hasher
+- [reilabs/sunspot](https://github.com/reilabs/sunspot) — Noir → Solana tooling used in the build and deploy steps
+- [noir-lang/poseidon](https://github.com/noir-lang/poseidon) — Poseidon circuit library for Noir; referenced for hash-function parameter compatibility


### PR DESCRIPTION
## Summary

Appends a uniform `## Reference repos` H2 section to the seven Solana guides shipped for the hackathon queue (PRs #337–#343).

Each section follows the same shape:

> These are the source repositories we worked against while writing this guide. They stay closer to reality than docs — check them first when something here looks off.
>
> - [`org/repo`](url) — lowercase purpose line starting with an active verb or predicate

## Why

- **Agent-first.** Agents retrieving docs via `mcp.chainstack.com`'s `get_doc_page` get canonical source pointers alongside prose. The `[name](url) — purpose` pattern parses into `{name, url, purpose}` triples with one regex.
- **Freshness arbitrage.** Repos stay closer to reality than docs; when the guide goes stale, readers have authoritative fallback.
- **Provenance signal.** "Here are the repos we read while writing this" is stronger than "go search GitHub".

Per the simpler scope agreed with @ake: Option A (inline markdown), no frontmatter changes, no component changes, no audit-date or version pinning.

## Test plan

- [ ] `mintlify dev` renders without errors on all seven pages
- [ ] New H2 appears as the last section on each page
- [ ] Markdown formatting matches existing style-guide rules (em-dash with spaces, lowercase after dash, no trailing periods on list fragments, sentence case heading)
- [ ] All linked repos are reachable on GitHub