### PR TITLE
Rename pay-as-you-go to extra usage in docs

### DIFF
--- a/docs/billing-thresholds.mdx
+++ b/docs/billing-thresholds.mdx
@@ -14,7 +14,7 @@ With metered billing, you're typically charged at the end of your billing cycle.
 - Protect both customers and Chainstack from unexpected overages
 
 <Info>
-Billing thresholds apply to metered pay-as-you-go usage charges, including API requests, dedicated node hours, Warp transactions, subgraph usage and so on that exceed your plan's included allowances.
+Billing thresholds apply to metered extra usage charges, including API requests, dedicated node hours, Warp transactions, subgraph usage and so on that exceed your plan's included allowances.
 </Info>
 
 ## Threshold levels by subscription plan

--- a/docs/bnb-trader-nodes.mdx
+++ b/docs/bnb-trader-nodes.mdx
@@ -6,7 +6,7 @@ description: "Use BNB Smart Chain Trader Nodes with Warp transactions for fast p
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 ## Benefits with Chainstack
@@ -25,7 +25,7 @@ All calls go through Chainstack's infrastructure, except for `eth_sendRawTransac
 ## Availability and usage
 
 * Available from the [paid plans](https://chainstack.com/pricing).
-* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 * Only `eth_sendRawTransaction` calls are consumed as Warp transactions.
 * Deploy nodes close to your bot for best performance.
 

--- a/docs/deploy-a-subgraph.mdx
+++ b/docs/deploy-a-subgraph.mdx
@@ -37,7 +37,7 @@ To set up a subgraph, complete the following steps:
 ## Add a subgraph
 
 <Note>
-Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing#manage-the-pay-as-you-go-setting) setting enabled.
+Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 
 Subgraphs are billed at $0.10 per hour plus 20 request units per request.
 </Note>

--- a/docs/elastic-subgraphs.mdx
+++ b/docs/elastic-subgraphs.mdx
@@ -26,7 +26,7 @@ See the [Ormi–Chainstack transition guide](https://docs.ormilabs.com/subgraphs
 ## Overview
 
 <Note>
-Elastic Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing#manage-the-pay-as-you-go-setting) setting enabled.
+Elastic Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 DeFi protocols enable various financial services such as lending, borrowing, trading, and yield farming. Via Chainstack Elastic Subgraphs, you can access such protocols as Uniswap, SushiSwap, Lido, Aave, OpenSea, and more.

--- a/docs/ethereum-trader-nodes.mdx
+++ b/docs/ethereum-trader-nodes.mdx
@@ -6,7 +6,7 @@ description: "Use Ethereum Trader Nodes with Warp transactions for faster block 
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 ## Benefits with Chainstack
@@ -25,7 +25,7 @@ All calls go through Chainstack's infrastructure, except for `eth_sendRawTransac
 ## Availability and usage
 
 * Available from the [paid plans](https://chainstack.com/pricing).
-* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 * Only `eth_sendRawTransaction` calls are consumed as Warp transactions.
 * Deploy nodes close to your bot for best performance.
 

--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -20,11 +20,11 @@ description: Manage your Chainstack billing, payment methods, invoices, and cryp
  * View your current metered usage by category and its cost.
  * Manage your organization subscription plan and support level.
 
- ## Manage the pay-as-you-go setting
+ ## Manage the extra usage setting
 
- With the pay-as-you-go setting enabled in your [Billing](https://console.chainstack.com/user/settings/billing), your Chainstack services will stay operational on reaching your plan's quota limit. Going over the limit will trigger the pay-as-you-go charges.
+ With the extra usage setting enabled in your [Billing](https://console.chainstack.com/user/settings/billing), your Chainstack services will stay operational on reaching your plan's quota limit. Going over the limit will trigger the extra usage charges.
 
- With the pay-as-you-go setting disabled, you introduce a hard limit to your plan. On reaching the quota, your Chainstack services will stop and you won't be charged on going over the limit.
+ With the extra usage setting disabled, you introduce a hard limit to your plan. On reaching the quota, your Chainstack services will stop and you won't be charged on going over the limit.
 
  In both cases, you will receive at least two email notifications—on using up 80% of your plan's quota and on using up 100%.
 

--- a/docs/manage-your-subgraphs.mdx
+++ b/docs/manage-your-subgraphs.mdx
@@ -23,7 +23,7 @@ See the [Ormi–Chainstack transition guide](https://docs.ormilabs.com/subgraphs
 * Delete any subgraph directly from its details page to clean up your workspace.
 
 <Note>
-Subgraphs require a [paid plan](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing#manage-the-pay-as-you-go-setting) setting enabled.
+Subgraphs require a [paid plan](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 ## View your subgraph

--- a/docs/pricing-introduction.mdx
+++ b/docs/pricing-introduction.mdx
@@ -5,7 +5,7 @@ description: Understand Chainstack pricing plans, request unit billing, node cos
 
 ## Pricing principles
 
-Each Chainstack’s subscription plan has its own quota that represents the allocated resources and usage limits that users can spend within their chosen plan. In addition to the allocated quota, Chainstack also offers the convenience of "pay-as-you-go" billing for any extra usage beyond the specified limits. This means that if users exceed their allocated quota, they can continue using Chainstack's services seamlessly, with any additional usage being automatically charged at the applicable rates. Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs.
+Each Chainstack’s subscription plan has its own quota that represents the allocated resources and usage limits that users can spend within their chosen plan. In addition to the allocated quota, Chainstack also offers an extra usage setting. With it enabled, if you exceed your allocated quota, you can continue using Chainstack's services seamlessly, with any additional usage being automatically charged at the applicable rates. Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs.
 
 Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-are-request-units).
 

--- a/docs/quotas.mdx
+++ b/docs/quotas.mdx
@@ -7,9 +7,9 @@ description: View resource quotas for Chainstack subscription plans including ma
 
 Each Chainstack’s subscription plan has its own quota that represents the allocated resources and usage limits that users can spend within their chosen plan.
 
-In addition to the allocated quota, Chainstack also offers the convenience of "pay-as-you-go" billing for any extra usage beyond the specified limits. This means that if users exceed their allocated quota, they can continue using Chainstack's services seamlessly, with any additional usage being automatically charged at the applicable rates.
+In addition to the allocated quota, Chainstack also offers an extra usage setting. With it enabled, if you exceed your allocated quota, you can continue using Chainstack's services seamlessly, with any additional usage being automatically charged at the applicable rates.
 
-Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs. See [Manage your billing](/docs/manage-your-billing) on how to enable or disable the pay-as-you-go feature.
+Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs. See [Manage your billing](/docs/manage-your-billing#manage-the-extra-usage-setting) on how to enable or disable the extra usage setting.
 
 Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-are-request-units).
 

--- a/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
+++ b/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
@@ -12,7 +12,7 @@ description: Send Warp transactions through Trader Nodes using web3.js, ethers.j
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 ## Main article

--- a/docs/solana-trader-nodes.mdx
+++ b/docs/solana-trader-nodes.mdx
@@ -10,7 +10,7 @@ description: "Use Solana Trader Nodes with Warp transactions for fast propagatio
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 See also the [Solana Warp transactions](https://chainstack.com/solana-trader-nodes/) page for a more general overview.
@@ -27,7 +27,7 @@ Chainstack Solana Trader nodes with Warp transactions offer the following benefi
 * 40% of transactions land in the first two blocks.
 * Front-running protection is not enabled, as it would reduce transaction processing speed.
 * You can use [priority fees](/docs/solana-how-to-priority-fees-faster-transactions) to increase the chances of getting earlier placement within a block and in earlier blocks.
-* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+* Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 
 ## No need for custom setups
 

--- a/docs/subgraphs-introduction.mdx
+++ b/docs/subgraphs-introduction.mdx
@@ -24,7 +24,7 @@ See the [Ormi–Chainstack transition guide](https://docs.ormilabs.com/subgraphs
 * Enterprise-grade infrastructure reliability ensures a stable, scalable, and efficient data indexing experience.
 
 <Note>
-Chainstack Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing#manage-the-pay-as-you-go-setting) setting enabled.
+Chainstack Subgraphs are available starting from the [paid plans](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 
 Subgraphs are billed at $0.10 per hour plus 20 request units per request.
 </Note>

--- a/docs/unlimited-node.mdx
+++ b/docs/unlimited-node.mdx
@@ -18,9 +18,9 @@ Instead of paying per request, you pick an RPS (requests per second) tier, activ
 - 1000 RPS
 
 <Info>
-  ### Add‑on vs. pay-as-you-go
+  ### Add‑on vs. extra usage
   
-  With Unlimited Node, you **do not need the pay-as-you-go** option for the attached node.
+  With Unlimited Node, you **do not need the extra usage** option for the attached node.
   
   The node **consumes zero plan quota** and never incurs overage.
   

--- a/docs/warp-transactions.mdx
+++ b/docs/warp-transactions.mdx
@@ -9,7 +9,7 @@ With the *Warp transactions* setting on, your transactions will be distributed i
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 </Note>
 
 ## Why use with Chainstack
@@ -42,7 +42,7 @@ For best results and reduced latency, deploy a Trader node or Global node with W
 
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
 
-Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [pay-as-you-go](/docs/manage-your-billing) setting enabled.
+Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 
 ## Usage
 

--- a/reference/node-api-errors-reference.mdx
+++ b/reference/node-api-errors-reference.mdx
@@ -14,7 +14,7 @@ description: "Complete reference of node API error codes you may encounter on Ch
 | 413 | Request Entity Too Large | The default limit of the request body size is 1 MB. Reduce the request body size. |
 | 429 | Too Many Requests | You hit the default node [HTTP connections limit](https://docs.chainstack.com/docs/handle-real-time-data-using-websockets-with-javascript-and-python#http-and-websocket-connection-limitations). Reduce the number of requests. |
 | 429 | You've exceeded the RPS limit available on the current plan | You hit the [rate limit on your plan](https://docs.chainstack.com/docs/pricing-introduction#rate-limits). Reduce the request rate or upgrade to a higher plan. See also [RPS plan limits](https://docs.chainstack.com/docs/rps-plan-limits). |
-| 429 | You've reached your monthly quota of Request Units (RUs) | You exhausted the monthly RU quota on your plan. [Enable pay-as-you-go](https://console.chainstack.com/user/settings/billing) to continue beyond the quota or upgrade for more RUs. See also [Quotas](https://docs.chainstack.com/docs/quotas). |
+| 429 | You've reached your monthly quota of Request Units (RUs) | You exhausted the monthly RU quota on your plan. [Enable extra usage](https://console.chainstack.com/user/settings/billing) to continue beyond the quota or upgrade for more RUs. See also [Quotas](https://docs.chainstack.com/docs/quotas). |
 | 499 | No Response From Node | Increase the client-side time-out. [Contact support](https://support.chainstack.com/) if the issue persists. |
 | 500 | Internal Server Error | [Contact support](https://support.chainstack.com/) to check if you are accessing the correct node and if the gateway is healthy. |
 | 500 | ECONNREFUSED | [Contact support](https://support.chainstack.com/). |


### PR DESCRIPTION
## Summary

- Product renamed the billing toggle in the Chainstack console from **Pay-as-you-go** to **Extra usage** (per Alexandr in `#product-mcp` team Slack).
- Updated all public doc references across 15 files — 14 guide/reference pages plus `reference/node-api-errors-reference.mdx`.
- Heading in `docs/manage-your-billing.mdx` became `Manage the extra usage setting`, so the anchor auto-updates to `#manage-the-extra-usage-setting`. Every incoming link was updated to the new anchor.
- Historical release notes (`changelog.mdx` + `changelog/chainstack-updates-november-30-2023.mdx`) were intentionally left intact — they are dated records of when the feature shipped under the original name.

## Out of scope for this PR

- Blog posts and `chainstack.com` website copy live in separate repos.
- A new release-note entry announcing the rename can be added as a follow-up.

## Test plan

- [ ] Mintlify preview renders `docs/manage-your-billing` cleanly with the new heading.
- [ ] Anchor `/docs/manage-your-billing#manage-the-extra-usage-setting` resolves from the subgraph and trader-node pages.
- [ ] No remaining live doc mentions of "pay-as-you-go" (only the two dated changelog entries from Nov 30, 2023 remain, by design).