### PR TITLE
docs: note synthetic short-YES path in HIP-4 trading guide

### DIFF
--- a/docs/hyperliquid-hip4-outcome-markets-trading.mdx
+++ b/docs/hyperliquid-hip4-outcome-markets-trading.mdx
@@ -318,7 +318,7 @@ Outcome trading **only charges fees when closing or settling, not when opening**
 
 Fee rates are taken from the same per-user tier returned by `userFees` (`makerRate` / `takerRate`). There are no maker rebates for outcome trading — users who would otherwise receive rebates pay zero on maker orders instead.
 
-There is no `splitPosition` or `mergePositions` API. To get YES exposure, place a buy on the YES book. To get short-YES exposure, buy NO. Mint and burn happen implicitly inside the matching engine as a side-effect of the fill — you cannot directly request them. As of mainnet launch, `splitPosition` and `mergePositions` exist in the protocol but are not enabled.
+There is no `splitPosition` or `mergePositions` API. To get YES exposure, place a buy on the YES book. To get short-YES exposure, you have two equivalent paths: place a sell on the YES book at price `p` (synthetic short, opens a new short position via mint classification when the counterparty is also flat), or place a buy on the NO book at price `1 - p`. Both routes are economically equivalent in a fair market but show up differently in your inventory and route through different books — which matters for execution and fee classification. Mint and burn happen implicitly inside the matching engine as a side-effect of the fill — you cannot directly request them. As of mainnet launch, `splitPosition` and `mergePositions` exist in the protocol but are not enabled.
 
 The closest comparison points for fee structure: Polymarket charges around 200 basis points on winnings every trade, and Kalshi roughly 700 basis points. HIP-4 charges only on close, burn, or settlement, at the perp-tier rate.
 


### PR DESCRIPTION
Adds the second equivalent path to short-YES exposure (sell on YES book) alongside the existing 'buy NO' path. Matches the explainer in the chainstacklabs/hyperliquid-hip-4 reference repo and gives readers both execution routes.