### PR TITLE
docs(hyperliquid): fix contradictory /nanoreth system-tx availability

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: May 26, 2026" description=" by Ake">
+
+**Protocols**. **Hyperliquid `/nanoreth` is now on testnet** as well as mainnet. Both `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (system transactions included) paths exist by default on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) node, mainnet and testnet. Append the path you need to your endpoint URL. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.
+
+<Button href="/changelog/chainstack-updates-may-26-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: May 18, 2026" description=" by Ake">
 
 **Protocols**. **Flashblocks on Optimism** is live on every Chainstack [Optimism](https://chainstack.com/build-better-with-optimism/) mainnet node. The Optimism sequencer streams Flashblocks every 250ms, and Chainstack Optimism nodes expose the preconfirmation state through standard JSON-RPC calls with the `pending` block tag. See [Flashblocks on Optimism](/docs/flashblocks-on-optimism) for the full guide, including the Optimism vs. Base differences and performance expectations.

--- a/changelog/chainstack-updates-may-26-2026.mdx
+++ b/changelog/chainstack-updates-may-26-2026.mdx
@@ -1,0 +1,8 @@
+---
+title: "Chainstack updates: May 26, 2026"
+description: "Hyperliquid /nanoreth is now available on testnet as well as mainnet, with protocol-level system transactions included in HyperEVM JSON-RPC responses on every node."
+---
+
+**Protocols**. **Hyperliquid `/nanoreth`** is now available on testnet as well as mainnet. Both `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (system transactions included) paths exist by default on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) node, mainnet and testnet. There is nothing to enable — append the path you need to your endpoint URL. For testnet, use `hyperliquid-testnet.core.chainstack.com` with the same `/evm` and `/nanoreth` paths.
+
+See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.

--- a/docs.json
+++ b/docs.json
@@ -3560,6 +3560,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-may-26-2026",
           "changelog/chainstack-updates-may-18-2026",
           "changelog/chainstack-updates-april-29-2026",
           "changelog/chainstack-updates-april-22-2026",

--- a/docs/features-availability-across-subscription-plans.mdx
+++ b/docs/features-availability-across-subscription-plans.mdx
@@ -59,7 +59,6 @@ Feel free to check with us for any additional customization that's not on the li
   - **Tailored load balancing** — a dedicated gateway that balances the request load between multiple dedicated nodes.
   - **Private networking** — connect your application running on AWS to a Chainstack node running on AWS through a private network. This eliminates the need for your application and the node to communicate over the internet, reducing latency and increasing speed.
   - **Bitcoin address indexing** — [electrs](https://github.com/Blockstream/electrs) indexer for address-level queries (transaction history, balance at a past block) not available via vanilla Bitcoin Core JSON-RPC.
-  - **Hyperliquid system transactions** — enable system transaction visibility for tracking transfers between HyperCore and HyperEVM. Available on [Dedicated Nodes](/docs/dedicated-node). See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for details.
 </Check>
 
 For any customizations not listed here, contact [Chainstack support](https://support.chainstack.com/). We are always happy to explore your case and help you.

--- a/docs/hyperliquid-infrastructure-faq.mdx
+++ b/docs/hyperliquid-infrastructure-faq.mdx
@@ -29,7 +29,7 @@ Both layers share HyperBFT consensus and produce interleaved blocks. Rather than
 
 ### API structure
 
-The platform exposes distinct endpoints for each layer. HyperCore operations route through `/info` for queries and `/exchange` for trading actions, while HyperEVM uses the standard JSON-RPC endpoint with Chain ID 999. Chainstack exposes HyperEVM on two paths: `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (with system transactions included). Both are visible on every node and you append the path you need to your endpoint URL — see [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for when to use which.
+The platform exposes distinct endpoints for each layer. HyperCore operations route through `/info` for queries and `/exchange` for trading actions, while HyperEVM uses the standard JSON-RPC endpoint with Chain ID 999. Chainstack exposes HyperEVM on two paths: `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (with system transactions included). Both exist by default on every node, on mainnet and testnet, and you append the path you need to your endpoint URL — see [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for when to use which.
 
 ### Cross-layer integration
 

--- a/docs/hyperliquid-node-configuration.mdx
+++ b/docs/hyperliquid-node-configuration.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Hyperliquid node configuration and system transactions"
-description: "Chainstack exposes two HyperEVM JSON-RPC paths on every Hyperliquid node: a default path that strips system transactions, and /nanoreth which includes them."
+description: "Chainstack exposes two HyperEVM JSON-RPC paths on every Hyperliquid node, mainnet and testnet: a default path that strips system transactions, and /nanoreth which includes them."
 ---
 
-Every Chainstack Hyperliquid node exposes two HyperEVM JSON-RPC paths on the same endpoint:
+Every Chainstack Hyperliquid node, on both mainnet and testnet, exposes two HyperEVM JSON-RPC paths on the same endpoint:
 
 | Console label | Path | What it returns |
 | --- | --- | --- |
 | **JSON-RPC API (default)** | `/evm` | hl-node-compliant output; system transactions stripped from block-shaped responses |
 | **JSON-RPC API (with system tx)** | `/nanoreth` | Full nanoreth output; system transactions included in blocks and receipts |
 
-You don't pick one at deploy time — both are always available. Append the path you need to your endpoint URL.
+You don't pick one at deploy time and there's nothing to enable — both paths exist by default on every node. Append the path you need to your endpoint URL.
 
 ## What system transactions are
 
@@ -54,7 +54,9 @@ wss://hyperliquid-mainnet.core.chainstack.com/<auth>/evm
 https://hyperliquid-mainnet.core.chainstack.com/<auth>/info
 ```
 
-Find both paths in the [console](https://console.chainstack.com/) under **Access and credentials** on any Hyperliquid node. Username/password access is provided alongside.
+The examples above use the mainnet host. For testnet, use `hyperliquid-testnet.core.chainstack.com` with the same `/evm` and `/nanoreth` paths.
+
+Find both paths in the [console](https://console.chainstack.com/) under **Access and credentials** on any Hyperliquid node, mainnet or testnet. Username/password access is provided alongside.
 
 ## Related resources
 

--- a/docs/hyperliquid-tooling.mdx
+++ b/docs/hyperliquid-tooling.mdx
@@ -102,6 +102,4 @@ Hyperliquid HyperEVM supports debug and trace APIs on both mainnet and testnet f
 
 ## Hyperliquid system transactions
 
-By default, the HyperCore ↔ HyperEVM transfers (aka [system transactions](/docs/hyperliquid-node-configuration)) are excluded.
-
-Hyperliquid system transactions are available on [Dedicated Nodes](/docs/dedicated-node) only.
+The default `/evm` path strips HyperCore ↔ HyperEVM transfers (system transactions) from block-shaped responses; the `/nanoreth` path includes them. Both paths exist by default on every Hyperliquid node, on mainnet and testnet. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method differences.


### PR DESCRIPTION
## Problem

The docs contradicted each other on whether Hyperliquid `/nanoreth` (system-transaction visibility) is available on every node or only Dedicated Nodes:

- **`hyperliquid-node-configuration.mdx`** + **`hyperliquid-infrastructure-faq.mdx`**: "on every node"
- **`hyperliquid-tooling.mdx`** + **`features-availability-across-subscription-plans.mdx`**: "Dedicated Nodes only"

## Ground truth

`/nanoreth` is a universal append-path that exists **by default on every Hyperliquid node, mainnet and testnet** (shipped for Alchemy/QuickNode data parity, CORE-14160; later extended to testnet). It is not configurable and not Dedicated-gated. The "Dedicated Nodes only" wording was stale — it described the pre-parity model when system-tx visibility was a Dedicated enable-on-request customization.

## Changes

- **node-configuration**: state every node + mainnet/testnet, "nothing to enable", add testnet host note (single source of truth)
- **tooling**: remove "Dedicated Nodes only"; defer to node configuration
- **features-availability**: remove the system-tx bullet from the Dedicated-customizations list (it's universal, not a Dedicated feature)
- **infrastructure-faq**: align wording (exist by default, mainnet + testnet)
- **changelog**: add a May 26, 2026 entry for testnet `/nanoreth` availability (none existed)

Root cause was three pages independently asserting availability — fix consolidates to node-configuration as the single source of truth, with the others deferring to it.