### PR TITLE
docs(solana): remove stale/contradictory Warp landing-rate figures

### DIFF
--- a/docs/solana-trader-nodes.mdx
+++ b/docs/solana-trader-nodes.mdx
@@ -24,7 +24,7 @@ Chainstack Solana Trader nodes with Warp transactions offer the following benefi
 * All requests, except `sendTransaction`, go through the highly reliable & balanced Chainstack Solana node. The `sendTransaction` request is routed through the [bloXroute Trader API](https://bloxroute.com/products/solana-trader-api/).
 * No need to craft custom transaction instructions or change your regular trading setup if it's using standard Solana nodes.
 * All `sendTransaction` requests (i.e., all transactions) are sent to the current leader through a staked validator connection.
-* 40% of transactions land in the first two blocks.
+* Transactions land competitively in the first blocks via SwQoS. See [Speed metrics](#speed-metrics) for current measured data.
 * Front-running protection is not enabled, as it would reduce transaction processing speed.
 * You can use [priority fees](/docs/solana-how-to-priority-fees-faster-transactions) to increase the chances of getting earlier placement within a block and in earlier blocks.
 * Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
@@ -33,7 +33,7 @@ Chainstack Solana Trader nodes with Warp transactions offer the following benefi
 
 If you have a trading project setup that's using regular Solana nodes, to transform your project to a high-speed one with all the benefits, all you need to do is swap the Solana node endpoint to a Chainstack node with Warp transactions enabled (available on both Trader nodes and Global nodes).
 
-Just doing that will immediately have your project have 40% of your transactions within the first two blocks and so on.
+Just doing that immediately routes your transactions through the staked SwQoS relay, with no custom transaction crafting on your side.
 
 All your project requests will be going through the Chainstack Solana nodes with the exception of the `sendTransaction` requests that will be routed through the bloXroute infrastructure.
 
@@ -56,17 +56,7 @@ The speed metrics are tricky, especially on an extremely fast chain like Solana.
 
 Note that the metrics below are done **without high priority fees** to provide you with a base expectation to work from.
 
-That said, here's some of the rough metrics that you can start with:
-
-* 75% of the transactions are included in less than 5 blocks:
-
-  * 37% within 2 blocks
-  * 79% within 4 blocks
-  * 95% within 6 blocks
-  * 98% within 8 blocks
-  * 99% within 10 blocks
-
-Again, keep in mind that you can greatly impact these numbers with your trading project actual location and priority fees.
+Landing rates depend heavily on your bot's proximity to the node and routing gate, the priority fees you set, and live network conditions, so a single fixed number isn't meaningful. For current, continuously-measured Solana transaction-landing rates — Warp compared against other providers, refreshed every 15 minutes — see the [Chainstack Compare dashboard](https://compare.chainstack.com/).
 
 ## No front running protection
 


### PR DESCRIPTION
## Problem

`solana-trader-nodes.mdx` contradicted itself on Warp transaction landing rate:

- Overview (and "No need for custom setups"): **"40% of transactions land in the first two blocks"**
- Speed-metrics table: **"37% within 2 blocks"** — same metric, different number

## Why drop the numbers (not just reconcile)

Both figures are pre-fix snapshots. The Solana landing-rate metric was buggy (it counted no-balance test cases) and was **recomputed on 2026-05-27** — now measured via `getTransaction` with no-balance cases excluded. So both `37%` and `40%` are stale, and any hardcoded figure will drift again (which is what caused the contradiction).

There's already a live source: the [Chainstack Compare dashboard](https://compare.chainstack.com/) measures Solana transaction landing continuously (every 15 min, Warp vs other providers).

## Fix

- Remove the hardcoded `40%` from the overview bullet and the "no custom setups" paragraph
- Replace the static `37%` speed-metrics table with a pointer to the live Compare dashboard
- Keep the SwQoS framing and the existing latency / priority-fee caveats

No number to maintain, points to the authoritative live source.