### PR TITLE
PROD-1390-add-50%-promocode-from-limestonenetrowks-to-self-hosted

### DIFF
--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -192,12 +192,12 @@ For the Mainnet **standard** preset (8 cores / 32 GiB per node), the combined to
 
 Chainstack Self-Hosted works on any compatible infrastructure you provision yourself. To simplify hardware procurement, you can use one of our trusted partners that offer servers meeting the requirements above.
 
-| Partner | |
-|---------|--|
-| Hostkey | [Deploy on Hostkey](https://hostkey.com/apps/developer-tools/chainstack/?utm_source=chainstack&utm_campaign=docs) |
-| Velia | [Deploy on Velia](https://www.velia.net/web3/?utm_source=chainstack&utm_campaign=docs) |
-| Serverside | [Deploy Serverside](https://serverside.com/en-gb/partners/chainstack?utm_source=chainstack&utm_campaign=docs) |
-| BreezeHost | [Deploy BreezeHost](https://www.breezehost.io/chainstack/?utm_source=chainstack&utm_campaign=docs) |
+| Partner | | Promo |
+|---------|--|-------|
+| Hostkey | [Deploy on Hostkey](https://hostkey.com/apps/developer-tools/chainstack/?utm_source=chainstack&utm_campaign=docs) | — |
+| Velia | [Deploy on Velia](https://www.velia.net/web3/?utm_source=chainstack&utm_campaign=docs) | — |
+| Serverside | [Deploy on Serverside](https://serverside.com/en-gb/partners/chainstack?utm_source=chainstack&utm_campaign=docs) | 10% off — applied automatically via the link |
+| BreezeHost | [Deploy on BreezeHost](https://www.breezehost.io/chainstack/?utm_source=chainstack&utm_campaign=docs) | Promocode `CHAINSTACK50` — 50% off your first month on all Chainstack products |
 
 ## Next steps
 


### PR DESCRIPTION
add 50% promocode from limestonenetworks/breezehost to the self-hosted trusted partners table 