### PR TITLE
Fix Solana getRecentPrioritizationFees doc semantics and example

### DIFF
--- a/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
+++ b/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
@@ -53,7 +53,11 @@ The method's response is structured as an array of objects, with each object she
 
 Below is a practical demonstration of a simple `getRecentPrioritizationFees` request using cURL.
 
-This example uses the Jupiter aggregator as a reference point, meaning the fees reflect those pertinent to that specific DApp.
+This example queries the Orca Whirlpool SOL-USDC pool state account — a writable state account that competing swap transactions lock. Pass writable state accounts (pool state, reserves, user token accounts) for meaningful results.
+
+<Warning>
+Do not pass program IDs (Jupiter, Raydium, pump.fun, etc.) to this method. Programs are executable and read-only in user transactions, so they are not present in the per-account writable fee map. Passing a program ID returns near-empty data and gives a misleading picture of recent fees.
+</Warning>
 
 <CodeGroup>
   ```solidity solidity
@@ -68,7 +72,7 @@ This example uses the Jupiter aggregator as a reference point, meaning the fees 
     "method": "getRecentPrioritizationFees",
     "params": [
       [
-        "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
+        "HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ"
       ]
     ]
   }
@@ -89,6 +93,10 @@ This project will provide various priority fee measurements based on the `getRec
 * Average Prioritization Fee, including slots with zero fees.
 * Average Prioritization Fee excluding slots with zero fees.
 * Median Prioritization Fee excluding slots with zero fees.
+
+<Warning>
+Each value returned by `getRecentPrioritizationFees` is the floor for that slot — the cheapest fee paid by any transaction writing to your supplied accounts. Computing the average or median therefore gives you the average or median *floor*, not the average or median fee actually paid. To produce a competitive bid, take the maximum of non-zero values (or a high percentile like p95) over the 150-slot window and multiply by an urgency factor — typically 1.5x for normal load, 3x or higher when racing against other transactions for the same accounts.
+</Warning>
 
 ### Environment setup
 
@@ -269,7 +277,7 @@ Now that we have set up the project, installed the required packages, and config
           const SOLANA_RPC = getEnvVariable('SOLANA_RPC');
           const connection = new Connection(SOLANA_RPC);
 
-          const publicKey = new PublicKey('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4');
+          const publicKey = new PublicKey('HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ');
 
           const config: Config = {
               lockedWritableAccounts: [publicKey]
@@ -380,7 +388,7 @@ Now that we have the code and understand how it works, it’s time to run it. Yo
 
 <CodeGroup>
   ```typescript TypeScript
-  const publicKey = new PublicKey('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4');
+  const publicKey = new PublicKey('HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ');
 
   const config: Config = {
       lockedWritableAccounts: [publicKey]

--- a/reference/solana-getrecentprioritizationfees.mdx
+++ b/reference/solana-getrecentprioritizationfees.mdx
@@ -31,12 +31,27 @@ You can sign up with your GitHub, Twitter, Google, or Microsoft account.
 The response is an array of objects, where each object represents a prioritization fee observed in a recent slot (block). Each object has the following properties:
 
 * `slot` (u64) — the slot where the transactions associated with the prioritization fees were processed.
-* `prioritizationFee` (u64) — the fee in micro-lamports **per compute unit** paid by at least one transaction within the specified slot to achieve prioritized processing.
+* `prioritizationFee` (u64) — the per-compute-unit fee in micro-lamports. With no `params`, this is the minimum prioritization fee observed across all transactions in the slot. With `params`, this is the maximum across the supplied accounts of each account's minimum writable-account fee for that slot — that is, the floor fee for the most expensive of your accounts in that slot.
 
 The node's prioritization-fee cache stores data from the most recent 150 blocks.
 
-When account addresses are provided, the response reflects fees observed for transactions that locked **all** of the supplied accounts as writable simultaneously — not just any of them. If you omit the `params` array entirely, the response returns unfiltered samples across all transactions.
+### How the account filter works
+
+For each slot in the cache, the node:
+
+1. Looks up the minimum fee paid by any transaction that wrote to each supplied account that slot.
+2. Returns the maximum of those per-account minimums.
+
+The returned value is a floor — the cheapest fee that landed while writing to the most expensive of your accounts that slot — not a typical or competitive fee.
+
+If you omit the `params` array entirely, the response returns the minimum prioritization fee per slot across all transactions. Because every slot contains 0-priority-fee vote transactions, this floor is effectively 0 in every slot and is not useful for fee estimation.
+
+<Warning>
+Pass writable state accounts (pool state accounts, reserves, user token accounts) — not program IDs. Programs are typically executable and read-only, so they are not present in the per-account writable fee map. Passing a program ID like a Jupiter or Raydium program returns near-empty data and gives a misleading picture of recent fees.
+</Warning>
 
 ## Use case
 
-A practical use case for `getRecentPrioritizationFees` is to determine an appropriate priority fee for your transactions. By querying recent fees for the specific accounts your transaction will lock, you get a realistic picture of what competing transactions are paying. See also [Estimate priority fees with getRecentPrioritizationFees](/docs/solana-estimate-priority-fees-getrecentprioritizationfees) for a practical implementation guide.
+A practical use case for `getRecentPrioritizationFees` is to set a floor for your priority fee. By querying recent fees for the specific writable accounts your transaction locks, you see the cheapest competing transactions that landed touching those accounts. To produce a competitive bid, take a high percentile (p95) or the maximum of non-zero values over the 150-slot window and multiply by an urgency factor.
+
+See also [Estimate priority fees with getRecentPrioritizationFees](/docs/solana-estimate-priority-fees-getrecentprioritizationfees) for a practical implementation guide.


### PR DESCRIPTION
## Summary
- Fixes incorrect "AND across accounts" description in `reference/solana-getrecentprioritizationfees.mdx`. Actual Agave behavior is **max of per-account writable-fee floors**, not "transactions that locked all supplied accounts simultaneously".
- Replaces the Jupiter program ID (`JUP6LkbZbj...`) example in `docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx` with an actual writable state account (Orca Whirlpool SOL-USDC pool, `HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ`). Programs are executable / read-only, so the previous example returned near-empty data.
- Adds Warning callouts explaining that returned values are **per-slot floors**, not typical fees. The guide's average / median calculations are computing statistics _of floors_, which can lead readers to underbid.

## Why
Verified by curl against a Chainstack Solana mainnet endpoint:

| Test | non-zero / 150 | max fee |
|------|----------------|---------|
| Empty params | 0 | 0 (vote tx floor) |
| Jupiter program ID (old example) | 2 | 25,835 µlamp |
| Orca Whirlpool SOL-USDC pool (new example) | varies | meaningful |
| Pump.fun global state | 5 | 1,800,000 µlamp |
| USDC mint | 24 | 1,000,000 µlamp |

The "AND across accounts" description was contradicted by the data: passing two accounts together returned **more** non-zero hits than either alone, consistent with max-of-floors and inconsistent with strict AND.

Follow-up to #283 (the Feb fix that clarified EVM RU billing for archive vs full requests). Same theme: docs were directionally right but technically wrong in ways prospects and AI assistants could trip on.

## Out of scope (kept for a later PR to keep this tight)
- The cURL block is tagged \`solidity solidity\` (should be \`bash Bash\`); same for the main TS code block. Pre-existing.
- The page's TLDR / opening framing still describes the method in the older "fees others are paying" framing. The Warning partially counteracts but a fuller rewrite is a larger edit.

## Test plan
- [ ] Mintlify renders both Warning callouts.
- [ ] Preview deploy shows the updated reference and guide pages.
- [ ] The new example curl returns meaningful (non-empty) data when run against a Chainstack Solana endpoint.