### PR TITLE
docs(solana): note getTokenLargestAccounts is Dedicated Nodes only

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -87,7 +87,7 @@ The following per-method RPS limits apply identically across all regions:
 | `getTokenAccountsByOwner` | 80 |
 | `getSupply` | 2 |
 | `getLargestAccounts` | 0 — available on [Dedicated Nodes](/docs/dedicated-node) only |
-| `getTokenLargestAccounts` | 0 — disabled |
+| `getTokenLargestAccounts` | 0 — available on [Dedicated Nodes](/docs/dedicated-node) only |
 
 [`getProgramAccounts`](/reference/solana-getprogramaccounts) — unfiltered requests to large programs are blocked; always use `dataSize` or `memcmp` filters:
 

--- a/docs/solana-gettokenlargestaccounts-rpc-method.mdx
+++ b/docs/solana-gettokenlargestaccounts-rpc-method.mdx
@@ -3,6 +3,10 @@ title: "Solana: getTokenLargestAccounts for SPL holders"
 description: Use getTokenLargestAccounts to view SPL token holder distribution, whale wallets, and concentration metrics through a Chainstack Solana RPC node.
 ---
 
+<Warning>
+`getTokenLargestAccounts` is available on [Dedicated Nodes](/docs/dedicated-node) only.
+</Warning>
+
 **TLDR:**
 * `getTokenLargestAccounts` retrieves the top 20 largest SPL token accounts in one request.
 * Useful for distribution analysis, showing holders’ addresses and token balances.

--- a/reference/solana-gettokenlargestaccounts.mdx
+++ b/reference/solana-gettokenlargestaccounts.mdx
@@ -5,6 +5,10 @@ openapi: /openapi/solana_node_api/getTokenLargestAccounts.json POST /9de47db917d
 
 ## Solana `getTokenLargestAccounts` Method
 
+<Warning>
+`getTokenLargestAccounts` is available on [Dedicated Nodes](/docs/dedicated-node) only.
+</Warning>
+
 The `getTokenLargestAccounts` method is a useful RPC method in Solana that returns the 20 largest accounts for a specific SPL Token type.
 
 This method offers a snapshot of the largest token holders, providing insights into the token's distribution and potential market dynamics. This can be particularly useful for developers, analysts, and investors looking to gauge the distribution of tokens in the Solana ecosystem.


### PR DESCRIPTION
## Summary
- Adam flagged ([Slack](https://chainstackhq.slack.com/archives/CKDV5FT2L/p1778943761339689), ticket 21663) that the reference and tutorial pages for `getTokenLargestAccounts` did not reflect the method's restriction. The limits page mentioned it but used different wording ("disabled") than the RPC error customers see ("only available on dedicated nodes").
- The ban was made permanent on 2026-05-11 after the May 5 incident (1 RPS was enough to flatline Solana nodes globally).
- Normalized wording across all three pages to match `getLargestAccounts` directly above.

## Changes
- `reference/solana-gettokenlargestaccounts.mdx` — `<Warning>` below the H2.
- `docs/solana-gettokenlargestaccounts-rpc-method.mdx` — `<Warning>` above the TLDR.
- `docs/limits.mdx` — `0 — disabled` → `0 — available on Dedicated Nodes only`.

## Test plan
- [ ] Mintlify preview renders both `<Warning>` callouts and the updated limits table cell.
- [ ] `/docs/dedicated-node` links resolve.