### PR TITLE
docs: clarify Bitcoin Full vs Archive and electrs add-on

### DIFF
--- a/docs/bitcoin-methods.mdx
+++ b/docs/bitcoin-methods.mdx
@@ -3,6 +3,12 @@ title: "Bitcoin methods"
 description: Complete reference of supported Bitcoin JSON-RPC methods on Chainstack nodes, covering blockchain queries, raw transactions, and network information.
 ---
 
+<Note>
+  On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.
+
+  Historical address queries (transaction history, balance at a past block) need an indexer like [electrs](https://github.com/Blockstream/electrs) — available as a [Bitcoin dedicated node customization](/docs/features-availability-across-subscription-plans#node-customization). [Contact us](https://chainstack.com/contact/) to enable it.
+</Note>
+
 See also [interactive Bitcoin API call examples](/reference/bitcoin-api-reference).
 
 ## Method availability

--- a/docs/features-availability-across-subscription-plans.mdx
+++ b/docs/features-availability-across-subscription-plans.mdx
@@ -58,7 +58,7 @@ Feel free to check with us for any additional customization that's not on the li
   - **Scaling node resources** — options to scale up node resources like storage, CPU, and RAM.
   - **Tailored load balancing** — a dedicated gateway that balances the request load between multiple dedicated nodes.
   - **Private networking** — connect your application running on AWS to a Chainstack node running on AWS through a private network. This eliminates the need for your application and the node to communicate over the internet, reducing latency and increasing speed.
-  - **Indexing** for Bitcoin nodes.
+  - **Bitcoin address indexing** — [electrs](https://github.com/Blockstream/electrs) indexer for address-level queries (transaction history, balance at a past block) not available via vanilla Bitcoin Core JSON-RPC.
   - **Hyperliquid system transactions** — enable system transaction visibility for tracking transfers between HyperCore and HyperEVM. Available on [Dedicated Nodes](/docs/dedicated-node). See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for details.
 </Check>
 

--- a/docs/protocols-modes-and-types.mdx
+++ b/docs/protocols-modes-and-types.mdx
@@ -15,6 +15,12 @@ For most of the available public chains, Chainstack supports deploying nodes in 
 * Archive — a node that stores full blockchain data and an archive of historical states, which makes it possible to query any block since the chain genesis.
 * Trader — a node that propagates transactions to the global mempool at high speed. See [Trader nodes](/docs/warp-transactions).
 
+<Note>
+  On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.
+
+  Historical address queries (transaction history, balance at a past block) need an indexer like [electrs](https://github.com/Blockstream/electrs) — available as a [Bitcoin dedicated node customization](/docs/features-availability-across-subscription-plans#node-customization). [Contact us](https://chainstack.com/contact/) to enable it.
+</Note>
+
 <Info>
   ### Advanced options on paid plans
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -3,6 +3,12 @@ title: "Networks"
 description: Browse all supported blockchain networks on Chainstack including Ethereum, Solana, Bitcoin, Polygon, and 70+ mainnet and testnet protocol networks.
 ---
 
+<Note>
+  On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.
+
+  Historical address queries (transaction history, balance at a past block) need an indexer like [electrs](https://github.com/Blockstream/electrs) — available as a [Bitcoin dedicated node customization](/docs/features-availability-across-subscription-plans#node-customization). [Contact us](https://chainstack.com/contact/) to enable it.
+</Note>
+
 | Chain | Support | Elastic Mainnet Support | Elastic Testnet Support | Testnet networks | Debug and Trace | Deploy node |
 |-------|---------|-------------------------|--------------------------|------------------|-----------------|-------------|
 | Apechain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |


### PR DESCRIPTION

This PR:

- Adds a shared Note to `protocols-modes-and-types`, `protocols-networks`, and `bitcoin-methods` explaining:
  - Why Archive vs Full as a distinction doesn't apply to Bitcoin (no separate per-block historical state)
  - That Chainstack Bitcoin nodes are non-pruned with `txindex` enabled — every block and tx since genesis is queryable, Full does not mean pruned
  - That historical address queries (tx history, balance at a past block) genuinely require an indexer like [electrs](https://github.com/Blockstream/electrs), pointing to the dedicated-node customization SKU we already sell
- Expands the existing "Indexing for Bitcoin nodes" stub on `features-availability-across-subscription-plans` (Node customization section) with a proper description and link to electrs
