### PR TITLE
docs: polish Self-Hosted docs pre-launch

### DIFF
--- a/docs/self-hosted/advanced-installation.mdx
+++ b/docs/self-hosted/advanced-installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Advanced installation"
-description: Customize your Chainstack Self-Hosted deployment with external PostgreSQL databases, custom Helm values, and full cpctl command-line reference options.
+description: Customize your Chainstack Self-Hosted deployment with external PostgreSQL databases, custom Helm values, and a full cpctl flag reference.
 ---
 
 Advanced installation generates a values template with pre-filled passwords and RSA keys before deploying. Use this mode when you need to customize the deployment — for example, to connect an external PostgreSQL database or Temporal server, or to adjust resource limits.
@@ -14,7 +14,7 @@ For a quick setup with auto-generated defaults, use the [basic installation](/do
 <Step title="Generate the values template">
 
 ```bash
-cpctl install --advanced -v VERSION
+cpctl install --advanced
 ```
 
 This creates a `cp-values.yaml` file in your current directory with auto-generated passwords and keys.
@@ -22,8 +22,12 @@ This creates a `cp-values.yaml` file in your current directory with auto-generat
 To specify a different output file, use the `-o` flag:
 
 ```bash
-cpctl install --advanced -v VERSION -o my-values.yaml
+cpctl install --advanced -o my-values.yaml
 ```
+
+<Note>
+By default, the installer uses the latest version. To pin a specific version, add `-v vX.Y.Z` — see [Release notes](/docs/self-hosted/release-notes) for available versions.
+</Note>
 
 </Step>
 
@@ -49,7 +53,7 @@ Common customizations:
 Run the installer with your edited values file (replace the file name if you used `-o`):
 
 ```bash
-cpctl install -v VERSION -f cp-values.yaml -s STORAGE_CLASS_NAME
+cpctl install -f cp-values.yaml -s STORAGE_CLASS_NAME
 ```
 
 </Step>
@@ -60,7 +64,7 @@ The installer shows a summary and asks you to confirm:
 
 ```text
 ==> About to install Control Panel
-  Version: v1.4.6
+  Version: v1.8.0
   Namespace: control-panel
   Workload Namespace: control-panel-deployments
   Release: cp

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -46,7 +46,20 @@ The Control Panel itself consumes system resources. When planning your infrastru
 
 <Step title="Configure node settings">
 
-Select the deployment configuration preset.
+Each Ethereum network ships with two preset tiers — a standard preset for production and a Light preset for evaluation. The Light preset uses half the CPU and RAM of the standard preset but the same storage, so you can move between tiers without resizing disks.
+
+| Network | Preset name in the UI | CPU (total) | RAM (total) | Storage |
+|---------|------------------------|-------------|-------------|---------|
+| Ethereum Mainnet | `Ethereum Mainnet Reth Prysm` | 8 vCPU | 32 GiB | ~2 TiB |
+| Ethereum Mainnet | `Ethereum Mainnet Reth Prysm (Light)` | 4 vCPU | 16 GiB | ~2 TiB |
+| Ethereum Sepolia | `Ethereum Sepolia Reth Prysm` | 8 vCPU | 32 GiB | ~1.3 TiB |
+| Ethereum Sepolia | `Ethereum Sepolia Reth Prysm (Light)` | 4 vCPU | 16 GiB | ~1.3 TiB |
+| Ethereum Hoodi | `Ethereum Hoodi Reth Prysm` | 8 vCPU | 32 GiB | 250 GiB |
+| Ethereum Hoodi | `Ethereum Hoodi Reth Prysm (Light)` | 4 vCPU | 16 GiB | 250 GiB |
+
+CPU and RAM are split evenly between the Reth (execution) and Prysm (consensus) clients. Both presets currently ship Reth v1.11.3 and Prysm v7.1.3, with snapshot bootstrap enabled by default — see the next step.
+
+For production, pick the standard preset and size your host per [System requirements](/docs/self-hosted/requirements). For evaluation on a smaller server, pick the Light preset.
 
 </Step>
 

--- a/docs/self-hosted/download-installer.mdx
+++ b/docs/self-hosted/download-installer.mdx
@@ -1,9 +1,15 @@
 ---
-title: "Install Chainstack Self-Hosted"
-description: Download the Chainstack Self-Hosted installer and run the cpctl bootstrap command to set up your self-managed blockchain infrastructure environment.
+title: "Install the Self-Hosted CLI"
+description: Install cpctl, the Chainstack Self-Hosted command-line tool, on Linux, macOS, or Windows using the Chainstack bootstrap script.
 ---
 
-To install Chainstack Self-Hosted, run the installer for your operating system:
+**`cpctl`** is the command-line tool for installing and upgrading Chainstack Self-Hosted. This page covers getting it onto your local machine.
+
+<Info>
+Installing `cpctl` only puts it on your machine. It does not deploy the Control Panel itself — for that, see [Installation](/docs/self-hosted/installation).
+</Info>
+
+To install `cpctl`, run the script for your operating system:
 
 <Tabs>
 <Tab title="Linux / macOS">
@@ -46,13 +52,13 @@ The installer automatically detects your operating system and architecture.
 Pass the version as an argument:
 
 ```bash
-curl -sSL https://install.chainstack.com/cpctl.sh | sh -s v1.4.6
+curl -sSL https://install.chainstack.com/cpctl.sh | sh -s v1.8.0
 ```
 
 Or set the `CPCTL_VERSION` environment variable:
 
 ```bash
-CPCTL_VERSION=v1.4.6 curl -sSL https://install.chainstack.com/cpctl.sh | sh
+CPCTL_VERSION=v1.8.0 curl -sSL https://install.chainstack.com/cpctl.sh | sh
 ```
 
 </Tab>
@@ -60,13 +66,13 @@ CPCTL_VERSION=v1.4.6 curl -sSL https://install.chainstack.com/cpctl.sh | sh
 
 ```powershell
 iwr https://install.chainstack.com/cpctl.ps1 -OutFile cpctl.ps1
-.\cpctl.ps1 -Version v1.4.6
+.\cpctl.ps1 -Version v1.8.0
 ```
 
 Or set the `CPCTL_VERSION` environment variable:
 
 ```powershell
-$env:CPCTL_VERSION = "v1.4.6"
+$env:CPCTL_VERSION = "v1.8.0"
 irm https://install.chainstack.com/cpctl.ps1 | iex
 ```
 
@@ -170,3 +176,11 @@ To persist, add that line to your PowerShell profile (`$PROFILE`).
 
 </Tab>
 </Tabs>
+
+## Next steps
+
+With `cpctl` on your machine, you're ready to set up the cluster and deploy the Control Panel:
+
+1. [Environment setup](/docs/self-hosted/environment-setup) — Set up your Kubernetes cluster and required tools, if not already done
+2. [Installation](/docs/self-hosted/installation) — Deploy the Control Panel using `cpctl install`
+3. [Quick start](/docs/self-hosted/quick-start) — End-to-end walkthrough from a fresh server

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -17,7 +17,7 @@ Yes. Chainstack Self-Hosted is generally available and supports production deplo
 
 ### Is snapshot-based deployment available?
 
-Snapshot-based deployment is available as of v1.4.6. Nodes can be deployed from a pre-downloaded chain snapshot, reducing initial sync from days to hours. The sync method is presented as an option in the deployment wizard.
+Yes. Nodes can be deployed from a pre-downloaded chain snapshot, reducing initial sync from days to hours. The sync method is presented as an option in the deployment wizard.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 
@@ -31,7 +31,7 @@ Planned additions include additional EVM-compatible chains and Layer 2 networks.
 
 ### Is monitoring and observability available?
 
-Monitoring is available as of v1.4.6. The Control Panel ships with an optional integrated observability stack: VictoriaMetrics for metrics storage, Grafana for dashboards, and the Chainstack blockchain-node-exporter for chain-specific health signals. The stack is enabled at install time and requires no additional configuration.
+Yes. The Control Panel ships with an optional integrated observability stack: VictoriaMetrics for metrics storage, Grafana for dashboards, and the Chainstack blockchain-node-exporter for chain-specific health signals. The stack is enabled at install time and requires no additional configuration.
 
 ### Do you plan to support validator nodes?
 
@@ -64,7 +64,7 @@ Chainstack Self-Hosted works with any recent Kubernetes distribution:
 
 **Control Panel + Ethereum Mainnet node:**
 
-- 6 CPU cores, 18 GB RAM, 2+ TB NVMe SSD
+- 6 CPU cores, 20 GB RAM, 2+ TB NVMe SSD
 
 See [System requirements](/docs/self-hosted/requirements) for detailed specifications.
 

--- a/docs/self-hosted/first-login.mdx
+++ b/docs/self-hosted/first-login.mdx
@@ -24,7 +24,7 @@ Your credentials:
 
 ### Accessing the login page
 
-Open your browser and navigate to the Control Panel URL. If you haven't exposed the service yet, see [Expose the UI service](/docs/self-hosted/installation#expose-the-ui-service) for instructions. The URL depends on how you exposed the service:
+Open your browser and navigate to the Control Panel URL. If you haven't exposed the services yet, see [Expose the UI and deployments API](/docs/self-hosted/installation#expose-the-ui-and-deployments-api) for instructions. The URL depends on how you exposed the services:
 
 | Exposure method | URL |
 |-----------------|-----|

--- a/docs/self-hosted/installation.mdx
+++ b/docs/self-hosted/installation.mdx
@@ -27,17 +27,21 @@ Common storage classes:
 - `topolvm-provisioner` — TopoLVM (multi-disk setups)
 - Cloud providers use their own defaults (`gp2`/`gp3` on AWS, `standard` on GCP, `managed-premium` on Azure)
 
-Run the installer with your version and storage class:
+Run the installer with your storage class:
 
 ```bash
-cpctl install -v VERSION -s STORAGE_CLASS_NAME
+cpctl install -s STORAGE_CLASS_NAME
 ```
 
 For example:
 
 ```bash
-cpctl install -v v1.4.6 -s topolvm-provisioner
+cpctl install -s topolvm-provisioner
 ```
+
+<Note>
+By default, the installer uses the latest version. To pin a specific version, add `-v vX.Y.Z` — see [Release notes](/docs/self-hosted/release-notes) for available versions.
+</Note>
 
 To get the installer, see [Download Chainstack Self-Hosted](/docs/self-hosted/download-installer).
 
@@ -55,14 +59,18 @@ No values file provided. Generate passwords automatically? [y/N]: y
 
 <Step title="Specify the URL for the backend">
 
-The installer will ask for the backend API URL. The Control Panel UI uses this URL to reach the deployments API.
+The installer will ask for the backend API URL. This is the URL the Control Panel UI uses to reach the deployments API. **The browser must be able to resolve and reach this URL** — an in-cluster hostname will not work for browser access.
 
 ```text
 Enter CP UI backend API URL [http://cp-cp-deployments-api]:
 ```
 
-- **Single server, accessing the UI from a browser** — enter your server's public IP: `http://<SERVER-PUBLIC-IP>`. You will need to expose the UI service on port 80 later (see [Post-installation](#expose-the-ui-service)).
-- **Default** — press Enter to keep `http://cp-cp-deployments-api`. This uses in-cluster DNS and only works if the UI is also accessed from inside the cluster.
+- **Single server, browser access (recommended)** — enter `http://<SERVER-IP>:8081`. You will expose the deployments API on port 8081 in [Post-installation](#expose-the-ui-and-deployments-api). Use port 80 (or another free port) instead of 8081 if it suits your environment, but match it during exposure.
+- **In-cluster only (rare)** — press Enter to keep `http://cp-cp-deployments-api`. This is reachable only from inside the cluster, so the UI will fail to log in from a browser outside.
+
+<Tip>
+You can skip this prompt by passing `--backend-url http://<SERVER-IP>:8081` to `cpctl install`.
+</Tip>
 
 </Step>
 
@@ -103,7 +111,7 @@ The installer will show a summary and ask you to confirm:
 
 ```text
 ==> About to install Control Panel
-  Version: v1.4.6
+  Version: v1.8.0
   Namespace: control-panel
   Workload Namespace: control-panel-deployments
   Release: cp
@@ -134,7 +142,7 @@ This file contains sensitive passwords and keys. Keep it secure and backed up.
 
 ### Monitoring stack
 
-v1.4.6+ includes an optional integrated observability stack (Grafana, VictoriaMetrics, and the Chainstack blockchain-node-exporter). During installation, you are prompted to install it, reuse an existing VictoriaMetrics operator, or skip it. See [Monitoring](/docs/self-hosted/monitoring) for access instructions and available dashboards.
+The Control Panel includes an optional integrated observability stack (Grafana, VictoriaMetrics, and the Chainstack blockchain-node-exporter). During installation, you are prompted to install it, reuse an existing VictoriaMetrics operator, or skip it. See [Monitoring](/docs/self-hosted/monitoring) for access instructions and available dashboards.
 
 ### Verify deployment status
 
@@ -160,23 +168,27 @@ Useful flags:
 | `-o json` / `-o yaml` | Machine-readable output for automation |
 | `--log-file <path>` | Write the status output to a file |
 
-### Expose the UI service
+### Expose the UI and deployments API
+
+For browser access to work, you need to expose **two** services to the network: the UI (`cp-cp-ui`) and the deployments API (`cp-cp-deployments-api`). The UI page is served by the first; the JavaScript in the page calls the URL you set in the [backend URL step](#specify-the-url-for-the-backend) — by default, that's `http://<SERVER-IP>:8081`, which routes to the deployments API.
 
 #### Option 1: LoadBalancer (recommended for production)
 
 ```bash
 kubectl expose service cp-cp-ui --type=LoadBalancer --name=cp-ui-external -n control-panel
+kubectl expose service cp-cp-deployments-api --type=LoadBalancer --name=cp-deployments-api-external -n control-panel --port=8081 --target-port=8080
 ```
 
 #### Option 2: NodePort
 
 ```bash
 kubectl expose service cp-cp-ui --type=NodePort --name=cp-ui-nodeport -n control-panel
+kubectl expose service cp-cp-deployments-api --type=NodePort --name=cp-deployments-api-nodeport -n control-panel --port=8081 --target-port=8080
 ```
 
 #### Option 3: Ingress
 
-Create an Ingress resource:
+Create an Ingress that exposes the UI on port 80. The deployments API is exposed separately on port 8081 via a LoadBalancer or port-forward (see Options 1 or 4):
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -201,7 +213,8 @@ spec:
 #### Option 4: Port forward (testing only)
 
 ```bash
-kubectl port-forward svc/cp-cp-ui 8080:80 -n control-panel --address 0.0.0.0
+kubectl port-forward svc/cp-cp-ui 8080:80 -n control-panel --address 0.0.0.0 &
+kubectl port-forward svc/cp-cp-deployments-api 8081:8080 -n control-panel --address 0.0.0.0 &
 ```
 
 ## Next steps

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -18,6 +18,8 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 
+You install and upgrade Chainstack Self-Hosted using `cpctl`, our command-line tool — see [Install the Self-Hosted CLI](/docs/self-hosted/download-installer) to get it.
+
 ## Getting help
 
 - Technical support — [Chainstack Support Center](https://support.chainstack.com/hc/en-us)

--- a/docs/self-hosted/managing-nodes.mdx
+++ b/docs/self-hosted/managing-nodes.mdx
@@ -59,7 +59,7 @@ The endpoint URLs are internal Kubernetes service addresses. To access nodes fro
 
 ### Settings tab
 
-Additional actions for the deployed node. The list of available actions at the moment:
+The Settings tab provides additional actions for the deployed node. Currently available:
 
 | Action | Purpose |
 |--------|---------|
@@ -67,7 +67,7 @@ Additional actions for the deployed node. The list of available actions at the m
 
 ## Monitoring
 
-v1.4.6+ includes an integrated observability stack with pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics. See [Monitoring](/docs/self-hosted/monitoring) for access instructions.
+The Control Panel includes an integrated observability stack with pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics. See [Monitoring](/docs/self-hosted/monitoring) for access instructions.
 
 ## Next steps
 

--- a/docs/self-hosted/monitoring.mdx
+++ b/docs/self-hosted/monitoring.mdx
@@ -3,7 +3,7 @@ title: "Monitoring"
 description: Use the integrated Grafana and Prometheus observability stack in Chainstack Self-Hosted to monitor node health, sync status, and resource utilization.
 ---
 
-Chainstack Self-Hosted v1.4.6+ ships with an optional integrated observability stack deployed inside the `control-panel` namespace alongside the Control Panel itself. No additional configuration is required.
+Chainstack Self-Hosted ships with an optional integrated observability stack deployed inside the `control-panel` namespace alongside the Control Panel itself. No additional configuration is required.
 
 ## Stack components
 
@@ -65,7 +65,7 @@ During installation, the installer prompts you to configure the monitoring stack
 You can also skip it non-interactively with `--disable-monitoring`:
 
 ```bash
-cpctl install -v VERSION -s STORAGE_CLASS_NAME --disable-monitoring
+cpctl install -s STORAGE_CLASS_NAME --disable-monitoring
 ```
 
 Skipping monitoring removes all observability components. The Control Panel itself is unaffected.

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -144,21 +144,24 @@ If you're using the default k3s local-path storage class (single disk), you can 
 
 <Step title="Run the installation">
 
-Run the installer with your desired version and storage class:
+Run the installer with your storage class and your server's public IP. Replace `<SERVER-IP>` with the actual IP:
 
 ```bash
-cpctl install -v v1.4.6 -s topolvm-provisioner
+cpctl install -s topolvm-provisioner --backend-url http://<SERVER-IP>:8081
 ```
+
+<Note>
+The `--backend-url` is the URL the browser will use to reach the deployments API. We expose the deployments API on port 8081 in the next steps. By default, the installer uses the latest version — to pin one, add `-v vX.Y.Z` (see [Release notes](/docs/self-hosted/release-notes) for available versions).
+</Note>
 
 The installer will:
 
 1. Check prerequisites (kubectl, helm, yq, openssl, cluster access)
 2. Generate secure passwords for all services
 3. Save the credentials to `~/.config/cp-suite/values/`
-4. Prompt for the backend API URL. Use the default (`http://cp-cp-deployments-api`) for in-cluster access, or specify an external URL (e.g., `http://<SERVER-PUBLIC-IP>`) if accessing from outside the cluster.
-5. Prompt for the workload namespace where blockchain node pods will run (default: `control-panel-deployments`).
-6. Prompt to configure the monitoring stack — install fresh, reuse an existing VictoriaMetrics operator, or skip.
-7. Show a summary and ask you to confirm before deploying.
+4. Prompt for the workload namespace where blockchain node pods will run (default: `control-panel-deployments`).
+5. Prompt to configure the monitoring stack — install fresh, reuse an existing VictoriaMetrics operator, or skip.
+6. Show a summary and ask you to confirm before deploying.
 
 The installation typically takes 5–10 minutes. You'll see output similar to:
 
@@ -178,7 +181,7 @@ The installation typically takes 5–10 minutes. You'll see output similar to:
 ✓ Storage class "topolvm-provisioner" validated
 
 ==> About to install Control Panel
-  Version: v1.4.6
+  Version: v1.8.0
   Namespace: control-panel
   Workload Namespace: control-panel-deployments
   Release: cp
@@ -213,9 +216,11 @@ Reason: All components ready
 
 </Step>
 
-<Step title="Expose the web interface">
+<Step title="Expose the web interface and deployments API">
 
-Apply an Ingress to expose both the Control Panel and Grafana under the same IP. The example below uses Traefik, which k3s ships with by default:
+Browser access requires exposing both the UI and the deployments API. The Ingress below puts the UI and Grafana on port 80; the deployments API is exposed separately on port 8081 to match the `--backend-url` you set during installation.
+
+Apply the Ingress for the UI and Grafana. The example uses Traefik, which k3s ships with by default:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -247,12 +252,23 @@ spec:
 EOF
 ```
 
-For testing without an ingress controller, use port forwarding:
+Expose the deployments API on port 8081:
+
+```bash
+kubectl port-forward svc/cp-cp-deployments-api 8081:8080 -n control-panel --address 0.0.0.0 &
+```
+
+For testing without an ingress controller, use port forwarding for everything:
 
 ```bash
 kubectl port-forward svc/cp-cp-ui 8080:80 -n control-panel --address 0.0.0.0 &
 kubectl port-forward svc/cp-grafana 3000:80 -n control-panel --address 0.0.0.0 &
+kubectl port-forward svc/cp-cp-deployments-api 8081:8080 -n control-panel --address 0.0.0.0 &
 ```
+
+<Note>
+The `kubectl port-forward` process must keep running for the deployments API to remain reachable. For production deployments, expose `cp-cp-deployments-api` via a LoadBalancer or NodePort instead — see [Expose the UI and deployments API](/docs/self-hosted/installation#expose-the-ui-and-deployments-api).
+</Note>
 
 </Step>
 

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -25,12 +25,16 @@ The Control Panel runs inside a Kubernetes cluster and includes the web interfac
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
 | CPU | 1 core | 4 cores |
-| RAM | 2 GB | 4 GB |
-| Storage | 8 GB | 15 GB |
+| RAM | 4 GB | 4 GB |
+| Storage | 10 GB | 15 GB |
 
 <Note>
 These requirements are for the Control Panel only. Blockchain nodes require additional resources as specified below.
 </Note>
+
+<Tip>
+The Control Panel has a small, stable memory footprint — 4 GB is sufficient for production deployments.
+</Tip>
 
 ### Software requirements
 
@@ -111,7 +115,7 @@ For a deep dive on SSD selection for Ethereum nodes, see [yorickdowne's SSD guid
 | Snapshot-based bootstrapping | Minutes to Hours (network dependent) |
 
 <Note>
-Snapshot-based bootstrapping is available in v1.4.6+. The sync method is selected in the deployment wizard.
+You select the sync method in the [deployment wizard](/docs/self-hosted/deploying-nodes#deployment-wizard).
 </Note>
 
 ## Network requirements
@@ -131,7 +135,14 @@ All Control Panel services communicate internally within the Kubernetes cluster.
 
 ### External access
 
-To access the Control Panel web interface, you need to expose the `cp-cp-ui` service. Options include:
+For browser-based UI access, you need to expose **both** the UI service (`cp-cp-ui`) and the deployments API service (`cp-cp-deployments-api`). The browser loads the UI page from `cp-cp-ui` and then calls `cp-cp-deployments-api` directly using the `--backend-url` you set at install time.
+
+| Service | Default external port | Purpose |
+|---------|----------------------|---------|
+| `cp-cp-ui` | 80 | Web interface |
+| `cp-cp-deployments-api` | 8081 (mapped to internal 8080) | Backend API used by the UI |
+
+Either service can be exposed using:
 
 | Method | Use case |
 |--------|----------|
@@ -142,7 +153,7 @@ To access the Control Panel web interface, you need to expose the `cp-cp-ui` ser
 
 ### Firewall rules
 
-For the Control Panel, the UI service port must be accessible from outside the cluster. If you configured an external backend URL during installation, the deployments API port (default 8081) must also be accessible. All other services communicate internally.
+The UI service port (default 80) and the deployments API port (default 8081) must both be reachable from clients that will access the Control Panel through a browser. All other Control Panel services communicate internally inside the cluster.
 
 For blockchain nodes, the required ports depend on the protocol:
 
@@ -161,8 +172,12 @@ For a complete deployment running the Control Panel plus one Ethereum Mainnet fu
 | Resource | Control Panel | Ethereum Node | Total |
 |----------|---------------|---------------|-------|
 | CPU | 2 cores | 4 cores | 6 cores |
-| RAM | 2 GB | 16 GB | 18 GB |
+| RAM | 4 GB | 16 GB | 20 GB |
 | Storage | 10 GB | 2 TB | ~2 TB |
+
+<Note>
+The Control Panel column reflects the recommended allocation when running alongside a blockchain node, which gives the Control Panel some headroom on a shared host. The strict Control Panel minimum is 1 core — see [Hardware requirements](#hardware-requirements) above.
+</Note>
 
 ### Example server configurations
 

--- a/docs/self-hosted/support.mdx
+++ b/docs/self-hosted/support.mdx
@@ -29,16 +29,16 @@ When contacting support, please include:
 ./cpctl status > diagnostic.txt
 kubectl get events -n control-panel >> diagnostic.txt
 kubectl get events -n control-panel-deployments >> diagnostic.txt
-timestamp=\$(date +%s)
-touch debug-\$timestamp.txt
-debug=debug-\$timestamp.txt
-for pod in \$(kubectl get pods -n control-panel -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel --since=1h 2>/dev/null >> \$debug
+timestamp=$(date +%s)
+touch debug-$timestamp.txt
+debug=debug-$timestamp.txt
+for pod in $(kubectl get pods -n control-panel -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel --since=1h 2>/dev/null >> $debug
 done
-for pod in \$(kubectl get pods -n control-panel-deployments -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel-deployments --since=1h 2>/dev/null >> \$debug
+for pod in $(kubectl get pods -n control-panel-deployments -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel-deployments --since=1h 2>/dev/null >> $debug
 done
 ```
 

--- a/docs/self-hosted/troubleshooting.mdx
+++ b/docs/self-hosted/troubleshooting.mdx
@@ -304,16 +304,16 @@ kubectl top pods -n control-panel
 
 ```bash
 # All pods, last hour
-timestamp=\$(date +%s)
-touch debug-\$timestamp.txt
-debug=debug-\$timestamp.txt
-for pod in \$(kubectl get pods -n control-panel -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel --since=1h 2>/dev/null >> \$debug
+timestamp=$(date +%s)
+touch debug-$timestamp.txt
+debug=debug-$timestamp.txt
+for pod in $(kubectl get pods -n control-panel -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel --since=1h 2>/dev/null >> $debug
 done
-for pod in \$(kubectl get pods -n control-panel-deployments -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel-deployments --since=1h 2>/dev/null >> \$debug
+for pod in $(kubectl get pods -n control-panel-deployments -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel-deployments --since=1h 2>/dev/null >> $debug
 done
 ```
 
@@ -340,7 +340,7 @@ This destroys all data. Only use as last resort.
 cpctl uninstall
 
 # Reinstall
-cpctl install -v v1.4.6
+cpctl install
 ```
 
 ### Recover from database issues
@@ -365,16 +365,16 @@ If you cannot resolve an issue, check the [FAQ](/docs/self-hosted/faq) for known
 cpctl status > diagnostic.txt
 kubectl get events -n control-panel >> diagnostic.txt
 kubectl get events -n control-panel-deployments >> diagnostic.txt
-timestamp=\$(date +%s)
-touch debug-\$timestamp.txt
-debug=debug-\$timestamp.txt
-for pod in \$(kubectl get pods -n control-panel -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel --since=1h 2>/dev/null >> \$debug
+timestamp=$(date +%s)
+touch debug-$timestamp.txt
+debug=debug-$timestamp.txt
+for pod in $(kubectl get pods -n control-panel -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel --since=1h 2>/dev/null >> $debug
 done
-for pod in \$(kubectl get pods -n control-panel-deployments -o name); do
-  echo "=== \$pod ===" >> \$debug
-  kubectl logs \$pod -n control-panel-deployments --since=1h 2>/dev/null >> \$debug
+for pod in $(kubectl get pods -n control-panel-deployments -o name); do
+  echo "=== $pod ===" >> $debug
+  kubectl logs $pod -n control-panel-deployments --since=1h 2>/dev/null >> $debug
 done
 ```
 

--- a/docs/self-hosted/upgrade.mdx
+++ b/docs/self-hosted/upgrade.mdx
@@ -17,11 +17,9 @@ Use `cpctl upgrade` to update the Control Panel to a new version in place.
 cpctl upgrade -v VERSION
 ```
 
-For example:
-
-```bash
-cpctl upgrade -v v1.4.6
-```
+<Note>
+Replace `VERSION` with the target version — see [Release notes](/docs/self-hosted/release-notes) for available versions.
+</Note>
 
 The upgrade is atomic: if the deployment fails or times out, Helm automatically rolls back to the previous revision.
 
@@ -32,8 +30,8 @@ After passing preflight checks and backing up your values, `cpctl upgrade` compu
 │                              Upgrade Plan                              │
 ├────────────────────────────────────────────────────────────────────────┤
 │  Release:   cp (namespace: control-panel)                              │
-│  From:      cp-distributed v1.4.6 (rev 1)                              │
-│  To:        cp-distributed v1.5.0                                      │
+│  From:      cp-distributed v1.7.1 (rev 1)                              │
+│  To:        cp-distributed v1.8.0                                      │
 │  Values:    preserved (backed up)                                      │
 │  Mode:      atomic (auto-rollback on fail)                             │
 │  Backup:    /root/.config/cp-suite/values/pre-upgrade-cp-1-<timestamp>…│
@@ -52,7 +50,7 @@ Proceed with upgrade? [y/N]:
 On success:
 
 ```text
-✓ Upgrade to v1.5.0 completed (revision 1 → 2)
+✓ Upgrade to v1.8.0 completed (revision 1 → 2)
 ```
 
 After a successful upgrade, a journal is written to your config directory for auditability.


### PR DESCRIPTION
## Summary

Pre-launch polish pass on the Self-Hosted documentation, covering issues caught in a structured read-through of all 14 guide pages plus cross-checks against engineering tickets, Slack history, the actual `cp-gts` preset definitions, and a hands-on `cpctl v1.8.0` dry-run.

Highlights (full list in the commit message):

- **Sizing numbers reconciled** across the 4 pages that mentioned them (Control Panel min: 1 core / 4 GB / 10 GB; combined example labeled with headroom note)
- **`cpctl install` examples no longer require `-v VERSION`** — CORE-14381 shipped in cpctl v1.8.0, default is latest
- **Backend URL flow now works end-to-end** — quick-start and installation now produce a working browser login by default; deployments API is exposed on port 8081 alongside the UI
- **New preset table** in deploying-nodes.mdx Step 3 (Standard / Light tiers per Ethereum network, with CPU/RAM/storage)
- **Terminology cleanup** — dropped redundant "cpctl CLI" / "chart version", introduced cpctl on the introduction page
- **Stripped `v1.4.6+` feature gates** (redundant — bootstrap pulls latest)
- **Fixed broken `\$` escapes** in bash code blocks across `support.mdx` and `troubleshooting.mdx`

## Test plan

- [x] Reviewed locally with `mintlify dev` — all 14 affected pages render cleanly, cross-links resolve, code blocks render without escape artifacts
- [x] Cross-references between renamed sections still resolve (first-login link to expose-services)
- [ ] Hands-on validation against a real install — pending post-launch (Section 3 of the project plan); follow-up fixes likely