### PR TITLE
feature/PROD-1387-update-release-notes-and-requirements-for-public-launch

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3787,6 +3787,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v1-8-0-may-4-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-7-1-april-15-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-6-0-april-10-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v1-5-0-april-10-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v1-8-0-may-4-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v1-8-0-may-4-2026.mdx
@@ -1,0 +1,35 @@
+---
+title: "Chainstack Self-Hosted v1.8.0: May 4, 2026"
+description: "First public (non-beta) release: new Ethereum evaluation presets, telemetry on by default, simpler installs and upgrades, explicit Postgres resource limits, and Control Panel UI refinements."
+---
+
+**Chainstack Self-Hosted is now generally available.** With v1.8.0, the product exits beta and becomes the first public release. This version expands Ethereum coverage with new evaluation presets, makes telemetry on by default, and smooths out install, upgrade, and resource defaults.
+
+## Ethereum evaluation presets
+
+Three new lightweight Ethereum presets are available in the deployment flow: Mainnet, Sepolia, and Hoodi. The deployment Control Panel now lists every preset configuration available for a given network instead of surfacing only one, so you can pick the client combination and footprint that matches your evaluation or production target without leaving the wizard.
+
+## Simpler installs and upgrades
+
+`cpctl install` now defaults to the latest available chart version when you omit `-v`, so first-time installs no longer require looking up a version string. Error messages from the version resolver are clearer about what went wrong — empty tag lists, dev-only registries, and unsupported version jumps are now reported separately.
+
+Upgrades also run without the previous Helm hook step, which removes a class of upgrade-time failures on clusters with restrictive RBAC.
+
+## Resource limit defaults
+
+The bundled Postgres component now ships with explicit CPU, memory, and storage limits instead of relying on cluster defaults. This makes capacity planning predictable on small or shared clusters and avoids the noisy-neighbor scenarios reported by early adopters running the control plane alongside other workloads.
+
+## UI refinements
+
+The Control Panel now uses the shared UIKit side menu, aligning navigation with the rest of the Chainstack product surface. The Node Summary panel was repolished so resource readouts line up with the surrounding layout.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.0.0 |
+| cp-deployments-api | v0.32.0 |
+| cp-workflows | v1.13.1 |
+| cp-auth | v0.4.2 |
+| cp-bolt | v1.8.0 |
+| cp-tracer | v0.1.1 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -61,6 +61,10 @@ CPU and RAM are split evenly between the Reth (execution) and Prysm (consensus) 
 
 For production, pick the standard preset and size your host per [System requirements](/docs/self-hosted/requirements). For evaluation on a smaller server, pick the Light preset.
 
+<Warning>
+Snapshot bootstrap temporarily requires **2× the final storage**. The node first downloads the snapshot archive, then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at 2× the storage figure in the table above; the volume can be reclaimed or stay sized for headroom once the snapshot archive is removed.
+</Warning>
+
 </Step>
 
 <Step title="Review and deploy">

--- a/docs/self-hosted/download-installer.mdx
+++ b/docs/self-hosted/download-installer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install the Self-Hosted CLI"
+title: "Download Self-Hosted CLI"
 description: Install cpctl, the Chainstack Self-Hosted command-line tool, on Linux, macOS, or Windows using the Chainstack bootstrap script for setup.
 ---
 

--- a/docs/self-hosted/evaluation-setup.mdx
+++ b/docs/self-hosted/evaluation-setup.mdx
@@ -11,8 +11,8 @@ The Control Panel is the management interface where you deploy, monitor, and man
 
 | Resource | Minimum |
 |----------|---------|
-| CPU | 6 cores |
-| RAM | 8 GiB |
+| CPU | 5 cores |
+| RAM | 6 GiB |
 | Storage | 15 GB |
 
 These requirements are for the Control Panel only. Blockchain nodes require additional resources — see [Optional — deploy a testnet node](#optional-deploy-a-testnet-node) below or [System requirements](/docs/self-hosted/requirements) for the full picture.
@@ -20,7 +20,7 @@ These requirements are for the Control Panel only. Blockchain nodes require addi
 Any of these environments will work for the Control Panel:
 
 - A small dedicated server
-- A virtual machine with at least 6 vCPUs and 8 GiB RAM
+- A virtual machine with at least 5 vCPUs and 6 GiB RAM
 - A cloud instance such as DigitalOcean `s-8vcpu-16gb` or equivalent on AWS/GCP/Azure
 
 ## Software
@@ -55,11 +55,16 @@ If you want to go a step further and deploy an actual blockchain node, the Ether
 
 | Resource | Control Panel + Hoodi node (Light preset) |
 |----------|--------------------------------------------|
-| CPU | 10 cores |
-| RAM | 24 GiB |
-| Storage | 265 GB NVMe SSD |
+| CPU | 9 cores |
+| RAM | 22 GiB |
+| Storage (steady state) | 265 GB NVMe SSD |
+| Storage (during deploy) | 515 GB NVMe SSD |
 
-The numbers above sum the Control Panel minimum (6 cores / 8 GiB / 15 GB) and the Hoodi Light preset (4 cores / 16 GiB / 250 GiB).
+The numbers above sum the Control Panel minimum (5 cores / 6 GiB / 15 GB) and the Hoodi Light preset (4 cores / 16 GiB / 250 GB steady state, 500 GB during deploy).
+
+<Warning>
+Snapshot bootstrap temporarily requires **2× the node storage**: the snapshot archive and the extracted chain data coexist on disk until extraction completes. Provision the node's persistent volume at the during-deploy figure.
+</Warning>
 
 <Note>
 Hoodi is an Ethereum testnet that uses test ETH with no real value, making it ideal for evaluation. Initial bootstrap from the snapshot completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background.

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -144,10 +144,10 @@ If you're using the default k3s local-path storage class (single disk), you can 
 
 <Step title="Run the installation">
 
-Run the installer with your storage class and your server's public IP. Replace `<SERVER-IP>` with the actual IP. This example uses `local-path` — the default k3s storage class for single-disk setups. If you set up TopoLVM in the previous step, use `-s topolvm-provisioner` instead.
+Run the installer with your storage class and your server's public IP. Replace `<SERVER-IP>` with the actual IP. This example uses `topolvm-provisioner` — the storage class set up in the previous step.
 
 ```bash
-cpctl install -s local-path --backend-url http://<SERVER-IP>:8081
+cpctl install -s topolvm-provisioner --backend-url http://<SERVER-IP>:8081
 ```
 
 <Note>
@@ -178,7 +178,7 @@ The installation typically takes 5–10 minutes. You'll see output similar to:
 → Generating RSA keys for JWT authentication...
 → Saving credentials to config directory...
 ✓ Credentials saved: /root/.config/cp-suite/values/cp-control-panel-<timestamp>.yaml
-✓ Storage class "local-path" validated
+✓ Storage class "topolvm-provisioner" validated
 
 ==> About to install Control Panel
   Version: v1.8.0

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v1.8.0: May 4, 2026" description="">
+
+**General availability**. Chainstack Self-Hosted exits beta with this first public release. v1.8.0 also adds three lightweight Ethereum evaluation presets (Mainnet, Sepolia, Hoodi), turns telemetry on by default, simplifies installs and upgrades via `cpctl`, sets explicit Postgres resource limits, and refines the Control Panel side menu and Node Summary layout.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v1-8-0-may-4-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v1.7.1: April 15, 2026" description="">
 
 This release adds built-in telemetry management via a new cp-tracer component, improves upgrade reliability with stricter input validation and more resilient preflight checks, and fixes a hard-coded timeout issue in node deployment volume population.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -24,8 +24,8 @@ The Control Panel runs inside a Kubernetes cluster and includes the web interfac
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| CPU | 6 cores | 8 cores |
-| RAM | 8 GiB | 16 GiB |
+| CPU | 5 cores | 8 cores |
+| RAM | 6 GiB | 16 GiB |
 | Storage | 15 GB | 20 GB |
 
 <Note>
@@ -71,7 +71,8 @@ Resource requirements vary by protocol and node configuration. Below are the req
 |----------|---------|-------------|
 | CPU | 4 cores | 6+ cores |
 | RAM | 16 GB | 32 GB |
-| Storage | 2 TB NVMe SSD | 4 TB NVMe SSD |
+| Storage (steady state) | 2 TB NVMe SSD | 4 TB NVMe SSD |
+| Storage (during deploy) | 4 TB NVMe SSD | 4 TB NVMe SSD |
 
 ### Ethereum Sepolia testnet full node (Reth + Prysm)
 
@@ -79,7 +80,8 @@ Resource requirements vary by protocol and node configuration. Below are the req
 |----------|---------|-------------|
 | CPU | 4 cores | 6+ cores |
 | RAM | 16 GB | 32 GB |
-| Storage | 1.5 TB NVMe SSD | 2 TB NVMe SSD |
+| Storage (steady state) | 1.5 TB NVMe SSD | 2 TB NVMe SSD |
+| Storage (during deploy) | 3 TB NVMe SSD | 3 TB NVMe SSD |
 
 ### Ethereum Hoodi testnet full node (Reth + Prysm)
 
@@ -87,7 +89,12 @@ Resource requirements vary by protocol and node configuration. Below are the req
 |----------|---------|-------------|
 | CPU | 4 cores | 6+ cores |
 | RAM | 16 GB | 32 GB |
-| Storage | 250 GB NVMe SSD | 500 GB NVMe SSD |
+| Storage (steady state) | 250 GB NVMe SSD | 500 GB NVMe SSD |
+| Storage (during deploy) | 500 GB NVMe SSD | 500 GB NVMe SSD |
+
+<Warning>
+The **during deploy** row reflects the 2× peak required by snapshot bootstrap: the node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward.
+</Warning>
 
 ### Storage considerations
 
@@ -160,11 +167,12 @@ For a complete deployment running the Control Panel plus one Ethereum Mainnet fu
 
 | Resource | Control Panel | Ethereum Node (Light) | Total |
 |----------|---------------|------------------------|-------|
-| CPU | 6 cores | 4 cores | 10 cores |
-| RAM | 8 GiB | 16 GiB | 24 GiB |
-| Storage | 15 GB | 2 TB | ~2 TB |
+| CPU | 5 cores | 4 cores | 9 cores |
+| RAM | 6 GiB | 16 GiB | 22 GiB |
+| Storage (steady state) | 15 GB | 2 TB | ~2 TB |
+| Storage (during deploy) | 15 GB | 4 TB | ~4 TB |
 
-For the Mainnet **standard** preset (8 cores / 32 GiB per node), the combined total is **14 cores / 40 GiB / ~2 TB**.
+For the Mainnet **standard** preset (8 cores / 32 GiB per node), the combined total is **13 cores / 38 GiB / ~2 TB steady state (~4 TB during deploy)**.
 
 ### Example server configurations
 

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -194,7 +194,10 @@ Chainstack Self-Hosted works on any compatible infrastructure you provision your
 
 | Partner | |
 |---------|--|
-| Hostkey | [Deploy app](https://hostkey.com/apps/developer-tools/chainstack/) |
+| Hostkey | [Deploy on Hostkey](https://hostkey.com/apps/developer-tools/chainstack/) |
+| Velia | [Deploy on Velia](https://www.velia.net/web3/) |
+| Serverside | [Deploy Serverside](https://serverside.com/en-gb/partners/chainstack) |
+| BreezeHost | [Deploy BreezeHost](https://www.breezehost.io/chainstack/) |
 
 ## Next steps
 


### PR DESCRIPTION
1. Control Panel hardware — lowered minimum from 6 cores / 8 GiB to 5 cores / 6 GiB in requirements.mdx and evaluation-setup.mdx, based on actual measured pod resource requests in the control-panel namespace (~4750m CPU / ~5734Mi memory).
2. Snapshot bootstrap storage — added a 2× peak-storage callout: nodes temporarily need double the steady-state disk while the snapshot archive and extracted chain data coexist. Reflected in node tables (requirements.mdx), the combined-infrastructure example, the Hoodi evaluation total (evaluation-setup.mdx), and the deploy flow (deploying-nodes.mdx).
3. Trusted partners — added Velia, Serverside, and BreezeHost to the partners table in requirements.mdx.