### PR TITLE
docs: migrate Zendesk KB to dev-portal (batch 2)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1159,7 +1159,9 @@
                   "docs/solana-optimize-your-getblock-performance",
                   "docs/solana-understanding-block-time",
                   "docs/solana-listening-to-pumpfun-token-mint-using-geyser",
-                  "docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js"
+                  "docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js",
+                  "docs/solana-blocksubscribe-1009-error-on-websocket",
+                  "docs/common-errors-with-solana-web3js"
                 ]
               },
               {

--- a/docs/common-errors-with-solana-web3js.mdx
+++ b/docs/common-errors-with-solana-web3js.mdx
@@ -4,13 +4,13 @@ description: "Fix the @solana/web3.js v1 WSS-derivation bug that causes 404 or 5
 ---
 
 **TLDR:**
-* `@solana/web3.js` v1 derives the WebSocket URL from the HTTP URL by string substitution. The derived URL does not match a Chainstack WSS endpoint, and any subscription call fails with `Unexpected server response: 404` or `503`.
-* Fix it by passing `wsEndpoint` explicitly to `Connection`.
-* New projects should target [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit) — the v1 successor — which takes RPC and subscription transports separately and has no derivation bug.
+* `@solana/web3.js` v1 derives the WSS URL from the HTTP URL via its internal `makeWebsocketUrl` helper. The derived URL does not match a Chainstack WSS endpoint, and any subscription call fails with `Unexpected server response: 404` or `503`.
+* Fix v1 by passing `wsEndpoint` explicitly to `Connection`.
+* v1 is now [legacy](https://solana.com/docs/clients/official/javascript). [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit) is the recommended SDK — it has no derivation bug because it takes RPC and subscription transports as separate inputs.
 
 ## The WSS-derivation bug
 
-The v1 `Connection` constructor optimistically builds a WebSocket URL from the HTTP URL when `wsEndpoint` is not provided. It rewrites the scheme (`https://` → `wss://`) and trims path segments. The derived URL does not match a Chainstack node's WSS endpoint — your auth key is part of the HTTP path and is not preserved in the rewrite — so the first subscription call fails:
+When you call `new Connection(httpEndpoint)` without a `wsEndpoint`, v1 routes the URL through `makeWebsocketUrl` — a helper that rewrites the scheme (`https://` → `wss://`) and reshapes the host. The result does not match a Chainstack node's WSS endpoint, so the first subscription call fails:
 
 ```
 ws error: Unexpected server response: 404
@@ -18,7 +18,7 @@ ws error: Unexpected server response: 404
 
 You can also see `503` if the rewritten host resolves but the request hits a different upstream that returns 503 for the unknown path.
 
-This bites only the v1 line. `@solana/web3.js` v1 is on the [maintenance branch](https://github.com/solana-foundation/solana-web3.js/tree/maintenance/v1.x) — security fixes only, no new features. The same library, renamed and rewritten, is now [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit).
+This bites only the v1 line, which is now on the [maintenance branch](https://github.com/solana-foundation/solana-web3.js/tree/maintenance/v1.x) — security fixes only, no new features. The same project, renamed and restructured, ships today as [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit).
 
 ## Fix: pass `wsEndpoint` explicitly
 
@@ -41,7 +41,7 @@ The HTTPS and WSS endpoints share the same host on Chainstack — there is no `w
 
 ## Better: migrate to `@solana/kit`
 
-For new code, prefer [`@solana/kit`](https://github.com/anza-xyz/kit). Kit takes its RPC and subscription transports as separate inputs, so there is no derivation step that can go wrong:
+Per the [official Solana docs](https://solana.com/docs/clients/official/javascript), `@solana/kit` is now the recommended TypeScript SDK and `@solana/web3.js` is the legacy line. Kit takes RPC and subscription transports as separate inputs, so the derivation step that breaks v1 is gone:
 
 <CodeGroup>
   ```typescript TypeScript
@@ -55,7 +55,7 @@ For new code, prefer [`@solana/kit`](https://github.com/anza-xyz/kit). Kit takes
   ```
 </CodeGroup>
 
-If you are mid-migration, the [`@solana/web3-compat`](https://solana.com/docs/frontend/web3-compat) bridge lets your existing v1 imports keep working while you adopt Kit primitives incrementally.
+If a full rewrite is not on the table, the [`@solana/web3-compat`](https://solana.com/docs/frontend/web3-compat) bridge lets you swap your `@solana/web3.js` import for `@solana/web3-compat` and migrate file by file onto Kit primitives. It is a Phase 0 release — supported surface is currently `Connection` methods, `Keypair`, `Transaction`/`VersionedTransaction`, and `sendAndConfirmTransaction`; anything else falls back to legacy v1. Keep the v1 dependency in your `package.json` until your usage fits inside the supported surface.
 
 ## See also
 

--- a/docs/common-errors-with-solana-web3js.mdx
+++ b/docs/common-errors-with-solana-web3js.mdx
@@ -1,0 +1,64 @@
+---
+title: "Common errors with @solana/web3.js"
+description: "Fix the @solana/web3.js v1 WSS-derivation bug that causes 404 or 503 on subscriptions to Chainstack Solana endpoints. Pass wsEndpoint explicitly."
+---
+
+**TLDR:**
+* `@solana/web3.js` v1 derives the WebSocket URL from the HTTP URL by string substitution. The derived URL does not match a Chainstack WSS endpoint, and any subscription call fails with `Unexpected server response: 404` or `503`.
+* Fix it by passing `wsEndpoint` explicitly to `Connection`.
+* New projects should target [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit) — the v1 successor — which takes RPC and subscription transports separately and has no derivation bug.
+
+## The WSS-derivation bug
+
+The v1 `Connection` constructor optimistically builds a WebSocket URL from the HTTP URL when `wsEndpoint` is not provided. It rewrites the scheme (`https://` → `wss://`) and trims path segments. The derived URL does not match a Chainstack node's WSS endpoint — your auth key is part of the HTTP path and is not preserved in the rewrite — so the first subscription call fails:
+
+```
+ws error: Unexpected server response: 404
+```
+
+You can also see `503` if the rewritten host resolves but the request hits a different upstream that returns 503 for the unknown path.
+
+This bites only the v1 line. `@solana/web3.js` v1 is on the [maintenance branch](https://github.com/solana-foundation/solana-web3.js/tree/maintenance/v1.x) — security fixes only, no new features. The same library, renamed and rewritten, is now [`@solana/kit`](/docs/solana-tooling#javascript-and-typescript-solana-kit).
+
+## Fix: pass `wsEndpoint` explicitly
+
+Find the HTTPS and WSS endpoints in your node access details ([Manage your node](/docs/manage-your-node#view-node-access-and-credentials)) and pass both to `Connection`:
+
+<CodeGroup>
+  ```javascript Node.js
+  const { Connection } = require("@solana/web3.js");
+
+  const rpcEndpoint = "https://solana-mainnet.core.chainstack.com/AUTH_KEY";
+  const wsEndpoint  = "wss://solana-mainnet.core.chainstack.com/AUTH_KEY";
+
+  const connection = new Connection(rpcEndpoint, { wsEndpoint });
+  ```
+</CodeGroup>
+
+<Tip>
+The HTTPS and WSS endpoints share the same host on Chainstack — there is no `ws-` subdomain. Only the scheme changes.
+</Tip>
+
+## Better: migrate to `@solana/kit`
+
+For new code, prefer [`@solana/kit`](https://github.com/anza-xyz/kit). Kit takes its RPC and subscription transports as separate inputs, so there is no derivation step that can go wrong:
+
+<CodeGroup>
+  ```typescript TypeScript
+  import {
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+  } from "@solana/kit";
+
+  const rpc = createSolanaRpc("https://solana-mainnet.core.chainstack.com/AUTH_KEY");
+  const rpcSubscriptions = createSolanaRpcSubscriptions("wss://solana-mainnet.core.chainstack.com/AUTH_KEY");
+  ```
+</CodeGroup>
+
+If you are mid-migration, the [`@solana/web3-compat`](https://solana.com/docs/frontend/web3-compat) bridge lets your existing v1 imports keep working while you adopt Kit primitives incrementally.
+
+## See also
+
+* [Solana tooling](/docs/solana-tooling) — modern Solana stack (Kit, Anchor 1.0, Codama, LiteSVM, Surfpool)
+* [Solana blockSubscribe 1009 error on WebSocket](/docs/solana-blocksubscribe-1009-error-on-websocket) — fix `1009` (`MESSAGE_TOO_BIG`) on large block pushes
+* [Handle real-time data using WebSockets with JavaScript and Python](/docs/handle-real-time-data-using-websockets-with-javascript-and-python)

--- a/docs/manage-your-account.mdx
+++ b/docs/manage-your-account.mdx
@@ -65,6 +65,23 @@ To disable 2FA:
 
 3. Provide your current password. Click **Disable 2FA**.
 
+## If you lost access to your account
+
+Three scenarios cover most lost-access cases. Pick the one that matches yours.
+
+### You forgot your password (2FA not enabled)
+
+1. Go to the [log in](https://console.chainstack.com/) page.
+2. Click **Forgot password?** and follow the instructions sent to your email.
+
+### You lost your 2FA device but kept the recovery codes
+
+Use a recovery code as described in [Recover your account protected with two-factor authentication](#recover-your-account-protected-with-two-factor-authentication).
+
+### You lost your 2FA device and the recovery codes
+
+Email [support@chainstack.com](mailto:support@chainstack.com) from the address registered on the account and include proof of ownership — for example, a Chainstack purchase receipt or a bank statement showing the charge. Support will verify the request and restore access.
+
 ## Recover your account protected with two-factor authentication
 
 When you enable two-factor authentication (2FA) for your Chainstack account, you are provided with a list of recovery codes.

--- a/docs/manage-your-account.mdx
+++ b/docs/manage-your-account.mdx
@@ -67,12 +67,16 @@ To disable 2FA:
 
 ## If you lost access to your account
 
-Three scenarios cover most lost-access cases. Pick the one that matches yours.
+Pick the scenario that matches yours.
 
 ### You forgot your password (2FA not enabled)
 
 1. Go to the [log in](https://console.chainstack.com/) page.
-2. Click **Forgot password?** and follow the instructions sent to your email.
+2. Click **Forgot password?** and follow the instructions sent to your registered email.
+
+### You signed up with a social account and lost access to it
+
+If you signed up via Google, GitHub, X (Twitter), or Microsoft and never set a Chainstack password, you cannot use **Forgot password?** to recover. Recover access to the social account with the provider first, then sign in to Chainstack as usual.
 
 ### You lost your 2FA device but kept the recovery codes
 
@@ -80,7 +84,16 @@ Use a recovery code as described in [Recover your account protected with two-fac
 
 ### You lost your 2FA device and the recovery codes
 
-Email [support@chainstack.com](mailto:support@chainstack.com) from the address registered on the account and include proof of ownership — for example, a Chainstack purchase receipt or a bank statement showing the charge. Support will verify the request and restore access.
+Email [support@chainstack.com](mailto:support@chainstack.com) **directly from the email address registered on the account** — contact-form submissions are not eligible for recovery. Attach both:
+
+- a bank statement showing a Chainstack charge, and
+- the matching Chainstack purchase receipt or invoice.
+
+Support cross-checks the documents against Stripe and, once verified, asks Engineering to remove 2FA from your account.
+
+### Your account uses enterprise SSO
+
+If your organization signs in to Chainstack through SSO, account recovery is handled by your identity provider's administrator. Chainstack support cannot reset SSO access on your behalf.
 
 ## Recover your account protected with two-factor authentication
 

--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -68,39 +68,51 @@ description: Manage your Chainstack billing, payment methods, invoices, and cryp
 
  ## Card was declined
 
-If you see an error when adding a card to your Chainstack account, one of two things is usually happening.
+Chainstack processes card payments through Stripe. If a card is rejected when you add it, one of the cases below usually applies.
 
 ### Card is already linked to another Chainstack account
 
-Each card can be linked to one Chainstack account at a time. Search every inbox you have for Chainstack invoices or receipts — the card may already be on a different account you created earlier. If you find it, either reuse that account or remove the card from it before adding it elsewhere.
+Each card can only be attached to one Chainstack account at a time. Search every inbox you have for Chainstack invoices or receipts — the card may already be on an earlier account. Reuse that account, or remove the card from it before adding it elsewhere. If you have a legitimate reason to use the same card on multiple accounts (for example, separate org workspaces under the same finance owner), email [support@chainstack.com](mailto:support@chainstack.com) — support can whitelist the email to allow it.
 
 ### Card declined by the issuer
 
-The issuing bank can decline the card attachment regardless of available balance — for example, when the bank blocks card-on-file authorizations for foreign merchants. Chainstack cannot override this. Contact your bank to authorize the charge, then retry, or add a different card.
+The issuing bank can decline the card attachment regardless of available balance. The most common Stripe decline code is [`do_not_honor`](https://support.stripe.com/questions/decline-code-do-not-honor) — the bank rejected the charge without giving a reason. Chainstack cannot override this. Contact your bank to authorize the charge, then retry, or add a different card.
 
-If neither applies, email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/).
+### Card is blocked after a previous decline
+
+If your card was declined by the bank on an earlier attempt, Stripe stops trying it again until you update the payment method — even if you fix things on the bank side. The error message you see in this state is:
+
+> You previously attempted to charge this card. When the customer's bank declined that payment, it directed Stripe to block future attempts.
+
+The fix is to attach a different card. Re-adding the same card from the same source will not clear the block.
+
+### Country restrictions
+
+Stripe does not process cards issued in countries on its [restricted businesses list](https://stripe.com/legal/restricted-businesses) or under active sanctions. Use a card issued in a supported country.
+
+If none of the above applies, email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/).
 
  ## Prevent suspicious card activity
 
-Two scenarios cover most fraudulent activity reports involving Chainstack billing. Act on both fronts — your bank and Chainstack — for either case.
+Two scenarios cover most fraudulent card activity on Chainstack. Act on both fronts — your bank and Chainstack — for either case.
 
 ### Someone has access to your Chainstack account
 
 If charges appear on your card from an account you still control:
 
 1. **Block the card.** Contact your bank and stop further charges immediately.
-2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/) so support can revoke the malicious actor's access.
+2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/). Include the unauthorized invoices or charge dates — support can lock the account, terminate active sessions, and refund charges from confirmed unauthorized activity.
 3. **Enable two-factor authentication.** See [Enable two-factor authentication](/docs/manage-your-account#enable-two-factor-authentication).
-4. **Rotate your password** — and replace it on any other service where you reused the same email/password pair.
+4. **Rotate your password.** Change it on Chainstack and on any other service where you reused the same email/password pair.
 
 ### Someone used your card on a new Chainstack account
 
 If your card was used to create a Chainstack account you do not recognize:
 
-1. **Block the card and dispute the charges.** Contact your bank, report the fraud, and request an internal investigation.
-2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/) so support can delete the unauthorized account.
+1. **Block the card and dispute the charges with your bank.** Report the fraud and request an investigation.
+2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/) with the card's last four digits and the dates of the charges. Support locates the unauthorized account via the Stripe customer record, deletes it, and addresses any sibling accounts created with the same card.
 
-For broader hardening, see [Best practices for securing your Chainstack endpoint](/docs/best-practices-for-securing-your-chainstack-endpoint).
+If neither path produces a resolution within a reasonable window, the bank chargeback you opened in step 1 is the fallback.
 
  ## Settle failed payments
 

--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -66,6 +66,42 @@ description: Manage your Chainstack billing, payment methods, invoices, and cryp
 
  The billing page will reload automatically and show your new credit card details.
 
+ ## Card was declined
+
+If you see an error when adding a card to your Chainstack account, one of two things is usually happening.
+
+### Card is already linked to another Chainstack account
+
+Each card can be linked to one Chainstack account at a time. Search every inbox you have for Chainstack invoices or receipts — the card may already be on a different account you created earlier. If you find it, either reuse that account or remove the card from it before adding it elsewhere.
+
+### Card declined by the issuer
+
+The issuing bank can decline the card attachment regardless of available balance — for example, when the bank blocks card-on-file authorizations for foreign merchants. Chainstack cannot override this. Contact your bank to authorize the charge, then retry, or add a different card.
+
+If neither applies, email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/).
+
+ ## Prevent suspicious card activity
+
+Two scenarios cover most fraudulent activity reports involving Chainstack billing. Act on both fronts — your bank and Chainstack — for either case.
+
+### Someone has access to your Chainstack account
+
+If charges appear on your card from an account you still control:
+
+1. **Block the card.** Contact your bank and stop further charges immediately.
+2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/) so support can revoke the malicious actor's access.
+3. **Enable two-factor authentication.** See [Enable two-factor authentication](/docs/manage-your-account#enable-two-factor-authentication).
+4. **Rotate your password** — and replace it on any other service where you reused the same email/password pair.
+
+### Someone used your card on a new Chainstack account
+
+If your card was used to create a Chainstack account you do not recognize:
+
+1. **Block the card and dispute the charges.** Contact your bank, report the fraud, and request an internal investigation.
+2. **Contact Chainstack support.** Email [support@chainstack.com](mailto:support@chainstack.com) or [submit this form](https://chainstack.com/contact/) so support can delete the unauthorized account.
+
+For broader hardening, see [Best practices for securing your Chainstack endpoint](/docs/best-practices-for-securing-your-chainstack-endpoint).
+
  ## Settle failed payments
 
  If both the crypto balance and credit card deduction tries were unsuccessful, a payment is considered failed.

--- a/docs/solana-blocksubscribe-1009-error-on-websocket.mdx
+++ b/docs/solana-blocksubscribe-1009-error-on-websocket.mdx
@@ -7,7 +7,11 @@ description: "Fix WebSocket close code 1009 (message too big) when subscribing t
 * WebSocket close code `1009` (`MESSAGE_TOO_BIG`) fires when the inbound frame exceeds the client's payload cap — common on Solana `blockSubscribe` because mainnet blocks can be tens of MiB.
 * Python `websockets` defaults to a 1 MiB cap (`max_size=2**20`). Raise or disable it on the `connect()` call.
 * Node `ws` defaults to a 100 MiB cap (`maxPayload`). Usually fine, but disable it (`Infinity`) for full blocks.
-* The issue is client-side. The Chainstack endpoint does not impose a message-size limit on subscriptions.
+* Raising the cap stops `1009`, but `blockSubscribe` itself is [unstable upstream](https://solana.com/docs/rpc/websocket/blocksubscribe). For production, use [Yellowstone gRPC Geyser](/docs/yellowstone-grpc-geyser-plugin).
+
+<Warning>
+**`blockSubscribe` is marked [unstable by the Solana team](https://solana.com/docs/rpc/websocket/blocksubscribe).** The fixes below address client-side `1009` only — for production, use [Yellowstone gRPC Geyser](/docs/yellowstone-grpc-geyser-plugin) instead.
+</Warning>
 
 ## What close code 1009 means
 
@@ -19,6 +23,8 @@ The symptom differs by library:
 
 - **Python `websockets`** raises `PayloadTooBig`, then closes with code `1009`.
 - **Node `ws`** emits a `close` event with `code === 1009`.
+
+Code `1006` ("abnormal closure") often shows up on the same workload after the `1009` fix — that one is the upstream instability, not a payload-size issue. Raising the client cap will not fix `1006`; switching to Geyser will.
 
 ## Python: `websockets` default limit
 
@@ -99,14 +105,25 @@ Guidance:
 
 ## Trimming the payload instead
 
-If a smaller payload is acceptable, narrow what `blockSubscribe` returns before raising the cap:
+If you can live with less detail, narrow what `blockSubscribe` returns. This also makes the stream noticeably more stable — our internal load testing showed `transactionDetails: "signatures"` survives 1,000+ concurrent clients while `"full"` started disconnecting after ~40 seconds at a single client.
 
-- `transactionDetails: "signatures"` — drop full transaction bodies, keep signatures only.
+- `transactionDetails: "signatures"` — drop full transaction bodies, keep signatures only. **Most reliable option if you don't need the full body.**
 - `transactionDetails: "none"` — block metadata only, no transactions.
 - `showRewards: false` — skip the rewards array.
 - Filter to a single program via `{"mentionsAccountOrProgram": "<pubkey>"}` in `params[0]` — only blocks containing that program's transactions are pushed.
 
 See the [`blockSubscribe` reference](https://solana.com/docs/rpc/websocket/blocksubscribe) for the full parameter list.
+
+## Production path: Yellowstone gRPC Geyser
+
+Even after raising the client cap, `blockSubscribe` itself is upstream-flagged as [unstable on busy programs](https://solana.com/docs/rpc/websocket/blocksubscribe). Our load tests show connections drop within ~40 seconds even at 1 concurrent client when `transactionDetails: "full"` is used. Symptoms include `1006` (abnormal closure) closes and silently dropped notifications — not just the `1009` case the fixes above address.
+
+The recommended production path is [Yellowstone gRPC Geyser](/docs/yellowstone-grpc-geyser-plugin) — a Chainstack add-on that delivers the same data (blocks, transactions, account updates, slots) over a gRPC stream, with no RFC-6455 payload caps and without the upstream `blockSubscribe` instability. Existing `blockSubscribe` consumers migrate to a gRPC `subscribe` call against the Geyser endpoint.
+
+See:
+- [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin)
+- [Solana: listening to programs using Geyser and Yellowstone gRPC (Node.js)](/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js)
+- [Solana: listening to pump.fun token mint using Geyser](/docs/solana-listening-to-pumpfun-token-mint-using-geyser)
 
 ## Billing note
 

--- a/docs/solana-blocksubscribe-1009-error-on-websocket.mdx
+++ b/docs/solana-blocksubscribe-1009-error-on-websocket.mdx
@@ -1,0 +1,120 @@
+---
+title: "Solana blockSubscribe 1009 error on WebSocket"
+description: "Fix WebSocket close code 1009 (message too big) when subscribing to large Solana blocks. Raise max_size in Python websockets and maxPayload in Node ws."
+---
+
+**TLDR:**
+* WebSocket close code `1009` (`MESSAGE_TOO_BIG`) fires when the inbound frame exceeds the client's payload cap — common on Solana `blockSubscribe` because mainnet blocks can be tens of MiB.
+* Python `websockets` defaults to a 1 MiB cap (`max_size=2**20`). Raise or disable it on the `connect()` call.
+* Node `ws` defaults to a 100 MiB cap (`maxPayload`). Usually fine, but disable it (`Infinity`) for full blocks.
+* The issue is client-side. The Chainstack endpoint does not impose a message-size limit on subscriptions.
+
+## What close code 1009 means
+
+Per [RFC 6455 §7.4.1](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1), close code `1009` (`MESSAGE_TOO_BIG`) signals that an endpoint received a frame or message larger than it is willing or able to process. It is a defensive cap meant to protect the client from resource exhaustion or a hostile server flooding it with oversized frames.
+
+On Solana, [`blockSubscribe`](https://solana.com/docs/rpc/websocket/blocksubscribe) pushes the full block payload — transactions, inner instructions, log messages, balance deltas. On Mainnet this is routinely well above 1 MiB and can climb past 10 MiB during heavy activity. A library default of 1 MiB will drop the connection on the first large block.
+
+The symptom differs by library:
+
+- **Python `websockets`** raises `PayloadTooBig`, then closes with code `1009`.
+- **Node `ws`** emits a `close` event with `code === 1009`.
+
+## Python: `websockets` default limit
+
+The [`websockets`](https://websockets.readthedocs.io/) library sets `max_size = 2**20` bytes (1 MiB) per message and `max_queue = 32` buffered messages. Any inbound frame larger than `max_size` triggers:
+
+```
+websockets.exceptions.PayloadTooBig: over size limit (length > max_size)
+ConnectionClosedError: sent 1009 (message too big)
+```
+
+### Fix
+
+Pass `max_size` to `connect()` — raise it, or set `None` to disable the cap:
+
+<CodeGroup>
+  ```python Python
+  import asyncio
+  import json
+  import websockets
+
+  WS_URL = "wss://solana-mainnet.core.chainstack.com/AUTH_KEY"
+
+  async def main():
+      async with websockets.connect(WS_URL, max_size=None) as ws:
+          await ws.send(json.dumps({
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "blockSubscribe",
+              "params": ["all", {"encoding": "json", "transactionDetails": "full", "showRewards": False, "maxSupportedTransactionVersion": 0}],
+          }))
+          async for msg in ws:
+              print(msg)
+
+  asyncio.run(main())
+  ```
+</CodeGroup>
+
+Guidance:
+
+- `max_size=None` — disable the cap entirely.
+- `max_size=10 * 1024 * 1024` — 10 MiB ceiling, a reasonable headroom for `blockSubscribe`.
+
+Keep `max_queue` at its default unless you have a slow consumer; raising it just hides backpressure.
+
+## Node.js: `ws` default limit
+
+The [`ws`](https://github.com/websockets/ws) library defaults to `maxPayload = 100 * 1024 * 1024` (100 MiB), which usually covers Solana blocks. If you ever see code `1009`, raise the cap or disable it:
+
+<CodeGroup>
+  ```javascript Node.js
+  const WebSocket = require("ws");
+
+  const WS_URL = "wss://solana-mainnet.core.chainstack.com/AUTH_KEY";
+
+  const ws = new WebSocket(WS_URL, {
+    maxPayload: Infinity, // disable cap
+    // or: maxPayload: 10 * 1024 * 1024 // 10 MiB
+  });
+
+  ws.on("open", () => {
+    ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "blockSubscribe",
+      params: ["all", { encoding: "json", transactionDetails: "full", showRewards: false, maxSupportedTransactionVersion: 0 }],
+    }));
+  });
+
+  ws.on("message", (data) => console.log(data.toString()));
+  ws.on("close", (code, reason) => console.error("closed", code, reason.toString()));
+  ```
+</CodeGroup>
+
+Guidance:
+
+- `maxPayload: 0` or `Infinity` — no cap.
+- `maxPayload: <bytes>` — custom cap. Set it to your worst-case block size with headroom.
+
+## Trimming the payload instead
+
+If a smaller payload is acceptable, narrow what `blockSubscribe` returns before raising the cap:
+
+- `transactionDetails: "signatures"` — drop full transaction bodies, keep signatures only.
+- `transactionDetails: "none"` — block metadata only, no transactions.
+- `showRewards: false` — skip the rewards array.
+- Filter to a single program via `{"mentionsAccountOrProgram": "<pubkey>"}` in `params[0]` — only blocks containing that program's transactions are pushed.
+
+See the [`blockSubscribe` reference](https://solana.com/docs/rpc/websocket/blocksubscribe) for the full parameter list.
+
+## Billing note
+
+Each `blockSubscribe` push counts as 1 [request unit](/docs/request-units#http-requests-vs-websocket-subscriptions). On Mainnet that is one RU per slot — roughly two per second when the network is healthy. Factor the subscription cost into your plan before pointing a long-running consumer at `blockSubscribe`.
+
+## See also
+
+* [Solana tooling](/docs/solana-tooling)
+* [Handle real-time data using WebSockets with JavaScript and Python](/docs/handle-real-time-data-using-websockets-with-javascript-and-python)
+* [Request units](/docs/request-units#http-requests-vs-websocket-subscriptions)
+* [EVM node connection: HTTP vs WebSocket](/docs/evm-node-connection-http-vs-websocket)

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -50,13 +50,11 @@ $ solana block-height
 
 Full command reference: [Solana CLI docs](https://docs.anza.xyz/cli).
 
-## QUIC for transaction submission
+## QUIC support
 
-Chainstack Solana nodes accept transactions over [QUIC](https://datatracker.ietf.org/doc/html/rfc9000). QUIC is enabled by default on all servers and routing — you do not need to configure anything to use it. Sending transactions via QUIC matters because the network rate-limits raw UDP under load; QUIC's connection-oriented model gives well-behaved senders priority and is the recommended path for Mainnet transaction submission.
+`sendTransaction` on a Chainstack Solana node forwards over QUIC to the current and next leaders. No client configuration required.
 
-The validator flag `--tpu-disable-quic` (default `false`) can disable QUIC on a node operator's side; Chainstack runs with QUIC on.
-
-If you submit transactions via [`sendTransaction` over JSON-RPC](https://solana.com/docs/rpc/http/sendtransaction), the node forwards them over QUIC to the current leader on your behalf — no client changes needed. Native QUIC clients exist as well; the Solana CLI uses QUIC by default when broadcasting transactions.
+For high landing rate under contention, use [Solana Trader Nodes](/docs/solana-trader-nodes) — `sendTransaction` is routed through bloXroute's staked [Trader API](https://docs.bloxroute.com/solana/trader-api-v2), all other RPC calls stay on the standard endpoint. See also the [Stake-Weighted QoS guide](https://solana.com/developers/guides/advanced/stake-weighted-qos).
 
 ## JSON-RPC API
 

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -50,6 +50,14 @@ $ solana block-height
 
 Full command reference: [Solana CLI docs](https://docs.anza.xyz/cli).
 
+## QUIC for transaction submission
+
+Chainstack Solana nodes accept transactions over [QUIC](https://datatracker.ietf.org/doc/html/rfc9000). QUIC is enabled by default on all servers and routing — you do not need to configure anything to use it. Sending transactions via QUIC matters because the network rate-limits raw UDP under load; QUIC's connection-oriented model gives well-behaved senders priority and is the recommended path for Mainnet transaction submission.
+
+The validator flag `--tpu-disable-quic` (default `false`) can disable QUIC on a node operator's side; Chainstack runs with QUIC on.
+
+If you submit transactions via [`sendTransaction` over JSON-RPC](https://solana.com/docs/rpc/http/sendtransaction), the node forwards them over QUIC to the current leader on your behalf — no client changes needed. Native QUIC clients exist as well; the Solana CLI uses QUIC by default when broadcasting transactions.
+
 ## JSON-RPC API
 
 Any HTTP client works. Use [curl](https://curl.haxx.se) or [Postman](https://www.getpostman.com) for ad-hoc calls; see the full [JSON-RPC reference](https://solana.com/docs/rpc) for all methods.


### PR DESCRIPTION
## Summary

Second batch of the Zendesk KB → dev-portal migration tracked in DEVEX-299, covering the 16 articles Anton flagged as still Published after the batch-1 mass archive on 2026-05-21.

Same SEO playbook as PR #385: keep content useful enough to migrate, redirect what we keep, delete the rest.

### New pages (2)

- [`solana-blocksubscribe-1009-error-on-websocket`](https://github.com/chainstack/dev-portal/blob/docs/zendesk-migration-batch-2/docs/solana-blocksubscribe-1009-error-on-websocket.mdx) — fix the client-side `1009` (`MESSAGE_TOO_BIG`) on `blockSubscribe` (Python `websockets` `max_size`, Node `ws` `maxPayload`), with an upstream-instability warning pointing readers to Yellowstone gRPC Geyser for production
- [`common-errors-with-solana-web3js`](https://github.com/chainstack/dev-portal/blob/docs/zendesk-migration-batch-2/docs/common-errors-with-solana-web3js.mdx) — the v1 `makeWebsocketUrl` derivation bug (`404`/`503` on subscriptions); recommend `@solana/kit` per Solana's official guidance

### Existing pages with new sections (4)

- `solana-tooling` — **QUIC support** section: `sendTransaction` forwards over QUIC, point at Solana Trader Nodes for landing-rate workloads
- `manage-your-billing` — **Card was declined**: card-already-linked / bank decline / Stripe-blocked-after-decline / country restrictions
- `manage-your-billing` — **Prevent suspicious card activity**: response playbook for account compromise vs. fraudulent use of your card on an unknown account
- `manage-your-account` — **If you lost access to your account**: password / social-login / 2FA-with-codes / 2FA-without-codes / enterprise SSO

### Disposition of the 16 batch-2 articles

| Source article | Disposition |
|---|---|
| Solana blockSubscribe 1009 error on WebSocket | → new page (above) |
| Common errors with Solana Web3JS | → new page (above) |
| QUIC in Solana nodes | → `/docs/solana-tooling#quic-support` |
| Card was declined | → `/docs/manage-your-billing#card-was-declined` |
| Prevent Suspicious Card Activity | → `/docs/manage-your-billing#prevent-suspicious-card-activity` |
| Lost Access to Chainstack Account | → `/docs/manage-your-account#if-you-lost-access-to-your-account` *(re-routed from billing — better topic fit)* |
| API namespaces available for public EVM nodes | 301-only → `/docs/ethereum-methods` |
| What is zkSync? | delete |
| What is Ronin? | delete |
| What is Avalanche? | delete |
| Develop on Bitcoin | delete |
| EVM-compatible node APIs provided by Chainstack | delete |
| API namespaces available for public Avalanche nodes | delete |
| Avalanche transaction indexing | delete |
| Downgrading account | delete *(content already covered by the existing billing page)* |
| Binding Chainstack node to a custom domain | **open question** — 401-gated even via the Zendesk API; no admin UI access on our side to fetch the body. Deferred to Anton / Pei Yong for disposition. |

### Handoff for Anton

Redirects + deletes are bundled in [`audit/zendesk-handoff-batch-2.csv`](https://github.com/chainstack/zendesk-migration/blob/main/audit/zendesk-handoff-batch-2.csv) in the migration repo, ready to drop into the same Zendesk Help Center API flow used for batch 1.

## Test plan

- [ ] After merge: confirm the 2 new pages render on `docs.chainstack.com` (~10 min Mintlify lag, per batch 1)
- [ ] After merge: confirm the 4 new anchors resolve:
  - `/docs/solana-tooling#quic-support`
  - `/docs/manage-your-billing#card-was-declined`
  - `/docs/manage-your-billing#prevent-suspicious-card-activity`
  - `/docs/manage-your-account#if-you-lost-access-to-your-account`
- [ ] Hand the addendum CSV to Anton in the `#ask-ai` thread; Anton applies the 7 redirects + 8 deletes via Zendesk Help Center API
- [ ] Resolve the open question on `Binding Chainstack node to a custom domain` (9397359239321)