### PR TITLE
Fix inaccurate auth-visibility note on chainstack-mcp-server

### DIFF
--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -31,7 +31,7 @@ The **Chainstack MCP server** gives AI agents direct access to the Chainstack pl
 | `contact_chainstack` | Submit a message to the Chainstack team — sales, support, or general inquiries |
 | `get_chainstack_pricing` | Fetch a live Chainstack pricing snapshot — plan tiers, feature matrix, add-ons, dedicated-node catalog |
 
-**API key required** (get one at [console.chainstack.com/user/settings/api-keys](https://console.chainstack.com/user/settings/api-keys)). These tools only appear in the agent's session once the key is configured in headers — that's why an unauthenticated session shows a shorter list.
+**API key required** (get one at [console.chainstack.com/user/settings/api-keys](https://console.chainstack.com/user/settings/api-keys)). All tools appear in the agent's tool list regardless of auth — the tools below execute only when the key is configured. Calls without it return an auth error.
 
 | Tool | Description |
 |------|-------------|


### PR DESCRIPTION
## Summary
The note added in PR #373 said tools "only appear in the agent's session once the key is configured." That's incorrect: probing the live MCP server's `tools/list` unauthenticated returns all 18 tools. Auth gating happens at execution time, not at advertisement time (FastMCP default). This is also why Eugene's Codex session saw `request_testnet_funds` without auth — the tool is advertised, but executing it requires the key.

The Mintlify bot caught this when reviewing PR #373; verified the actual server behavior by probing the live `/mcp` endpoint.

## What changes
Replaces the inaccurate sentence with the actual model:

> All tools appear in the agent's tool list regardless of auth — the tools below execute only when the key is configured. Calls without it return an auth error.

The placement of `request_testnet_funds` in the API-key table stays correct (table represents execution requirements, which is what matters to users).

## Test plan
- [ ] Confirm the corrected note renders in the Mintlify preview under the API-key tools heading