### PR TITLE
Document Cronos Mainnet archive debug_traceBlockByNumber rate limit

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -24,6 +24,10 @@ description: View Chainstack platform limits for node deployments, API requests,
   **BSC limitation**: On Binance Smart Chain, `eth_getProof` currently only works with the `"latest"`, `"earliest",` `"safe"`, `"finalized"`, `"pending"` block tags. Using specific block numbers will result in an error. This limitation will be addressed in a future update.
 </Warning>
 
+### Cronos-specific
+
+- Cronos Mainnet archive: `debug_traceBlockByNumber` 10 RPS on all plans
+
 ### All other protocols
 
 For global plan RPS limits across all other protocols, see [Requests per second (RPS) plan limits](/docs/rps-plan-limits).


### PR DESCRIPTION
## Summary
- Adds a Cronos-specific subsection to `/docs/limits` with the 10 RPS cap on `debug_traceBlockByNumber` for Cronos Mainnet archive nodes.
- Mirrors the existing Arbitrum-specific entry's style.

## Context
The cap was applied by infra and confirmed permanent in [#ops](https://chainstackhq.slack.com/archives/C02RNV8J3UM/p1778044903127519). Rationale: `debug_*` calls are blocking IO and dense Cronos blocks can take many minutes to trace, degrading archive UX otherwise.

## Test plan
- [ ] Confirm the new subsection renders between BNB Smart Chain-specific and All other protocols in the Mintlify preview
- [ ] Verify formatting matches the Arbitrum-specific entry above it