### PR TITLE
Add relnotes for Agents page on console

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: April 22, 2026" description=" by Ake">
+
+**Console**. The new [Agents page](https://console.chainstack.com/agents) is live in the Chainstack console — one place to plug Chainstack into Claude Code, Codex CLI/App, Gemini CLI, Cursor, or any other coding agent: migration prompt, docs, MCP server, and Chainstack skill.
+
+<Button href="/changelog/chainstack-updates-april-22-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: March 27, 2026" description=" by Ake">
 
 **Protocols**. Sui Testnet is now available on Chainstack. You can deploy [Global Nodes](/docs/global-elastic-node) for Sui Testnet with JSON-RPC and gRPC endpoint support. See also [Sui tooling](/docs/sui-tooling).

--- a/changelog/chainstack-updates-april-22-2026.mdx
+++ b/changelog/chainstack-updates-april-22-2026.mdx
@@ -1,0 +1,11 @@
+---
+title: "Chainstack updates: April 22, 2026"
+description: "Chainstack platform update — new Agents page in the console with a migration prompt for AI coding agents, MCP server access, llms-full.txt, and Chainstack skill."
+---
+
+**Console**. The new [Agents page](https://console.chainstack.com/agents) is live in the Chainstack console. One place to plug Chainstack into Claude Code, Codex CLI/App, Gemini CLI, Cursor, or any other coding agent:
+
+* **Migrate to Chainstack** — `get docs.chainstack.com/docs/migrate-to-chainstack-with-ai.md` runs a pre-written prompt that switches your project's RPC endpoints over to Chainstack.
+* **Docs for Agents** — point your agent at [llms-full.txt](https://docs.chainstack.com/llms-full.txt) for all Chainstack docs in one shot, or pull them through the Chainstack MCP server (see below).
+* **MCP Server** — `get mcp.chainstack.com` connects the [Chainstack MCP server](https://mcp.chainstack.com) for full access to infrastructure, testnet faucet funds, and the Chainstack documentation from inside your agent.
+* **Skills** — `get mcp.chainstack.com/skill` installs the [Chainstack skill](https://mcp.chainstack.com/skill) in your agent so it can operate the Chainstack platform, contact Chainstack directly, pull testnet faucet funds, build web3 apps, and apply battle-tested best practices for web3 infrastructure.

--- a/docs.json
+++ b/docs.json
@@ -3544,6 +3544,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-april-22-2026",
           "changelog/chainstack-updates-march-27-2026",
           "changelog/chainstack-updates-march-18-2026",
           "changelog/chainstack-updates-march-5-2026",


### PR DESCRIPTION
## Summary
- Adds release notes entry for the new [Agents page](https://console.chainstack.com/agents) shipped in CORE-14245 (migration prompt, docs for agents, MCP server, Chainstack skill).
- Adds the overview block on `changelog.mdx` and registers the new page in `docs.json`.

## Test plan
- [ ] `mintlify dev` — `/changelog` shows the new April 22, 2026 entry at the top
- [ ] `/changelog/chainstack-updates-april-22-2026` renders cleanly
- [ ] All links (console, docs, MCP, skill) resolve