### PR TITLE
Document EVM disabled debug methods and Solana getTokenLargestAccounts ban

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -52,6 +52,14 @@ For users on the Developer subscription plan, Chainstack applies a specific rang
 
 This limit is designed to optimize the performance and resource allocation for our users on this plan.
 
+## EVM disabled debug methods
+
+The following debug methods are disabled on EVM chains:
+
+- `debug_executionWitness`
+- `debug_executionWitnessByBlockHash`
+- `debug_executePayload`
+
 ## Custom tracers on EVMs
 
 Custom JavaScript tracers are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
@@ -79,6 +87,7 @@ The following per-method RPS limits apply identically across all regions:
 | `getTokenAccountsByOwner` | 80 |
 | `getSupply` | 2 |
 | `getLargestAccounts` | 0 — available on [Dedicated Nodes](/docs/dedicated-node) only |
+| `getTokenLargestAccounts` | 0 — disabled |
 
 [`getProgramAccounts`](/reference/solana-getprogramaccounts) — unfiltered requests to large programs are blocked; always use `dataSize` or `memcmp` filters:
 


### PR DESCRIPTION
## Summary

- New `EVM disabled debug methods` section in the throughput guidelines listing the three debug methods banned across EVM chains: `debug_executionWitness`, `debug_executionWitnessByBlockHash`, `debug_executePayload`. These were blocked after they triggered the May 7 elevated-latency/OOM incident on Ethereum Mainnet (LON/SGP).
- New row in the Solana method limits table for `getTokenLargestAccounts` (0 RPS — disabled).

Per Edin's request in Slack.

## Test plan

- [ ] Page renders correctly on the docs preview
- [ ] No broken links or formatting regressions in `docs/limits.mdx`