### PR TITLE
Changelog: June 2, 2026 — MCP server provider migration

### DIFF
--- a/changelog/chainstack-updates-june-2-2026.mdx
+++ b/changelog/chainstack-updates-june-2-2026.mdx
@@ -1,0 +1,12 @@
+---
+title: "Chainstack updates: June 2, 2026"
+description: "The Chainstack MCP server now migrates your project to Chainstack from another RPC provider — assessing usage, estimating savings, and repointing endpoints from inside your AI coding agent."
+---
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) now helps you migrate to Chainstack from another RPC provider — QuickNode, Alchemy, or any other — without leaving your AI coding agent:
+
+* **Assess** — ask your agent to migrate and it fetches the [migration runbook](https://docs.chainstack.com/docs/migrate-to-chainstack-with-ai), scans your project for non-Chainstack RPC endpoints, and verifies Chainstack coverage for the chains and methods you use.
+* **Estimate savings** — it reads your current usage (QuickNode automatically via its Admin API; Alchemy or any other provider from a dashboard screenshot or the numbers you provide), then uses `get_chainstack_pricing` to show your equivalent Chainstack cost and the savings versus your current bill.
+* **Migrate** — after you review and approve the plan, it deploys any nodes you need and repoints your endpoints to Chainstack.
+
+The [Chainstack skill](https://mcp.chainstack.com/skill) gains a **Migrate from another provider** workflow, so the same flow works in any coding agent.

--- a/docs.json
+++ b/docs.json
@@ -3564,6 +3564,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-2-2026",
           "changelog/chainstack-updates-may-26-2026",
           "changelog/chainstack-updates-may-18-2026",
           "changelog/chainstack-updates-april-29-2026",


### PR DESCRIPTION
## What
New docs release note `changelog/chainstack-updates-june-2-2026.mdx` (+ `docs.json` nav entry): the Chainstack MCP server now migrates your project to Chainstack from another RPC provider — assess, estimate savings, repoint — from inside your AI coding agent.

Docs-style mirror of the `chainstacklabs/mcp-server` 2026-06-02 changelog entry (mcp-server v1.10.4, live on mcp.chainstack.com). Companion: chainstacklabs/mcp-server#9.
