### PR TITLE
Align Chainstack MCP tool list and surface faucet capability

### DIFF
--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Chainstack MCP server"
-description: Deploy blockchain nodes, search documentation, and manage your entire Chainstack infrastructure directly from any AI agent using the MCP server protocol.
+description: Chainstack MCP server for AI agents — deploy blockchain nodes, search docs, request testnet faucet tokens, fetch pricing, and contact the team.
 ---
 
 ## Quick start
@@ -15,7 +15,7 @@ The agent will fetch the onboarding page, understand what the server offers, and
 
 ---
 
-The **Chainstack MCP server** gives AI agents direct access to the Chainstack platform — deploy blockchain nodes, search documentation, and check platform status, all from your coding environment. It works with Claude Code, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, Antigravity, Claude.ai, and ChatGPT.
+The **Chainstack MCP server** gives AI agents direct access to the Chainstack platform — deploy blockchain nodes, search documentation, request testnet faucet tokens, fetch live pricing, contact the Chainstack team, and check platform status, all from your coding environment. It works with Claude Code, Cursor, Codex, Windsurf, Gemini CLI, GitHub Copilot, Antigravity, Claude.ai, and ChatGPT.
 
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) is an open standard that lets AI applications connect to external tools and data sources. The Chainstack MCP server is a remote Streamable HTTP server — no local setup required.
 
@@ -28,8 +28,10 @@ The **Chainstack MCP server** gives AI agents direct access to the Chainstack pl
 | `search_docs` | Search Chainstack documentation — blockchain RPC methods, deployment guides, code examples |
 | `get_doc_page` | Fetch the full content of a documentation page |
 | `get_platform_status` | Check platform status, active incidents, and network health |
+| `contact_chainstack` | Submit a message to the Chainstack team — sales, support, or general inquiries |
+| `get_chainstack_pricing` | Fetch a live Chainstack pricing snapshot — plan tiers, feature matrix, add-ons, dedicated-node catalog |
 
-**API key required** (get one at [console.chainstack.com/user/settings/api-keys](https://console.chainstack.com/user/settings/api-keys)):
+**API key required** (get one at [console.chainstack.com/user/settings/api-keys](https://console.chainstack.com/user/settings/api-keys)). These tools only appear in the agent's session once the key is configured in headers — that's why an unauthenticated session shows a shorter list.
 
 | Tool | Description |
 |------|-------------|
@@ -45,6 +47,7 @@ The **Chainstack MCP server** gives AI agents direct access to the Chainstack pl
 | `create_node` | Deploy a new blockchain node |
 | `update_node` | Rename a node |
 | `delete_node` | Delete a node |
+| `request_testnet_funds` | Top up a testnet address from the [Chainstack faucet](/docs/faucets) — Sepolia, Hoodi, Base Sepolia, Amoy, BNB testnet, Solana devnet, and more |
 
 ## Option 1: Install as a skill
 

--- a/docs/migrate-to-chainstack-with-ai.mdx
+++ b/docs/migrate-to-chainstack-with-ai.mdx
@@ -17,7 +17,7 @@ The agent fetches this page and walks through the migration in three phases: Ass
 
 ## Tools used
 
-The runbook calls the [Chainstack MCP server](/docs/chainstack-mcp-server) — a single remote server that covers docs search, deployment options, node and project management, platform status, faucets, and pricing. Two URLs, two different purposes:
+The runbook calls the [Chainstack MCP server](/docs/chainstack-mcp-server) — a single remote server that covers docs search (`search_docs`, `get_doc_page`), deployment options (`get_deployment_options`), node and project management, platform status (`get_platform_status`), testnet faucets (`request_testnet_funds`), pricing (`get_chainstack_pricing`), and contact (`contact_chainstack`). Two URLs, two different purposes:
 
 - [mcp.chainstack.com](https://mcp.chainstack.com) — the agent onboarding page. Point any AI agent at this URL and it reads setup instructions, tool reference, and install options.
 - `https://mcp.chainstack.com/mcp` — the actual JSON-RPC 2.0 endpoint the agent calls once it's set up.

--- a/docs/platform-introduction.mdx
+++ b/docs/platform-introduction.mdx
@@ -13,6 +13,7 @@ For assistance, reach out to [Chainstack support](https://support.chainstack.com
 
 <CardGroup>
  <Card title="Available here" href="https://faucet.chainstack.com/" icon="angle-right" iconType="solid" horizontal/>
+ <Card title="Via the Chainstack MCP server" href="/docs/chainstack-mcp-server" icon="angle-right" iconType="solid" horizontal/>
  </CardGroup>
 
 ## Supported regions, locations, chains.

--- a/reference/chainstack-faucet-introduction.mdx
+++ b/reference/chainstack-faucet-introduction.mdx
@@ -11,6 +11,10 @@ This faucet API integrates seamlessly with existing development workflows and pr
   You can also request funds directly from the [Chainstack Faucet](https://faucet.chainstack.com) page.
 </Info>
 
+<Info>
+  AI agents can also call the Chainstack faucet through the [Chainstack MCP server](/docs/chainstack-mcp-server) using the `request_testnet_funds` tool — fund testnet addresses directly from your coding environment, no UI clicks, no copy-paste. Uses your Chainstack API key.
+</Info>
+
 ## Faucet limitations
 
 Due to the recent scarcity of testnet funds, the Chainstack Faucet API enforces stringent criteria for receiving testnet tokens.

--- a/reference/chainstack-faucet-introduction.mdx
+++ b/reference/chainstack-faucet-introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Chainstack Faucet API: free testnet tokens for development"
-description: "Get free testnet tokens from the Chainstack faucet for blockchain development and testing. Supports Sepolia and other testnets for smart contract deployment."
+description: "Get free testnet tokens from the Chainstack faucet — via the faucet UI, the Faucet API, or the Chainstack MCP server's request_testnet_funds tool for AI agents."
 ---
 
 The Chainstack Faucet API is a faucet API designed to facilitate the process of requesting testnet funds. By utilizing a simple API call with the Chainstack API key as authentication, users can effortlessly acquire the necessary testnet funds for their projects.


### PR DESCRIPTION
## Summary
- The current `docs/chainstack-mcp-server.mdx` tool tables were missing three tools that the live server at https://mcp.chainstack.com/skill exposes: `contact_chainstack`, `get_chainstack_pricing`, `request_testnet_funds`.
- Cold AI search and ChatGPT queries hitting the public docs were therefore told these capabilities weren't supported (e.g., "Does Chainstack MCP support faucet?" → "No"), even though the live MCP exposes them. See thread context in `#product-docs`.

## What changes
Four discovery surfaces updated for keyword/AI-search visibility:

- **`docs/chainstack-mcp-server.mdx`** — frontmatter description, intro paragraph, and tool tables (5 no-key + 13 API-key, was 3 + 12). Added a one-line clarification that API-key tools only appear in the agent's session once the key is configured.
- **`docs/migrate-to-chainstack-with-ai.mdx`** — name each tool inline in the "Tools used" paragraph so the runbook page carries every tool name as a keyword anchor.
- **`docs/platform-introduction.mdx`** — second card under "Chainstack faucets" pointing to the MCP server.
- **`reference/chainstack-faucet-introduction.mdx`** — `<Info>` box pitching the MCP option for AI agents from the API reference page.

`migrate-to-chainstack-with-ai.mdx` was already aligned with the live `/skill` list — this PR just enriches its keyword payload.

## Test plan
- [ ] All 5 + 13 tools render in the chainstack-mcp-server tables in the Mintlify preview
- [ ] Frontmatter description shows in the page metadata and propagates to llms.txt
- [ ] platform-introduction shows two cards under "Chainstack faucets"
- [ ] reference/chainstack-faucet-introduction shows two `<Info>` boxes
- [ ] Run `mint broken-links` — no new broken links