### PR TITLE
Crosslink BBW landing pages from high-traffic tutorials

### DIFF
--- a/docs/avalanche-tutorial-aavev3-flash-loans-with-hardhat.mdx
+++ b/docs/avalanche-tutorial-aavev3-flash-loans-with-hardhat.mdx
@@ -25,7 +25,7 @@ Specifically, in this tutorial, you will:
 
 ## Prerequisites
 
-* [Chainstack account](https://console.chainstack.com/) to deploy a [reliable Avalanche RPC endpoint](https://chainstack.com/build-better-with-avalanche/).
+* [Chainstack account](https://console.chainstack.com/) to deploy a [reliable Avalanche RPC endpoint](https://chainstack.com/build-better-with-avalanche/) on Chainstack's [Avalanche node infrastructure](https://chainstack.com/protocols/).
 * [Node.js](https://nodejs.org/en/) as the JavaScript framework.
 * [Hardhat](https://hardhat.org/hardhat-runner/docs/getting-started#overview) to create, deploy, and interact with contracts.
 

--- a/docs/geth-vs-erigon-deep-dive-into-rpc-methods-on-ethereum-clients.mdx
+++ b/docs/geth-vs-erigon-deep-dive-into-rpc-methods-on-ethereum-clients.mdx
@@ -15,7 +15,7 @@ The JSON-RPC API is an essential tool for blockchain development as it provides 
 
 For example, if your DApp was developed on Erigon and you plan to switch to a new RPC provider running Geth, it's possible that the core API used in your application won't be available on the new node. To avoid compatibility issues, it's important to identify the current client you're using and the available API methods.
 
-This article compares the available RPC APIs for two Ethereum clients, Erigon and Geth, that are available on Chainstack. It is important to note that all tests were performed using **Erigon version 2.42** and **Geth version 1.11.5**, which were the most up-to-date versions as of May 2023. It is possible that there may be changes in the future.
+This article compares the available RPC APIs for two Ethereum clients, Erigon and Geth, that are available on Chainstack. You can [run Geth or Erigon via Chainstack](https://chainstack.com/build-better-with-ethereum/) on a dedicated node and pick the client that fits your RPC needs. It is important to note that all tests were performed using **Erigon version 2.42** and **Geth version 1.11.5**, which were the most up-to-date versions as of May 2023. It is possible that there may be changes in the future.
 
 ### Find what client your node is running
 

--- a/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling.mdx
+++ b/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling.mdx
@@ -8,7 +8,7 @@ The Solana ecosystem is pretty rich & diverse in the projects, dapps, developer 
 <Check>
   ### Get your own Solana archive node today
 
-  [Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+  Deploy a [Solana archive node on Chainstack](https://chainstack.com/build-better-with-solana/) and [start for free](https://console.chainstack.com/) — get your app to production levels immediately. No credit card required.
 
   You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>

--- a/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
+++ b/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
@@ -27,7 +27,7 @@ Before diving into the token-swapping process using the Raydium SDK on Solana, e
 
 ### Deploy a Chainstack Solana node
 
-Deploy a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with-solana/):
+Deploy a [Solana RPC endpoint on Chainstack](https://chainstack.com/build-better-with-solana/):
 
 <CardGroup>
   <Card title="Sign up with Chainstack" href="https://console.chainstack.com/user/account/create" icon="angle-right" horizontal />

--- a/docs/solana-understanding-block-time.mdx
+++ b/docs/solana-understanding-block-time.mdx
@@ -13,6 +13,8 @@ description: Understand Solana block time mechanics including slot duration, lea
 
 If you are coming from EVM, or pretty much any other blockchain, you have to realize that Solana's **block time** is actually an integral part of the consensus and thus differs notably from everything else.
 
+To follow along with the RPC examples in this guide, you'll want a [Chainstack Solana RPC](https://chainstack.com/build-better-with-solana/) endpoint.
+
 ## Key concepts
 
 * **Slots** — scheduled intervals (\~400ms each) designated for validators to attempt block production. Due to network conditions, not all slots produce blocks. Which creates even more confusion. See [Solana: Understanding the difference between blocks and slots](/docs/understanding-the-difference-between-blocks-and-slots-on-solana).


### PR DESCRIPTION
## Summary
 add links to BBW (build-better-with) landing pages and `/protocols/` on five high-traffic tutorials to route organic search traffic to conversion pages.

| Tutorial | Target | Anchor |
|---|---|---|
| solana-how-to-perform-token-swaps-using-the-raydium-sdk | /build-better-with-solana/ | Solana RPC endpoint on Chainstack |
| solana-archive-nodes-the-backbone-of-… | /build-better-with-solana/ | Solana archive node on Chainstack |
| solana-understanding-block-time | /build-better-with-solana/ | Chainstack Solana RPC |
| geth-vs-erigon-deep-dive-into-rpc-methods-… | /build-better-with-ethereum/ | run Geth or Erigon via Chainstack |
| avalanche-tutorial-aavev3-flash-loans-with-hardhat | /protocols/ | Avalanche node infrastructure |

## Test plan
- [ ] Preview build passes on Mintlify
- [ ] Anchor text reads naturally in context on each page
- [ ] Links resolve to the correct landing pages