### PR TITLE
docs: add Arbitrum and Base mainnet to MEV protection support

### DIFF
--- a/docs/mev-protection.mdx
+++ b/docs/mev-protection.mdx
@@ -1,11 +1,13 @@
 ---
 title: "MEV protection"
-description: Enable MEV protection on your Chainstack Ethereum nodes to shield transactions from front-running, sandwich attacks, and other value extraction methods.
+description: Enable MEV protection on your Chainstack Ethereum, BNB Smart Chain, Arbitrum, and Base nodes to shield transactions from front-running, sandwich attacks, and other value extraction methods.
 ---
 
 This currently applies to:
 * Ethereum mainnet
 * BNB Smart Chain mainnet
+* Arbitrum mainnet
+* Base mainnet
 
 ### How it works
 


### PR DESCRIPTION
## What

Adds Arbitrum mainnet and Base mainnet to the [MEV protection](https://docs.chainstack.com/docs/mev-protection) supported-networks list, which previously listed only Ethereum and BNB Smart Chain mainnet. Also broadens the SEO description accordingly.

## Why

Chainstack also supports MEV protection on Arbitrum Mainnet and Base Mainnet, but the docs page never reflected it.

## Scope review

Checked every MEV protection reference across the portal:

- `docs/add-ons.mdx` — description already generic ("Ethereum and EVM chains"), no change.
- `docs/solana-mev-protection.mdx` — separate feature (Jito `dontfront`), unaffected.
- `changelog.mdx` + historical changelog entries — left as-is (dated historical record).
- Ethereum `reference/*` pages carrying the "disable MEV protection to track your own txs" note — left Ethereum-only to match the existing convention (BNB never carried this note despite MEV support since March 2025).

No changelog entry added (support predates this docs fix).