### PR TITLE
docs: add Flashblocks on Optimism guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1193,6 +1193,7 @@
                 "pages": [
                   "docs/chainstack-blockchain-apis-guides",
                   "docs/flashblocks-on-base",
+                  "docs/flashblocks-on-optimism",
                   "docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial",
                   "docs/uncovering-the-power-of-ethgetblockreceipts",
                   "docs/expanding-your-blockchain-horizons-the-eth_getblockreceipts-emulator",

--- a/docs/flashblocks-on-optimism.mdx
+++ b/docs/flashblocks-on-optimism.mdx
@@ -23,8 +23,8 @@ This two-side architecture implements the following flow:
   * [`eth_call`](/reference/optimism-call) with the `pending` tag
   * [`eth_getBalance`](/reference/optimism-getbalance) with the `pending` tag
   * [`eth_getTransactionCount`](/reference/optimism-gettransactioncount) with the `pending` tag
-  * [`eth_getCode`](/reference/optimism-getcode) with the `pending` tag
-  * [`eth_getStorageAt`](/reference/optimism-getstorageat) with the `pending` tag
+  * [`eth_getCode`](/reference/optimism-getcode) with the `pending` tag — per the Optimism Flashblocks specification
+  * [`eth_getStorageAt`](/reference/optimism-getstorageat) with the `pending` tag — per the Optimism Flashblocks specification
   * [`eth_estimateGas`](/reference/optimism-estimategas) with the `pending` tag
   * [`eth_getTransactionReceipt`](/reference/optimism-gettransactionreceipt) — returns the preconfirmed receipt as soon as the transaction is included in a Flashblock
   * [`eth_getTransactionByHash`](/reference/optimism-gettransactionbyhash) — returns the preconfirmed transaction as soon as it is included in a Flashblock
@@ -48,21 +48,21 @@ A quick view of the same canonical block number sampled 500ms apart while the bl
   <Tab title="Preconfirmed 250ms Flashblock (early)">
     ```json
     "number": "0x90b665c",
-    "blockHash": "0x0469f8a27172dbd4...",
+    "hash": "0x0469f8a27172dbd4...",
     "transactions": [ /* 15 transactions */ ]
     ```
   </Tab>
   <Tab title="Preconfirmed 250ms Flashblock (later)">
     ```json
     "number": "0x90b665c",
-    "blockHash": "0x4279d35247120a58...",
+    "hash": "0x4279d35247120a58...",
     "transactions": [ /* 46 transactions */ ]
     ```
   </Tab>
   <Tab title="Confirmed regular 2s block">
     ```json
     "number": "0x90b665c",
-    "blockHash": "0x...",
+    "hash": "0x...",
     "transactions": [ /* full transaction list, finalized stateRoot */ ]
     ```
   </Tab>
@@ -99,6 +99,10 @@ The actual confirmation time depends on:
 * Transaction processing time at the sequencer.
 * Time until the next Flashblock (up to 250ms).
 * Network travel time for the confirmation response.
+
+<Warning>
+Flashblock preconfirmations are not final. A preconfirmed receipt from `eth_getTransactionReceipt`, `eth_sendRawTransactionSync`, or a pending-tag call can be revoked if the Optimism sequencer drops or reorders the transaction before the canonical 2-second block is sealed. Do not treat preconfirmed receipts as settlement guarantees. Wait for the transaction to be included in a finalized canonical block before releasing funds or considering a payment settled.
+</Warning>
 
 ## Optimism vs. Base Flashblocks at a glance
 

--- a/docs/flashblocks-on-optimism.mdx
+++ b/docs/flashblocks-on-optimism.mdx
@@ -1,0 +1,137 @@
+---
+title: "Flashblocks on Optimism: 250ms preconfirmations"
+description: Enable Flashblocks on Optimism through Chainstack for 250ms transaction preconfirmations via standard JSON-RPC calls with the pending tag.
+---
+
+Get started with a [reliable Optimism RPC endpoint](https://chainstack.com/build-better-with-optimism/) to use Flashblocks.
+
+Flashblocks is a block builder sidecar for OP Stack chains. The sidecar is called Rollup-Boost, designed and built by [Flashbots](https://www.flashbots.net/) and co-designed with Uniswap Labs and OP Labs.
+
+As Optimism Mainnet is the canonical OP Stack chain, the Optimism team has implemented Flashblocks on Optimism. Flashblocks went live on the Optimism Mainnet sequencer in 2026.
+
+The Flashblocks implementation on Optimism is two-part:
+
+* Sequencer side — the Rollup-Boost sidecar and the `op-rbuilder` Reth-based builder run next to the OP Stack sequencer.
+* Node side — the Flashblocks module is implemented on the Reth-based execution client running on Chainstack.
+
+This two-side architecture implements the following flow:
+
+* The Optimism sequencer creates regular 2-second blocks and additionally creates sub-blocks called Flashblocks every 250ms.
+* The sequencer streams these Flashblocks every 250ms over WebSocket to the Reth nodes that have the Flashblocks module enabled.
+* The sequencer-streamed Flashblocks and the preconfirmation state can then be retrieved by apps over the standard Optimism RPC endpoints and methods with the `pending` block tag:
+  * [`eth_getBlockByNumber`](/reference/optimism-getblockbynumber) with the `pending` tag
+  * [`eth_call`](/reference/optimism-call) with the `pending` tag
+  * [`eth_getBalance`](/reference/optimism-getbalance) with the `pending` tag
+  * [`eth_getTransactionCount`](/reference/optimism-gettransactioncount) with the `pending` tag
+  * [`eth_getCode`](/reference/optimism-getcode) with the `pending` tag
+  * [`eth_getStorageAt`](/reference/optimism-getstorageat) with the `pending` tag
+  * [`eth_estimateGas`](/reference/optimism-estimategas) with the `pending` tag
+  * [`eth_getTransactionReceipt`](/reference/optimism-gettransactionreceipt) — returns the preconfirmed receipt as soon as the transaction is included in a Flashblock
+  * [`eth_getTransactionByHash`](/reference/optimism-gettransactionbyhash) — returns the preconfirmed transaction as soon as it is included in a Flashblock
+  * `eth_sendRawTransactionSync` — submit a signed transaction and receive the preconfirmed receipt in the same response
+
+* The transaction ordering is done at the Flashblock level instead of the block level.
+
+Each 2-second block on Optimism is formed after approximately 8 Flashblocks have been processed, each with its own transaction ordering.
+
+<Note>
+Unlike Base, Optimism does not expose Flashblocks as dedicated WebSocket subscriptions like `eth_subscribe newFlashblocks`. The customer-facing Flashblocks interface on Optimism is the standard JSON-RPC interface with the `pending` block tag, as defined in the [Optimism Flashblocks specification](https://specs.optimism.io/protocol/flashblocks.html).
+</Note>
+
+## Quick Flashblock vs. full block data comparison
+
+Call [eth_getBlockByNumber](/reference/optimism-getblockbynumber) with the `pending` tag on a Flashblocks-enabled Optimism endpoint while a 2-second canonical block is forming. The response evolves every 250ms as new Flashblocks arrive — the same block number, but the transaction list grows append-only and the block hash changes with each Flashblock.
+
+A quick view of the same canonical block number sampled 500ms apart while the block was being assembled on Chainstack:
+
+<Tabs>
+  <Tab title="Preconfirmed 250ms Flashblock (early)">
+    ```json
+    "number": "0x90b665c",
+    "blockHash": "0x0469f8a27172dbd4...",
+    "transactions": [ /* 15 transactions */ ]
+    ```
+  </Tab>
+  <Tab title="Preconfirmed 250ms Flashblock (later)">
+    ```json
+    "number": "0x90b665c",
+    "blockHash": "0x4279d35247120a58...",
+    "transactions": [ /* 46 transactions */ ]
+    ```
+  </Tab>
+  <Tab title="Confirmed regular 2s block">
+    ```json
+    "number": "0x90b665c",
+    "blockHash": "0x...",
+    "transactions": [ /* full transaction list, finalized stateRoot */ ]
+    ```
+  </Tab>
+</Tabs>
+
+The block number stays the same across all three samples — only the contents grow and the preconfirmation hash updates. Once the 2-second canonical block is sealed, the final block hash is computed and the transactions are attributed to it.
+
+## Verify Flashblocks behavior
+
+You can verify Flashblocks behavior on your Optimism endpoint by polling `eth_getBlockByNumber` with the `pending` tag and watching the response evolve within a single block number. Replace `YOUR_OPTIMISM_ENDPOINT` with your Chainstack Optimism node HTTPS endpoint:
+
+```bash
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  curl -s "YOUR_OPTIMISM_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["pending",false]}' \
+    | python3 -c "import sys,json; b=json.load(sys.stdin)['result']; print(int(b['number'],16), b['hash'][:18], len(b['transactions']))"
+  sleep 0.25
+done
+```
+
+On a Flashblocks-enabled endpoint, you will see multiple distinct hashes and growing transaction counts for the same block number within a 2-second window. On a non-Flashblocks endpoint, you will see at most one or two distinct pending blocks per canonical block.
+
+## Performance expectations
+
+Flashblocks on Optimism are produced at 250ms intervals, but actual end-to-end latency will be higher due to network travel time:
+
+* Standard Optimism endpoint — ~2000ms (2-second block time).
+* Flashblocks-enabled Optimism endpoint — ~350-550ms (250ms Flashblock interval + network travel time).
+
+The actual confirmation time depends on:
+
+* Network latency to and from the Optimism node.
+* Transaction processing time at the sequencer.
+* Time until the next Flashblock (up to 250ms).
+* Network travel time for the confirmation response.
+
+## Optimism vs. Base Flashblocks at a glance
+
+| Aspect                       | Optimism                              | Base                                  |
+| ---------------------------- | ------------------------------------- | ------------------------------------- |
+| Flashblock interval          | 250ms                                 | 200ms                                 |
+| Canonical block time         | 2s                                    | 2s                                    |
+| Flashblocks per block        | ~8                                    | ~10                                   |
+| Customer-facing interface    | JSON-RPC with `pending` tag           | JSON-RPC with `pending` tag and dedicated WebSocket subscriptions |
+| `eth_subscribe newFlashblocks` etc. | Not exposed                    | [Exposed](/docs/flashblocks-on-base)  |
+
+## Additional resources
+
+* [Flashblocks on Base](/docs/flashblocks-on-base) — the Base implementation, including dedicated WebSocket subscription methods
+* Optimism documentation: [Flashblocks overview](https://docs.optimism.io/op-stack/features/flashblocks)
+* Optimism specification: [Flashblocks JSON-RPC APIs](https://specs.optimism.io/protocol/flashblocks.html)
+* Flashbots blog: [Introducing Rollup-Boost](https://writings.flashbots.net/introducing-rollup-boost)
+* Original spec for Rollup-Boost: [External Block Production](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/external-block-production.md)
+
+### About the author
+
+<CardGroup>
+  <Card title="Ake">
+    <img src="/images/docs/profile_images/1719912994363326464/8_Bi4fdM_400x400.jpg" alt="Ake" style={{width: '80px', height: '80px', borderRadius: '50%', objectFit: 'cover', display: 'block', margin: '0 auto'}} noZoom />
+
+    <Icon icon="code" iconType="solid" /> Director of Developer Experience @ Chainstack
+    <br /><Icon icon="screwdriver-wrench" iconType="solid" /> Talk to me all things Web3
+    <br />20 years in technology | 8+ years in Web3 full time years experience
+
+    <div style={{display: "flex", justifyContent: "center", gap: "12px"}}>
+      <a href="https://github.com/akegaviar/" style={{textDecoration: "none", borderBottom: "none"}}><Icon icon="github" iconType="brands" /></a>
+      <a href="https://twitter.com/akegaviar" style={{textDecoration: "none", borderBottom: "none"}}><Icon icon="twitter" iconType="brands" /></a>
+      <a href="https://www.linkedin.com/in/ake/" style={{textDecoration: "none", borderBottom: "none"}}><Icon icon="linkedin" iconType="brands" /></a>
+    </div>
+  </Card>
+</CardGroup>

--- a/docs/optimism-methods.mdx
+++ b/docs/optimism-methods.mdx
@@ -45,6 +45,7 @@ See also [interactive Optimism API call examples](/reference/optimism-api-refere
 | eth\_uninstallFilter                     | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_unsubscribe                         | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_sendRawTransaction                  | <Icon icon="square-check"  iconType="solid" />            |         |
+| eth\_sendRawTransactionSync              | <Icon icon="square-check"  iconType="solid" />            | [Flashblocks](/docs/flashblocks-on-optimism) sync send |
 | net\_listening                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | net\_peerCount                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | net\_version                             | <Icon icon="square-check"  iconType="solid" />            |         |


### PR DESCRIPTION
## Summary

Adds a customer-facing guide for Flashblocks on Optimism, verified live on both Global and Trader archive Chainstack Optimism mainnet endpoints (and on Optimism Sepolia).

Unlike Base, Optimism does **not** expose Flashblocks via dedicated `eth_subscribe newFlashblocks` / `newFlashblockTransactions` / `pendingLogs` WebSocket methods. Optimism's customer-facing Flashblocks interface is the standard JSON-RPC interface with the `pending` block tag, as defined in the [Optimism Flashblocks specification](https://specs.optimism.io/protocol/flashblocks.html). The new page is structured around that interface.

## What changed

- New `docs/flashblocks-on-optimism.mdx`:
  - 250ms Flashblock interval (vs. 200ms on Base), 2-second canonical block time, ~8 Flashblocks per block
  - List of flashblock-aware JSON-RPC methods with `pending` tag, plus `eth_sendRawTransactionSync`, `eth_getTransactionReceipt`, `eth_getTransactionByHash`
  - Tabs comparing early Flashblock state, later Flashblock state, and the finalized 2-second block
  - Verification curl snippet for customers to test their endpoint
  - Performance expectations
  - Optimism vs. Base comparison table
  - Note clarifying that Base-style WebSocket subscription methods do not apply to Optimism
- `docs.json`: registers the new page in the "Blockchain APIs guides" group right after `docs/flashblocks-on-base`
- `docs/optimism-methods.mdx`: adds `eth_sendRawTransactionSync` to the supported methods table with a link to the new page

## How this was verified

Deployed three fresh Chainstack Optimism nodes I own (Global mainnet, Trader archive mainnet in LAX, Global sepolia) and polled `eth_getBlockByNumber("pending", false)` rapidly:

- Same canonical block number, growing transaction list, hash updating every ~250ms — matches the spec's append-only Flashblock pattern.
- Two independent Chainstack endpoints (Global via Dshackle proxy, Trader as dedicated op-reth) returned **byte-identical** pending block hashes at the same tx count — proof both consume the same upstream Flashblock stream.
- `eth_sendRawTransactionSync` is recognized on all three endpoints (returns decode error on dummy input, not "method not found").
- Reth versions: `reth/v2.0.0-27bfdde` (Global), `reth/v2.2.0-88505c7` (Trader archive and Sepolia).

Test nodes were deleted after verification.

## Test plan

- [ ] Mintlify build passes
- [ ] Navigation surfaces `docs/flashblocks-on-optimism` under "Blockchain APIs guides" right after `docs/flashblocks-on-base`
- [ ] All `/reference/optimism-*` links on the page resolve
- [ ] Optimism-vs-Base table renders correctly
- [ ] Verification curl snippet copies cleanly