### PR TITLE
Fix empty docs/faucets page

### DIFF
--- a/docs/faucets.mdx
+++ b/docs/faucets.mdx
@@ -3,3 +3,31 @@ title: "Faucet"
 description: Get free testnet tokens for Ethereum Sepolia, Polygon Amoy, BNB Smart Chain, and other supported networks from the Chainstack faucet for development.
 ---
 
+The [Chainstack faucet](https://faucet.chainstack.com/) dispenses free testnet tokens for development and testing — no Twitter or social login required.
+
+### Supported networks
+
+* Sepolia testnet
+* Hoodi testnet
+* Solana devnet
+* BNB Smart Chain testnet
+* Base Sepolia testnet
+* Monad testnet
+* Amoy testnet
+* Plasma testnet
+* Hyperliquid testnet
+* TON testnet
+* zkSync Sepolia testnet
+* Scroll Sepolia testnet
+
+### Request tokens via the faucet UI
+
+1. Open [faucet.chainstack.com](https://faucet.chainstack.com/) and sign in to your Chainstack account.
+2. Select a testnet.
+3. Paste the destination address and submit.
+
+The faucet tops up your address to a per-network cap. Each address can request once every 24 hours.
+
+### Request tokens via the MCP server
+
+The [Chainstack MCP server](/docs/chainstack-mcp-server) exposes a `request_testnet_funds` tool so AI agents can fund a testnet address directly from your coding environment. Authentication uses your Chainstack API key.


### PR DESCRIPTION
## Summary
- The page at https://docs.chainstack.com/docs/faucets has been empty since the Mintlify migration (commit 6460cc1, 2025-03-24) — only frontmatter rendered, leaving the live page blank under the title.
- Adds a one-line intro pointing at the Chainstack faucet, a supported networks list (ordered to match the UI grid), the public faucet UI flow, and a pointer to the MCP server's `request_testnet_funds` tool.

## Test plan
- [ ] Confirm the page renders with all four sections in the Mintlify preview
- [ ] Verify the network list order matches https://faucet.chainstack.com/
- [ ] Verify the link to /docs/chainstack-mcp-server resolves