### PR TITLE
docs: Self-Hosted hardware sizing + verification-driven fixes

### DIFF
--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -57,18 +57,9 @@ Each Ethereum network ships with two preset tiers — a standard preset for prod
 | Ethereum Hoodi | `Ethereum Hoodi Reth Prysm` | 8 vCPU | 32 GiB | 250 GiB |
 | Ethereum Hoodi | `Ethereum Hoodi Reth Prysm (Light)` | 4 vCPU | 16 GiB | 250 GiB |
 
-CPU and RAM are split evenly between the Reth (execution) and Prysm (consensus) clients. Both presets currently ship Reth v1.11.3 and Prysm v7.1.3, with snapshot bootstrap enabled by default — see the next step.
+CPU and RAM are split evenly between the Reth (execution) and Prysm (consensus) clients. Both presets currently ship Reth v1.11.3 and Prysm v7.1.3, with snapshot bootstrap pre-configured — the node downloads a pre-built chain snapshot rather than syncing from genesis. See [Initial sync times](#initial-sync-times) below for what to expect.
 
 For production, pick the standard preset and size your host per [System requirements](/docs/self-hosted/requirements). For evaluation on a smaller server, pick the Light preset.
-
-</Step>
-
-<Step title="Select sync method">
-
-Choose how the node bootstraps its chain data:
-
-- **Snapshot** — downloads a pre-built snapshot and starts from a recent block. Reduces time-to-live from days to hours or even minutes. Available when a snapshot exists for the selected network.
-- **Full sync** — syncs from genesis. Always available, but takes 2–5 days for Ethereum Mainnet.
 
 </Step>
 
@@ -95,17 +86,17 @@ After initiating deployment, the node goes through several phases:
 | **Running** | Node is deployed and synchronizing with the network | Continuous |
 
 <Note>
-The node shows **Running** status once deployed. Initial blockchain sync happens in the background. With standard sync, this can take 2–5 days for Ethereum Mainnet. With snapshot-based bootstrapping, sync completes in hours.
+The node shows **Running** status once deployed. Initial bootstrap from the snapshot completes in minutes to hours; the node then catches up to the chain head in the background.
 </Note>
 
 ### Initial sync times
 
-Sync times depend on your hardware, network, and sync method:
+Sync times depend on your hardware and network conditions:
 
-| Method | Approximate time |
-|--------|------------------|
-| Full sync from genesis | 2–5 days |
-| Snapshot-based bootstrapping | Minutes to Hours (network dependent) |
+| Phase | Approximate time |
+|-------|------------------|
+| Snapshot bootstrap | Minutes to hours (network dependent) |
+| Catch-up to chain head | Continuous |
 
 See [System requirements](/docs/self-hosted/requirements) for specifications and a community-maintained list of hardware recommendations.
 

--- a/docs/self-hosted/evaluation-setup.mdx
+++ b/docs/self-hosted/evaluation-setup.mdx
@@ -1,29 +1,27 @@
 ---
 title: "Evaluation setup"
-description: Minimum hardware requirements and quick setup path for evaluating Chainstack Self-Hosted on modest hardware before committing to a production deployment.
+description: Smallest viable hardware to install and try Chainstack Self-Hosted before committing to a production deployment.
 ---
 
-You do not need dedicated server hardware to try Chainstack Self-Hosted. The Control Panel runs comfortably on a laptop, a virtual machine, or a small cloud instance. This page covers the minimum you need to get started.
+This page covers the smallest hardware that lets you install the Chainstack Self-Hosted Control Panel end-to-end and click around. It is not "laptop-tier" — the Control Panel runs ~22 pods on Kubernetes, and the cumulative pod resource requests set a real floor.
 
 ## What you need
 
-The Control Panel is the management interface where you deploy, monitor, and manage blockchain nodes. It requires very modest resources:
+The Control Panel is the management interface where you deploy, monitor, and manage blockchain nodes. The minimum that lets a fresh `cpctl install` reach `Healthy` status:
 
 | Resource | Minimum |
 |----------|---------|
-| CPU | 1 core |
-| RAM | 2 GB |
-| Storage | 10 GB |
+| CPU | 6 cores |
+| RAM | 8 GiB |
+| Storage | 15 GB |
 
-<Note>
-These are the requirements for the Control Panel only. No blockchain node resources are needed at this stage.
-</Note>
+These requirements are for the Control Panel only. Blockchain nodes require additional resources — see [Optional — deploy a testnet node](#optional-deploy-a-testnet-node) below or [System requirements](/docs/self-hosted/requirements) for the full picture.
 
-Any of these environments will work:
+Any of these environments will work for the Control Panel:
 
-- A modern laptop or desktop running Linux
-- A virtual machine with 2 GB of RAM
-- A basic cloud instance from any provider
+- A small dedicated server
+- A virtual machine with at least 6 vCPUs and 8 GiB RAM
+- A cloud instance such as DigitalOcean `s-8vcpu-16gb` or equivalent on AWS/GCP/Azure
 
 ## Software
 
@@ -53,14 +51,16 @@ With just the Control Panel running, you can:
 
 ## Optional — deploy a testnet node
 
-If you want to go a step further and deploy an actual blockchain node, the Ethereum Hoodi testnet is the lightest option available.
+If you want to go a step further and deploy an actual blockchain node, the Ethereum Hoodi testnet is the lightest option available. The Light preset uses half the CPU and RAM of the standard preset but the same storage.
 
-| Resource | Control Panel + Hoodi node |
-|----------|---------------------------|
-| CPU | 4 cores |
-| RAM | 16 GB |
-| Storage | 250 GB NVMe SSD |
+| Resource | Control Panel + Hoodi node (Light preset) |
+|----------|--------------------------------------------|
+| CPU | 10 cores |
+| RAM | 24 GiB |
+| Storage | 265 GB NVMe SSD |
+
+The numbers above sum the Control Panel minimum (6 cores / 8 GiB / 15 GB) and the Hoodi Light preset (4 cores / 16 GiB / 250 GiB).
 
 <Note>
-Hoodi is an Ethereum testnet that uses test ETH with no real value, making it ideal for evaluation. Initial sync takes several hours to a day depending on your hardware.
+Hoodi is an Ethereum testnet that uses test ETH with no real value, making it ideal for evaluation. Initial bootstrap from the snapshot completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background.
 </Note>

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -60,11 +60,11 @@ Chainstack Self-Hosted works with any recent Kubernetes distribution:
 
 **Control Panel only:**
 
-- 1 CPU core, 4 GB RAM, 10 GB storage
+- 6 CPU cores, 8 GiB RAM, 15 GB storage
 
-**Control Panel + Ethereum Mainnet node:**
+**Control Panel + Ethereum Mainnet node (Light preset):**
 
-- 6 CPU cores, 20 GB RAM, 2+ TB NVMe SSD
+- 10 CPU cores, 24 GiB RAM, 2+ TB NVMe SSD
 
 See [System requirements](/docs/self-hosted/requirements) for detailed specifications.
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -17,7 +17,7 @@ Yes. Chainstack Self-Hosted is generally available and supports production deplo
 
 ### Is snapshot-based deployment available?
 
-Yes. Nodes can be deployed from a pre-downloaded chain snapshot, reducing initial sync from days to hours. The sync method is presented as an option in the deployment wizard.
+Yes — all current presets ship with snapshot bootstrap pre-configured. Nodes deploy from a pre-built chain snapshot rather than syncing from genesis, reducing initial sync from days to hours.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -144,10 +144,10 @@ If you're using the default k3s local-path storage class (single disk), you can 
 
 <Step title="Run the installation">
 
-Run the installer with your storage class and your server's public IP. Replace `<SERVER-IP>` with the actual IP:
+Run the installer with your storage class and your server's public IP. Replace `<SERVER-IP>` with the actual IP. This example uses `local-path` — the default k3s storage class for single-disk setups. If you set up TopoLVM in the previous step, use `-s topolvm-provisioner` instead.
 
 ```bash
-cpctl install -s topolvm-provisioner --backend-url http://<SERVER-IP>:8081
+cpctl install -s local-path --backend-url http://<SERVER-IP>:8081
 ```
 
 <Note>
@@ -178,7 +178,7 @@ The installation typically takes 5–10 minutes. You'll see output similar to:
 → Generating RSA keys for JWT authentication...
 → Saving credentials to config directory...
 ✓ Credentials saved: /root/.config/cp-suite/values/cp-control-panel-<timestamp>.yaml
-✓ Storage class "topolvm-provisioner" validated
+✓ Storage class "local-path" validated
 
 ==> About to install Control Panel
   Version: v1.8.0

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -24,17 +24,13 @@ The Control Panel runs inside a Kubernetes cluster and includes the web interfac
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| CPU | 1 core | 4 cores |
-| RAM | 4 GB | 4 GB |
-| Storage | 10 GB | 15 GB |
+| CPU | 6 cores | 8 cores |
+| RAM | 8 GiB | 16 GiB |
+| Storage | 15 GB | 20 GB |
 
 <Note>
 These requirements are for the Control Panel only. Blockchain nodes require additional resources as specified below.
 </Note>
-
-<Tip>
-The Control Panel has a small, stable memory footprint — 4 GB is sufficient for production deployments.
-</Tip>
 
 ### Software requirements
 
@@ -160,17 +156,15 @@ For blockchain nodes, the required ports depend on the protocol:
 
 ## Combined infrastructure example
 
-For a complete deployment running the Control Panel plus one Ethereum Mainnet full node:
+For a complete deployment running the Control Panel plus one Ethereum Mainnet full node (Light preset):
 
-| Resource | Control Panel | Ethereum Node | Total |
-|----------|---------------|---------------|-------|
-| CPU | 2 cores | 4 cores | 6 cores |
-| RAM | 4 GB | 16 GB | 20 GB |
-| Storage | 10 GB | 2 TB | ~2 TB |
+| Resource | Control Panel | Ethereum Node (Light) | Total |
+|----------|---------------|------------------------|-------|
+| CPU | 6 cores | 4 cores | 10 cores |
+| RAM | 8 GiB | 16 GiB | 24 GiB |
+| Storage | 15 GB | 2 TB | ~2 TB |
 
-<Note>
-The Control Panel column reflects the recommended allocation when running alongside a blockchain node, which gives the Control Panel some headroom on a shared host. The strict Control Panel minimum is 1 core — see [Hardware requirements](#hardware-requirements) above.
-</Note>
+For the Mainnet **standard** preset (8 cores / 32 GiB per node), the combined total is **14 cores / 40 GiB / ~2 TB**.
 
 ### Example server configurations
 

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -109,14 +109,7 @@ For a deep dive on SSD selection for Ethereum nodes, see [yorickdowne's SSD guid
 
 ### Initial sync time
 
-| Method | Approximate time |
-|--------|------------------|
-| Full sync from genesis | 2–5 days |
-| Snapshot-based bootstrapping | Minutes to Hours (network dependent) |
-
-<Note>
-You select the sync method in the [deployment wizard](/docs/self-hosted/deploying-nodes#deployment-wizard).
-</Note>
+Nodes bootstrap from a pre-built chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
 
 ## Network requirements
 

--- a/docs/self-hosted/troubleshooting.mdx
+++ b/docs/self-hosted/troubleshooting.mdx
@@ -260,6 +260,23 @@ kubectl logs <pod-name> -n control-panel-deployments --previous
 kubectl get pvc -n control-panel-deployments | grep <node-id>
 ```
 
+### Transient `PopulatorDataSourceNotFound` warning
+
+During the first ~10 seconds of a node deployment, `kubectl get events` may show a warning on the reth PVC:
+
+```text
+Warning  PopulatorDataSourceNotFound  ...  Data source control-panel-deployments/cp-<node-id>-reth-snapshot not found
+```
+
+This is a brief race condition between PVC creation and the snapshot data source being created by the Control Panel workflows. It resolves automatically once `cp-workflows` finishes the post-apply hook (typically within 10–15 seconds). No action is required.
+
+If the warning persists for more than a minute, check `cp-workflows` and `cp-bolt` logs:
+
+```bash
+kubectl logs -n control-panel -l app.kubernetes.io/name=cp-workflows --tail=50
+kubectl logs -n control-panel -l app.kubernetes.io/name=cp-bolt --tail=50
+```
+
 ## System health checks
 
 ### Check all components


### PR DESCRIPTION
## Summary

Follow-up to PR #362. Two commits that were ready before #362's squash-merge but never made it into main.

### Commit 1 — verification-driven fixes (`4e4d31d`)

Three doc bugs caught while running quick-start verbatim on a fresh DigitalOcean droplet:

- **`quick-start.mdx`** — storage class example was hardcoded to `topolvm-provisioner` while Step 3 tells single-disk users to skip the TopoLVM setup. Single-disk readers following the steps verbatim hit a non-existent storage class. Switched the example to `local-path` (the k3s default) with an inline note for TopoLVM users.
- **`deploying-nodes.mdx`** + related — the deployment wizard no longer has a Snapshot/Full-sync step. All current presets ship with snapshot bootstrap pre-configured. Removed the "Select sync method" wizard step; dropped "Full sync from genesis" rows from the sync-times tables in `deploying-nodes.mdx` and `requirements.mdx`; updated the FAQ answer.
- **`troubleshooting.mdx`** — added an entry for the brief `PopulatorDataSourceNotFound` warning that appears for ~10s during snapshot bootstrap (race between PVC creation and cp-workflows creating the snapshot DataSource).

### Commit 2 — hardware sizing correction (`ec19bd4`)

The previous CP-only minimum (1 core / 4 GiB) is unschedulable in practice. Verified across three droplet sizes:

- `s-1vcpu-2gb` — 6 critical pods Pending, install never reaches Healthy
- `s-4vcpu-8gb` — 1 critical pod (deployments-api) Pending, status Unhealthy
- `s-8vcpu-16gb` / `c2-16vcpu-32gb` — install completes Healthy in <5 min

Combined CP + Hoodi Light at the previous \"4 cores / 16 GB / 250 GB\" similarly fails: CP namespace requests + Hoodi Light's 4 CPU + 16 GiB push the total beyond 8 cores.

Updated tables across `evaluation-setup.mdx`, `requirements.mdx`, and `faq.mdx`:

- CP-only: 1/4/10 → **6/8/15** (min), Recommended bumped to 8/16/20
- Combined CP + Hoodi/Mainnet Light: 4/16/250 (eval) and 6/20/2TB (requirements) → **10/24/265** and **10/24/~2 TB** respectively
- Combined CP + Mainnet Standard: documented as **14/40/~2 TB**
- Reframed `evaluation-setup.mdx` intro to drop the misleading \"laptop / 2 GB VM\" framing
- Removed the \"small, stable memory footprint\" Tip in `requirements.mdx` (real CP namespace requests ~5.5 GiB, not 4 GiB)

## Test plan

- [x] All sizing changes verified hands-on across 3 different DigitalOcean droplet sizes
- [x] Cross-references and anchors verified (`mintlify dev` rendered locally)
- [x] Cherry-picked cleanly on top of current main (PRs #362 and #363 already merged)
- [ ] One open question logged separately to the team: snapshot bootstrap appears to be a no-op on `local-path` storage class — reth fell back to genesis sync in our test. If confirmed as a real bug or a CSI/TopoLVM-only feature, a small follow-up PR will adjust the snapshot-timing claims accordingly.