### PR TITLE
docs: refine Solana archive billing details with exact thresholds and worked example

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -23,7 +23,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Protocols | Classification |
 | --- | --- |
 | Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, Moonbeam, MegaETH, Ronin, Fantom, zkSync Era, Polygon zkEVM, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
-| Solana | **Archive** billing applies to specific methods when fetching historical data beyond the full-node retention. See [Solana method scope](#solana-method-scope) below. |
+| Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | Bitcoin, TON, Sui, Aptos, Starknet, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
@@ -62,7 +62,7 @@ Archive billing on Solana applies only to these methods:
 - `getFirstAvailableBlock`
 - `getSignatureStatuses`
 
-A request is archive (2 RUs) when its target slot is more than **5,000 slots** below the lowest slot our Solana full node still retains. Calls within retention are full (1 RU).
+A request is archive (2 RUs) when its target slot is below `firstAvailable + 5,000`, where `firstAvailable` is the lowest slot our Solana full node still retains. Slots at or above this boundary are full (1 RU).
 
 `getSignaturesForAddress` and `getFirstAvailableBlock` are always billed as archive, regardless of slot.
 
@@ -71,7 +71,7 @@ All other Solana methods are billed as full (1 RU) regardless of slot.
 #### Two values shape the boundary
 
 - **Ledger retention** — each Solana full node is configured with `--limit-ledger-size 400000000` (400 million shreds). [Shreds](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) are Solana's network-propagation units, and the number produced per slot varies with block density, so this caps disk usage rather than fixing the slot count retained.
-- **Safety buffer** — 5,000 slots. Requests targeting slots within 5,000 slots of the pruning floor are routed to the archive backend to avoid races where the full node prunes data mid-request. This is the threshold that triggers archive billing.
+- **Safety buffer** — 5,000 slots immediately above the pruning floor. Requests targeting these slots are routed to the archive backend to avoid races where the full node prunes data mid-request. This sets the boundary that triggers archive billing.
 
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -62,11 +62,16 @@ Archive billing on Solana applies only to these methods:
 - `getFirstAvailableBlock`
 - `getSignatureStatuses`
 
-For these methods, archive (2 RUs) applies when the requested slot is beyond the recent retention window of our Solana full nodes. Calls within retention are billed as full (1 RU).
+A request is archive (2 RUs) when its target slot is more than **5,000 slots** below the lowest slot our Solana full node still retains. Calls within retention are full (1 RU).
 
 `getSignaturesForAddress` and `getFirstAvailableBlock` are always billed as archive, regardless of slot.
 
 All other Solana methods are billed as full (1 RU) regardless of slot.
+
+#### Two values shape the boundary
+
+- **Ledger retention** — each Solana full node is configured with `--limit-ledger-size 400000000` (400 million shreds). [Shreds](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) are Solana's network-propagation units, and the number produced per slot varies with block density, so this caps disk usage rather than fixing the slot count retained.
+- **Safety buffer** — 5,000 slots. Requests targeting slots within 5,000 slots of the pruning floor are routed to the archive backend to avoid races where the full node prunes data mid-request. This is the threshold that triggers archive billing.
 
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -82,12 +82,11 @@ For a sequence of calls:
 | Call | Why | Cost |
 | --- | --- | --- |
 | `getBalance(account)` | Not eligible for archive billing | 1 RU |
-| `getBlockHeight()` | Not eligible | 1 RU |
 | `getTransaction(signature)` on a recent transaction | Eligible; target slot above the boundary | 1 RU |
 | `getTransaction(signature)` on a transaction from months ago | Eligible; target slot below the boundary | 2 RUs |
 | `getSignaturesForAddress(address)` | Always archive | 2 RUs |
 | `getBlock(slot=1)` | Eligible; target slot far below the boundary | 2 RUs |
-| **Total** | | **9 RUs** |
+| **Total** | | **8 RUs** |
 
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -68,7 +68,7 @@ A request is archive (2 RUs) when its target slot is below `firstAvailable + 5,0
 
 All other Solana methods are billed as full (1 RU) regardless of slot.
 
-#### Two values shape the boundary
+#### Two values shape the Solana archive boundary
 
 - **Ledger retention** — each Solana full node is configured with `--limit-ledger-size 400000000` (400 million shreds). [Shreds](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) are Solana's network-propagation units, and the number produced per slot varies with block density, so this caps disk usage rather than fixing the slot count retained.
 - **Safety buffer** — 5,000 slots immediately above the pruning floor. Requests targeting these slots are routed to the archive backend to avoid races where the full node prunes data mid-request. This sets the boundary that triggers archive billing.

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -73,6 +73,22 @@ All other Solana methods are billed as full (1 RU) regardless of slot.
 - **Ledger retention** — each Solana full node is configured with `--limit-ledger-size 400000000` (400 million shreds). [Shreds](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) are Solana's network-propagation units, and the number produced per slot varies with block density, so this caps disk usage rather than fixing the slot count retained.
 - **Safety buffer** — 5,000 slots immediately above the pruning floor. Requests targeting these slots are routed to the archive backend to avoid races where the full node prunes data mid-request. This sets the boundary that triggers archive billing.
 
+#### Putting it together
+
+A call's RU cost on Solana depends on the method and, for methods eligible for archive billing, the target slot. The ledger size (400M shreds) caps how far back the full node retains data; the 5,000-slot safety buffer above the pruning floor sets the actual billing boundary.
+
+For a sequence of calls:
+
+| Call | Why | Cost |
+| --- | --- | --- |
+| `getBalance(account)` | Not eligible for archive billing | 1 RU |
+| `getBlockHeight()` | Not eligible | 1 RU |
+| `getTransaction(signature)` on a recent transaction | Eligible; target slot above the boundary | 1 RU |
+| `getTransaction(signature)` on a transaction from months ago | Eligible; target slot below the boundary | 2 RUs |
+| `getSignaturesForAddress(address)` | Always archive | 2 RUs |
+| `getBlock(slot=1)` | Eligible; target slot far below the boundary | 2 RUs |
+| **Total** | | **9 RUs** |
+
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
 
 ## HTTP requests vs WebSocket subscriptions


### PR DESCRIPTION
## Summary

Follow-up to #389. Tightens the Solana section of `/docs/request-units` after a closer reading of `smart-proxy/plugin/classifier/type_solana.go` and the masternodes node configs.

Five small refinements:

- **Add exact thresholds** — both `--limit-ledger-size 400000000` (400M shreds) and the 5,000-slot safety buffer, with a brief explainer that shreds are variable-per-slot while the buffer is in fixed slots.
- **Fix boundary direction** — three statements in the prior version disagreed on which side of `firstAvailable` the safety buffer sits. Code is `slot < firstAvailable + 5000` (buffer is *above* the floor). Table cell, rule line, and buffer bullet all aligned to that.
- **Clarify subheading scope** — `Two values shape the boundary` → `Two values shape the Solana archive boundary` so the subheading is self-contained if linked to directly.
- **Worked example** — new "Putting it together" subsection: a 5-call table walking through non-eligible methods, eligible-recent, eligible-old, always-archive, and edge-case slot=1. Totals the RUs at the end.
- **Drop redundant non-eligible row** — the original 6-row example had two near-identical "not eligible" rows. Consolidated to one.

## Sources verified

- `smart-proxy/plugin/classifier/type_solana.go:21,97` — `AvailableBlockThreshold` default and the `slot < firstAvailable + threshold` rule.
- `masternodes/prod/<region>/solana-mainnet-full/nodes/nd-*.yaml` — `limitLedgerSize: "400000000"` confirmed across 8 sampled mainnet full-node configs.
- `helm-charts/solana-node/templates/_helpers.tpl:323` — value passed verbatim as `--limit-ledger-size`.
- `agave/validator/src/cli.rs` — `--limit-ledger-size` argument typed as `SHRED_COUNT`, help text "Keep this amount of shreds in root slots."
- [Solana Foundation `specs/p2p/shred.md`](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) — confirms shreds-per-block is variable; linked from the doc for readers who want to dig.

## Test plan

- [x] Mintlify dev preview renders cleanly
- [x] Anchor `#two-values-shape-the-solana-archive-boundary` resolves from the in-section cross-reference
- [x] Shreds spec link resolves
- [x] No regressions to the rest of the page (EVM table, method rules, HTTP/WS section, predicting section)