### PR TITLE
Revert tool-name inline edit on migrate-to-chainstack-with-ai

### DIFF
--- a/docs/migrate-to-chainstack-with-ai.mdx
+++ b/docs/migrate-to-chainstack-with-ai.mdx
@@ -17,7 +17,7 @@ The agent fetches this page and walks through the migration in three phases: Ass
 
 ## Tools used
 
-The runbook calls the [Chainstack MCP server](/docs/chainstack-mcp-server) — a single remote server that covers docs search (`search_docs`, `get_doc_page`), deployment options (`get_deployment_options`), node and project management, platform status (`get_platform_status`), testnet faucets (`request_testnet_funds`), pricing (`get_chainstack_pricing`), and contact (`contact_chainstack`). Two URLs, two different purposes:
+The runbook calls the [Chainstack MCP server](/docs/chainstack-mcp-server) — a single remote server that covers docs search, deployment options, node and project management, platform status, faucets, and pricing. Two URLs, two different purposes:
 
 - [mcp.chainstack.com](https://mcp.chainstack.com) — the agent onboarding page. Point any AI agent at this URL and it reads setup instructions, tool reference, and install options.
 - `https://mcp.chainstack.com/mcp` — the actual JSON-RPC 2.0 endpoint the agent calls once it's set up.


### PR DESCRIPTION
## Summary
- Reverts the one-line edit to `docs/migrate-to-chainstack-with-ai.mdx` line 20 from PR #373.
- That page is designed as a prompt for AI agents to consume during the migration runbook — not a keyword-rich docs surface for AI search. The inline tool-name expansion didn't help the prompt's behavior, only added noise.
- Other PR #373 changes (MCP server tool tables, faucet API reference Info box + description, platform intro card) stay in place.

## Test plan
- [ ] Confirm `migrate-to-chainstack-with-ai.mdx` line 20 is back to the original wording in the Mintlify preview