### PR TITLE
docs(changelog): announce Flashblocks on Optimism

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: May 18, 2026" description=" by Ake">
+
+**Protocols**. **Flashblocks on Optimism** is live on every Chainstack [Optimism](https://chainstack.com/build-better-with-optimism/) mainnet node. The Optimism sequencer streams Flashblocks every 250ms, and Chainstack Optimism nodes expose the preconfirmation state through standard JSON-RPC calls with the `pending` block tag. See [Flashblocks on Optimism](/docs/flashblocks-on-optimism) for the full guide, including the Optimism vs. Base differences and performance expectations.
+
+<Button href="/changelog/chainstack-updates-may-18-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: April 29, 2026" description=" by Ake">
 
 **Protocols**. **Hyperliquid `/nanoreth`** is live on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) mainnet node. Append `/nanoreth` to your endpoint URL to get system transactions included in `eth_getBlockByNumber`, `eth_getBlockReceipts`, and direct hash lookups. The default `/evm` path is unchanged — hl-node-compliant, system transactions stripped from block-shaped responses. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.

--- a/changelog/chainstack-updates-may-18-2026.mdx
+++ b/changelog/chainstack-updates-may-18-2026.mdx
@@ -1,0 +1,8 @@
+---
+title: "Chainstack updates: May 18, 2026"
+description: "Flashblocks on Optimism is live on every Chainstack Optimism mainnet node, with 250ms preconfirmations via standard JSON-RPC calls with the pending block tag."
+---
+
+**Protocols**. **Flashblocks on Optimism** is live on every Chainstack [Optimism](https://chainstack.com/build-better-with-optimism/) mainnet node. The Optimism sequencer streams Flashblocks every 250ms, and Chainstack Optimism nodes expose the preconfirmation state through standard JSON-RPC calls with the `pending` block tag — `eth_getBlockByNumber`, `eth_call`, `eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`, `eth_estimateGas` — plus `eth_getTransactionReceipt`, `eth_getTransactionByHash`, and `eth_sendRawTransactionSync` for preconfirmed transactions.
+
+See [Flashblocks on Optimism](/docs/flashblocks-on-optimism) for the full guide, including the Optimism vs. Base differences, performance expectations, and a verification snippet.

--- a/docs.json
+++ b/docs.json
@@ -3549,6 +3549,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-may-18-2026",
           "changelog/chainstack-updates-april-29-2026",
           "changelog/chainstack-updates-april-22-2026",
           "changelog/chainstack-updates-march-27-2026",


### PR DESCRIPTION
## Summary

Adds the May 18, 2026 changelog entry announcing Flashblocks on Optimism. Follow-up to #383 (the docs page itself was merged in 7c96193).

Also acts as a fresh-deploy trigger to verify whether dashboard Assistant toggle propagation is working.

## Test plan

- [ ] Changelog entry surfaces at top of /changelog
- [ ] Standalone page at /changelog/chainstack-updates-may-18-2026 renders