### PR TITLE
docs: remove HIP-4 status note from trading guide

### DIFF
--- a/docs/hyperliquid-hip4-outcome-markets-trading.mdx
+++ b/docs/hyperliquid-hip4-outcome-markets-trading.mdx
@@ -22,12 +22,6 @@ Outcomes share the matching engine, account model, and API surface with spot and
 
 The first mainnet market is a recurring BTC daily binary that settles at 06:00 UTC against the BTC mark price on HyperCore. Markets are validator-curated for now; multi-outcome categorical "questions" exist on testnet and will roll out on mainnet in stages.
 
-<Note>
-**Status**
-
-HIP-4 mainnet launched May 2, 2026. Official Hyperliquid documentation for HIP-4 is sparse, and several behaviors described below — the asset encoding, the settlement formula, the fee classification — were initially community-discovered during the launch window. Some features visible in the protocol (`splitPosition` and `mergePositions`, multi-outcome mainnet markets) are not yet enabled. Verify against the [Hyperliquid HIP-4 docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-improvement-proposals-hips/hip-4-outcome-markets) for the current state at the time you read this.
-</Note>
-
 ## Why the standard Python SDK won't work
 
 The official `hyperliquid-python-sdk` (v0.23.0 at the time of writing) does not know about HIP-4. The `Info` client builds its `coin_to_asset` map from `spot_meta` only — outcome encodings starting at `100_000_000` are unknown to the resolver.


### PR DESCRIPTION
Removes the temporal status callout per author preference. The HIP-4 launch date and source-of-truth pointer remain implicit in the lead paragraph and the upstream-docs links at the bottom of the page.