### PR TITLE
Clarify billing proration behavior for all plan change scenarios

### DIFF
--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -110,18 +110,18 @@ description: Manage your Chainstack billing, payment methods, invoices, and cryp
 3. Select a new subscription plan and click **Next**.
 4. Check the details of your new subscription plan and click **Confirm**.
 
- Your subscription plan changes immediately. You will also be billed for any uninvoiced metered usage during the used period of your previous subscription.
+ Your subscription plan changes immediately. You will also be billed for any uninvoiced metered usage from the portion of your previous subscription that you used.
 
 #### What happens to your balance on a plan change
 
-Chainstack does not issue monetary refunds. Where applicable, unused amounts are returned as credit to your Chainstack account balance, which is automatically applied against future charges.
+Eligible unused amounts are returned as credits to your Chainstack account balance and automatically applied against future charges. The **Balance change** column shows the outcome for each action: upgrades are prorated as immediate invoices, add-on or Chainstack Marketplace app changes can return prorated credits, and actions marked **Not prorated** do not receive account credits.
 
 | Action | Proration | Balance change |
 |--------|-----------|----------------|
-| Upgrade (e.g. Developer → Growth) | Prorated; prorated difference invoiced for remainder of cycle | Invoice issued immediately for the prorated difference |
-| Downgrade (e.g. Business → Developer) | Not prorated; new plan starts immediately | Unused funds not credited |
-| Account cancellation (closing your Chainstack account, including from Developer) | Not prorated | Unused funds not credited |
-| Add-on / Marketplace app change or removal | Prorated | Prorated credit applied to account balance |
+| Upgrade (for example, Growth to Pro) | Prorated; the difference is invoiced for the remainder of the cycle | Invoice issued immediately for the prorated difference |
+| Downgrade (for example, Business to Growth) | Not prorated; new plan starts immediately | Unused funds not credited |
+| Account cancellation (closing your Chainstack account) | Not prorated | Unused funds not credited |
+| Add-on or Chainstack Marketplace app change or removal | Prorated | Prorated credit applied to account balance |
 
 <Tip>
 To maximize value, consider timing downgrades or cancellations close to your renewal date.
@@ -142,7 +142,7 @@ To maximize value, consider timing downgrades or cancellations close to your ren
 3. Select a new support level and click **Next**.
 4. Check the details of your new support level and click **Confirm**.
 
- Your support level changes immediately. Funds that you haven’t spent during your previous upgrade option will be automatically used as a part of your new support level charge if it’s Professional or returned to your balance if you have switched to Standard.
+ Your support level changes immediately. Funds that you haven’t spent during your previous upgrade option will be automatically used as a part of your new support level charge if it’s Professional or credited to your Chainstack account balance if you have switched to Standard.
 
  ## Chainstack Subgraphs billing details
 
@@ -152,4 +152,4 @@ To maximize value, consider timing downgrades or cancellations close to your ren
 
  ## Chainstack Marketplace billing details
 
- The Chainstack Marketplace is a collection of applications, including add-ons, plugins, and tools designed to extend the functionality of your nodes and infrastructure. Each application may have its own pricing model—such as free, subscription-based, or one-time payment—which is billed separately and in addition to your main Chainstack subscription plan. If a paid application is removed before the end of its billing cycle, a partial refund will be issued for the unused portion of the subscription.
+ The Chainstack Marketplace is a collection of applications, including add-ons, plugins, and tools designed to extend the functionality of your nodes and infrastructure. Each application may have its own pricing model—such as free, subscription-based, or one-time payment—which is billed separately and in addition to your main Chainstack subscription plan. For proration behavior when you remove a paid application, see [What happens to your balance on a plan change](#what-happens-to-your-balance-on-a-plan-change).

--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -110,7 +110,22 @@ description: Manage your Chainstack billing, payment methods, invoices, and cryp
 3. Select a new subscription plan and click **Next**.
 4. Check the details of your new subscription plan and click **Confirm**.
 
- Your subscription plan changes immediately. Funds for the unused period of your previous subscription will be automatically returned to your balance. You will also be billed for any uninvoiced metered usage during the used period of your previous subscription.
+ Your subscription plan changes immediately. You will also be billed for any uninvoiced metered usage during the used period of your previous subscription.
+
+#### What happens to your balance on a plan change
+
+Chainstack does not issue monetary refunds. Where applicable, unused amounts are returned as credit to your Chainstack account balance, which is automatically applied against future charges.
+
+| Action | Proration | Balance change |
+|--------|-----------|----------------|
+| Upgrade (e.g. Developer → Growth) | Prorated; prorated difference invoiced for remainder of cycle | Invoice issued immediately for the prorated difference |
+| Downgrade (e.g. Business → Developer) | Not prorated; new plan starts immediately | Unused funds not credited |
+| Account cancellation (closing your Chainstack account, including from Developer) | Not prorated | Unused funds not credited |
+| Add-on / Marketplace app change or removal | Prorated | Prorated credit applied to account balance |
+
+<Tip>
+To maximize value, consider timing downgrades or cancellations close to your renewal date.
+</Tip>
 
 <Warning>
   ### Rate limits for Developer plans


### PR DESCRIPTION
## Summary

- Removes misleading claim that unused funds are returned on subscription plan changes
- Adds a table explaining proration behavior for upgrades, downgrades, account cancellation, and Chainstack Marketplace app changes
- Clarifies that eligible unused amounts are returned as account credits, not monetary refunds

Supersedes #354 with a more comprehensive fix per Eugene's request for explicit coverage of all scenarios.

## Changes

| Action | Proration | Balance change |
|--------|-----------|----------------|
| Upgrade (for example, Growth to Pro) | Prorated; the difference is invoiced for the remainder of the cycle | Invoice issued immediately for the prorated difference |
| Downgrade (for example, Business to Growth) | Not prorated; new plan starts immediately | Unused funds not credited |
| Account cancellation (closing your Chainstack account) | Not prorated | Unused funds not credited |
| Add-on or Chainstack Marketplace app change or removal | Prorated | Prorated credit applied to account balance |
