### PR TITLE
docs: include full error message for Base eth_sendRawTransactionSync timeout cap

### DIFF
--- a/reference/base-sendrawtransactionsync.mdx
+++ b/reference/base-sendrawtransactionsync.mdx
@@ -16,7 +16,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 ## Parameters
 
 * `signedTransactionData` — the signed transaction data in hexadecimal format. This data includes the transaction details such as nonce, gas price, gas limit, to address, value, data, and the signature.
-* `timeout` (optional) — maximum wait time in milliseconds, passed as a number (not a string). If not provided, uses the node's default timeout (typically 2 seconds). Must be a positive integer up to the node-configured maximum of `6000` ms. Values above the maximum are rejected with `time out too long`.
+* `timeout` (optional) — maximum wait time in milliseconds, passed as a number (not a string). If not provided, uses the node's default timeout (typically 2 seconds). Must be a positive integer up to the node-configured maximum of `6000` ms. Values above the maximum are rejected with `time out too long, timeout: <value> ms, max: 6000 ms`.
 
 ## Response
 


### PR DESCRIPTION
Follow-up to #359.

The node returns the cap value in the error string itself: `time out too long, timeout: <value> ms, max: 6000 ms`. Including the full format in the docs is more useful for debugging than the truncated form.

Verified against Base mainnet (Chainstack node, chainId 8453) — request with `timeout: 7000` returns `time out too long, timeout: 7000 ms, max: 6000 ms`.