### PR TITLE
Hyperliquid: document /nanoreth path for system transactions

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: April 29, 2026" description=" by Ake">
+
+**Protocols**. **Hyperliquid `/nanoreth`** is live on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) mainnet node. Append `/nanoreth` to your endpoint URL to get system transactions included in `eth_getBlockByNumber`, `eth_getBlockReceipts`, and direct hash lookups. The default `/evm` path is unchanged — hl-node-compliant, system transactions stripped from block-shaped responses. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.
+
+<Button href="/changelog/chainstack-updates-april-29-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: April 22, 2026" description=" by Ake">
 
 **Console**. The new [Agents page](https://console.chainstack.com/agents) is live in the Chainstack console — one place to plug Chainstack into Claude Code, Codex CLI/App, Gemini CLI, Cursor, or any other coding agent: migration prompt, docs, MCP server, and Chainstack skill.

--- a/changelog/chainstack-updates-april-29-2026.mdx
+++ b/changelog/chainstack-updates-april-29-2026.mdx
@@ -1,0 +1,8 @@
+---
+title: "Chainstack updates: April 29, 2026"
+description: "Hyperliquid /nanoreth is now live on every Chainstack Hyperliquid mainnet node, with protocol-level system transactions included in HyperEVM JSON-RPC responses."
+---
+
+**Protocols**. **Hyperliquid `/nanoreth`** is live on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) mainnet node. Append `/nanoreth` to your endpoint URL to get system transactions included in `eth_getBlockByNumber`, `eth_getBlockReceipts`, and direct hash lookups. The default `/evm` path is unchanged — hl-node-compliant, system transactions stripped from block-shaped responses. Find both paths in the [console](https://console.chainstack.com/) under **Access and credentials** on any Hyperliquid node.
+
+See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.

--- a/docs.json
+++ b/docs.json
@@ -3543,6 +3543,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-april-29-2026",
           "changelog/chainstack-updates-april-22-2026",
           "changelog/chainstack-updates-march-27-2026",
           "changelog/chainstack-updates-march-18-2026",

--- a/docs/hyperliquid-infrastructure-faq.mdx
+++ b/docs/hyperliquid-infrastructure-faq.mdx
@@ -29,7 +29,7 @@ Both layers share HyperBFT consensus and produce interleaved blocks. Rather than
 
 ### API structure
 
-The platform exposes distinct endpoints for each layer. HyperCore operations route through `/info` for queries and `/exchange` for trading actions, while HyperEVM uses the standard `/evm` JSON-RPC endpoint with Chain ID 999.
+The platform exposes distinct endpoints for each layer. HyperCore operations route through `/info` for queries and `/exchange` for trading actions, while HyperEVM uses the standard JSON-RPC endpoint with Chain ID 999. Chainstack exposes HyperEVM on two paths: `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (with system transactions included). Both are visible on every node and you append the path you need to your endpoint URL — see [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for when to use which.
 
 ### Cross-layer integration
 

--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -7,6 +7,8 @@ description: Complete reference of supported Hyperliquid EVM JSON-RPC methods on
 Methods marked as "Hyperliquid public RPC" in the table below are proprietary to Hyperliquid DEX and have not been open sourced. These methods are currently only available on the public Hyperliquid infrastructure.
 
 If you receive a response similar to `Failed to deserialize the JSON body into the target type`, you need to switch to the Hyperliquid Public RPC to use these methods.
+
+HyperEVM methods listed as `/evm` are also reachable on `/nanoreth`. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method differences.
 </Note>
 
 | Method | Endpoint | Engine | Availability |

--- a/docs/hyperliquid-node-configuration.mdx
+++ b/docs/hyperliquid-node-configuration.mdx
@@ -1,40 +1,65 @@
 ---
 title: "Hyperliquid node configuration and system transactions"
-description: "Understand Hyperliquid system addresses, how the hl-node-compliant flag affects transaction visibility, and availability on Chainstack."
+description: "Chainstack exposes two HyperEVM JSON-RPC paths on every Hyperliquid node: a default path that strips system transactions, and /nanoreth which includes them."
 ---
 
-<Note>
-System transactions are only available on [Dedicated Nodes](/docs/dedicated-node) with custom configuration.
-</Note>
+Every Chainstack Hyperliquid node exposes two HyperEVM JSON-RPC paths on the same endpoint:
 
-## System addresses and transactions
+| Console label | Path | What it returns |
+| --- | --- | --- |
+| **JSON-RPC API (default)** | `/evm` | hl-node-compliant output; system transactions stripped from block-shaped responses |
+| **JSON-RPC API (with system tx)** | `/nanoreth` | Full nanoreth output; system transactions included in blocks and receipts |
 
-System addresses in Hyperliquid facilitate token bridging between HyperCore and HyperEVM. They follow a specific format:
-- First byte: `0x20`
-- Remaining bytes: zeros with token index in big-endian format
-- HYPE token: `0x2222222222222222222222222222222222222222`
+You don't pick one at deploy time — both are always available. Append the path you need to your endpoint URL.
 
-Example for token index 200:
+## What system transactions are
+
+System transactions are protocol-generated pseudo-transactions that record HyperCore state changes on the HyperEVM ledger. They have no signing key — the protocol creates them to bridge state between HyperCore and HyperEVM (HYPE deposits and withdrawals, spot token transfers, and similar). They always carry `gasPrice: 0x0` and originate from system addresses:
+
+- `0x2222222222222222222222222222222222222222` — HYPE native token bridge
+- `0x20000000000000000000000000000000000000XX` — per-token bridge contract, where `XX` is the big-endian token index (token 200 → `…00c8`)
+
+For background, see Hyperliquid docs: [HyperCore ↔ HyperEVM transfers](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers) and the [nanoreth README](https://github.com/hl-archive-node/nanoreth).
+
+## How `/evm` and `/nanoreth` differ in practice
+
+Behavior verified against block `0x202e371` (one HYPE bridge system tx). All methods are present on both paths; the difference is whether system transactions appear in the response:
+
+| Method | `/evm` | `/nanoreth` |
+| --- | --- | --- |
+| `eth_getBlockByNumber` / `eth_getBlockByHash` | transactions array excludes system tx | transactions array includes system tx |
+| `eth_getBlockTransactionCountByNumber` / `ByHash` | count excludes system tx | count includes system tx |
+| `eth_getBlockReceipts` | receipts array excludes system tx receipt | receipts array includes system tx receipt |
+| `eth_getTransactionReceipt` for a system tx hash | returns `null` | returns the receipt |
+| `eth_getTransactionByHash` for a system tx hash | returns the transaction | returns the transaction |
+| `eth_getSystemTxsByBlockNumber` / `ByHash` | returns system txs | returns system txs |
+| `debug_*` / `trace_*` / `ots_*` methods | unchanged | unchanged |
+| All non-system-tx methods (regular blocks, txs, receipts, traces) | unchanged | unchanged |
+
+In short: `/evm` only hides system transactions inside **block-shaped responses** — the transactions array, the transaction count, the receipts array, and `eth_getTransactionReceipt` keyed by a system tx hash. Everything else, including direct system tx lookup by hash via `eth_getTransactionByHash` and the dedicated `eth_getSystemTxsBy*` methods, behaves identically on both paths.
+
+## Endpoint format
+
+```text
+# JSON-RPC API (default), hl-node-compliant
+https://hyperliquid-mainnet.core.chainstack.com/<auth>/evm
+
+# JSON-RPC API (with system tx), nanoreth full output
+https://hyperliquid-mainnet.core.chainstack.com/<auth>/nanoreth
+
+# WebSocket (HyperEVM)
+wss://hyperliquid-mainnet.core.chainstack.com/<auth>/evm
+
+# Info HTTP API (HyperCore)
+https://hyperliquid-mainnet.core.chainstack.com/<auth>/info
 ```
-0x20000000000000000000000000000000000000c8
-```
 
-On HyperEVM, these system transactions are recorded as pseudo-transactions to simplify the implementation of tools that need to track these, like block explorers.
+Find both paths in the [console](https://console.chainstack.com/) under **Access and credentials** on any Hyperliquid node. Username/password access is provided alongside.
 
-See Hyperliquid docs: [HyperCore ↔ HyperEVM transfers](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers) and [nanoreth README](https://github.com/hl-archive-node/nanoreth).
+## Related resources
 
-## Node configuration
-
-### Default nodes (hl-node compliant)
-
-Chainstack Hyperliquid nodes run with the nanoreth `--hl-node-compliant` flag by default:
-- System transactions are **excluded** from output
-- Provides cleaner transaction data similar to the default (non-nanoreth) Hyperliquid node operation.
-
-### Dedicated nodes (system transaction support)
-
-For applications requiring cross-layer transfer tracking, request a dedicated node without the `--hl-node-compliant` flag.
-
-## Requesting system transaction support
-
-Request a Hyperliquid [Dedicated Node](/docs/dedicated-node) deployment or connect to a [reliable Hyperliquid RPC endpoint](https://chainstack.com/build-better-with-hyperliquid/) for standard operations.
+- [Hyperliquid methods](/docs/hyperliquid-methods) — full method-by-method availability and which path each runs on
+- [Hyperliquid infrastructure FAQ](/docs/hyperliquid-infrastructure-faq) — node types, rate limits, and the dual-layer architecture
+- [`eth_getSystemTxsByBlockNumber`](/reference/hyperliquid-evm-eth-get-system-txs-by-block-number) — dedicated method for system transactions
+- [`eth_getSystemTxsByBlockHash`](/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash) — same, keyed by block hash
+- [Build better with Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) — Chainstack's Hyperliquid RPC overview

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
@@ -4,10 +4,10 @@ openapi: /openapi/hyperliquid_node_api/evm_eth_get_system_txs_by_block_hash.json
 ---
 
 <Info>
-This method is available on Chainstack. Not all Hyperliquid methods are available on Chainstack, as the open-source node implementation does not support them yet — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+Available on both the `/evm` (default) and `/nanoreth` (with system tx) paths of any Chainstack Hyperliquid node. To also see system transactions inside `eth_getBlockByHash` and `eth_getBlockReceipts`, use `/nanoreth`. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) and [Hyperliquid methods](/docs/hyperliquid-methods).
 </Info>
 
-The `eth_getSystemTxsByBlockHash` JSON-RPC method returns system transactions for a given block hash on Hyperliquid EVM. This Hyperliquid-specific method provides access to internal system transactions using the block's unique hash identifier, ensuring precise block identification even during chain reorganizations.
+The `eth_getSystemTxsByBlockHash` JSON-RPC method returns system transactions for a given block hash on Hyperliquid EVM. System transactions are protocol-generated pseudo-transactions that record HyperCore↔HyperEVM bridging events (HYPE deposits and withdrawals, spot token transfers, and similar operations) — they always carry `gasPrice: 0x0` and originate from system addresses such as `0x2222…2222` (HYPE bridge) or `0x2000…00XX` (per-token bridge).
 
 <Check>
 **Get your own node endpoint today**

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
@@ -4,10 +4,10 @@ openapi: /openapi/hyperliquid_node_api/evm_eth_get_system_txs_by_block_number.js
 ---
 
 <Info>
-This method is available on Chainstack. Not all Hyperliquid methods are available on Chainstack, as the open-source node implementation does not support them yet — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
+Available on both the `/evm` (default) and `/nanoreth` (with system tx) paths of any Chainstack Hyperliquid node. To also see system transactions inside `eth_getBlockByNumber` and `eth_getBlockReceipts`, use `/nanoreth`. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) and [Hyperliquid methods](/docs/hyperliquid-methods).
 </Info>
 
-The `eth_getSystemTxsByBlockNumber` JSON-RPC method returns system transactions for a given block number on Hyperliquid EVM. This Hyperliquid-specific method provides access to internal system transactions that handle protocol operations, network maintenance, and other system-level activities.
+The `eth_getSystemTxsByBlockNumber` JSON-RPC method returns system transactions for a given block number on Hyperliquid EVM. System transactions are protocol-generated pseudo-transactions that record HyperCore↔HyperEVM bridging events (HYPE deposits and withdrawals, spot token transfers, and similar operations) — they always carry `gasPrice: 0x0` and originate from system addresses such as `0x2222…2222` (HYPE bridge) or `0x2000…00XX` (per-token bridge).
 
 <Check>
 **Get your own node endpoint today**


### PR DESCRIPTION
## Summary

- Every Chainstack Hyperliquid mainnet node now exposes a second HyperEVM JSON-RPC path, `/nanoreth`, that includes protocol-level system transactions in block-shaped responses. The default `/evm` path is unchanged — nanoreth running with `--hl-node-compliant`, system transactions stripped from the transactions array, count, receipts array, and receipt-by-hash lookup.
- Rewrites `docs/hyperliquid-node-configuration.mdx` with the two-path model and a per-method behavior matrix verified against live mainnet block `0x202e371`.
- Adjusts `docs/hyperliquid-methods.mdx` and `docs/hyperliquid-infrastructure-faq.mdx` to point at the new path.
- Updates the two `eth_getSystemTxsBy*` reference pages.
- Adds the April 29, 2026 release notes entry and registers it in `docs.json`.

## Test plan

- [x] `mint validate` — only pre-existing warning (`reference/quick-tutorial` dangling nav entry, unrelated to this change)
- [x] `mint broken-links` — only pre-existing broken links unrelated to this change
- [x] Local visual review on `mintlify dev` for all eight touched pages
- [x] Behavior matrix in the configuration page verified live against `https://hyperliquid-mainnet.core.chainstack.com/<auth>/{evm,nanoreth}` on a block with one HYPE bridge system tx