### PR TITLE
Remove orphan mcp-servers-introduction nav entry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1264,7 +1264,6 @@
           {
             "group": "MCP servers",
             "pages": [
-              "docs/mcp-servers-introduction",
               "docs/chainstack-mcp-server",
               "docs/migrate-to-chainstack-with-ai",
               "docs/developer-portal-mcp-server",


### PR DESCRIPTION
## Summary

- `docs.json` lists `docs/mcp-servers-introduction` under the MCP servers group, but that file doesn't exist — the page has been 404ing at [/docs/mcp-servers-introduction](https://docs.chainstack.com/docs/mcp-servers-introduction).

## Context

History:

- **c32873e** (Apr 9): Removed `docs/mcp-servers-introduction.mdx` and its nav entry — the file's content had been merged into the main Chainstack MCP page.
- **2f61ca3** (Apr 11): Rebuilt the MCP servers nav group and inadvertently reintroduced `docs/mcp-servers-introduction`. The other entries in that group all point to real files — only this one has been orphaned.

This PR drops the orphan entry. No file to add, no other changes needed.

## Test plan

- [ ] `mintlify dev` passes without complaining about the missing page.
- [ ] `https://docs.chainstack.com/docs/mcp-servers-introduction` no longer appears in the MCP servers sidebar after deploy.