### PR TITLE
Fix MDX parse error blocking Mintlify production builds

### DIFF
--- a/docs/solana-litesvm-testing.mdx
+++ b/docs/solana-litesvm-testing.mdx
@@ -623,7 +623,7 @@ Reach for a different tool if any of these apply:
 
 - [Solana: Anchor development](/docs/solana-anchor-development) — where Anchor 1.0 makes LiteSVM the default test backend.
 - [Solana: Program derived addresses and cross-program invocations](/docs/solana-program-derived-addresses-and-cross-program-invocations) — the account-layout knowledge you need to write meaningful LiteSVM tests.
-- [Solana: Escrow pattern](/docs/solana-escrow-pattern) — a full DeFi primitive you can unit-test in LiteSVM in <100 ms.
+- [Solana: Escrow pattern](/docs/solana-escrow-pattern) — a full DeFi primitive you can unit-test in LiteSVM in under 100 ms.
 - [LiteSVM reference docs (Rust)](https://docs.rs/litesvm/latest/litesvm/).
 - [LiteSVM TypeScript docs](https://litesvm.github.io/litesvm/).
 - [solders LiteSVM tutorial (Python)](https://kevinheavey.github.io/solders/tutorials/litesvm.html).


### PR DESCRIPTION
## Summary

- `docs/solana-litesvm-testing.mdx:626` had `in <100 ms.` — MDX's JSX parser reads `<1` as a tag opening, and `1` is not a valid tag-name start character, so every production build from `main` has failed since PR #341 (LiteSVM guide) landed.
- Error seen locally: `Syntax error - Unable to parse docs/solana-litesvm-testing.mdx - 626:114: Unexpected character \`1\` (U+0031) before name`.
- PR preview checks passed green, but each subsequent merge (#342, #343, #344, #345) surfaced as Failed in the Mintlify dashboard because the production build re-parses the full tree.
- Rewrite to `in under 100 ms.` — matches the surrounding prose style and avoids the `&lt;` escape used elsewhere.

## Test plan

- [x] `npx mint broken-links` no longer reports the syntax error
- [ ] Mintlify production deployment goes green on merge