### PR TITLE
Add MCP server entries to changelog.mdx feed (Apr 9 – Jun 2)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,11 +6,32 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 2, 2026" description=" by Ake">
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) now migrates your project to Chainstack from another RPC provider — QuickNode, Alchemy, or any other — assessing your usage, estimating your savings, and repointing endpoints from inside your AI coding agent.
+
+<Button href="/changelog/chainstack-updates-june-2-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: May 28, 2026" description=" by Ake">
+
+**MCP Server**. Every Chainstack MCP server tool now publishes a typed `outputSchema`, so agents can consume structured results without guessing field names. List tools also emit `structuredContent` — an additive, non-breaking change.
+
+<Button href="/changelog/chainstack-updates-may-28-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: May 26, 2026" description=" by Ake">
 
 **Protocols**. **Hyperliquid `/nanoreth` is now on testnet** as well as mainnet. Both `/evm` (default, hl-node-compliant — system transactions stripped from block-shaped responses) and `/nanoreth` (system transactions included) paths exist by default on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) node, mainnet and testnet. Append the path you need to your endpoint URL. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.
 
 <Button href="/changelog/chainstack-updates-may-26-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: May 22, 2026" description=" by Ake">
+
+**MCP Server**. The Chainstack MCP server now supports all three Google Antigravity 2.0 surfaces — Antigravity CLI, the desktop app, and the IDE — on the [discovery page](https://mcp.chainstack.com).
+
+<Button href="/changelog/chainstack-updates-may-22-2026">Read more</Button>
 </Update>
 
 <Update label="Chainstack updates: May 18, 2026" description=" by Ake">
@@ -20,6 +41,13 @@ import { Button } from '/snippets/button.mdx';
 <Button href="/changelog/chainstack-updates-may-18-2026">Read more</Button>
 </Update>
 
+<Update label="Chainstack updates: May 12, 2026" description=" by Ake">
+
+**MCP Server**. Chainstack MCP tools now advertise standard MCP annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`) so clients skip prompts on read-only calls and require approval on writes, and the server reports its real release version on the `initialize` handshake.
+
+<Button href="/changelog/chainstack-updates-may-12-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: April 29, 2026" description=" by Ake">
 
 **Protocols**. **Hyperliquid `/nanoreth`** is live on every Chainstack [Hyperliquid](https://chainstack.com/build-better-with-hyperliquid/) mainnet node. Append `/nanoreth` to your endpoint URL to get system transactions included in `eth_getBlockByNumber`, `eth_getBlockReceipts`, and direct hash lookups. The default `/evm` path is unchanged — hl-node-compliant, system transactions stripped from block-shaped responses. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method behavior matrix.
@@ -27,11 +55,46 @@ import { Button } from '/snippets/button.mdx';
 <Button href="/changelog/chainstack-updates-april-29-2026">Read more</Button>
 </Update>
 
+<Update label="Chainstack updates: April 27, 2026" description=" by Ake">
+
+**MCP Server**. The [Pi](https://pi.dev/) coding agent can now install the Chainstack skill (skill-only — Pi rejects MCP servers by design), and the discovery page description now covers pricing and testnet funds.
+
+<Button href="/changelog/chainstack-updates-april-27-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: April 22, 2026" description=" by Ake">
 
 **Console**. The new [Agents page](https://console.chainstack.com/agents) is live in the Chainstack console — one place to plug Chainstack into Claude Code, Codex CLI/App, Gemini CLI, Cursor, or any other coding agent: migration prompt, docs, MCP server, and Chainstack skill.
 
 <Button href="/changelog/chainstack-updates-april-22-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: April 20, 2026" description=" by Ake">
+
+**MCP Server**. New tool: `get_chainstack_pricing` answers pricing questions grounded in live data — plan tiers, add-ons, and the full per-chain dedicated-node catalog. No API key required.
+
+<Button href="/changelog/chainstack-updates-april-20-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: April 18, 2026" description=" by Ake">
+
+**MCP Server**. New tool: `request_testnet_funds` tops up testnet addresses with gas across 12 EVM, Solana, and TON networks, directly from your agent.
+
+<Button href="/changelog/chainstack-updates-april-18-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: April 15, 2026" description=" by Ake">
+
+**MCP Server**. New tool: `contact_chainstack` lets you reach Chainstack's sales or support team directly from your agent. No API key required; the agent confirms before sending.
+
+<Button href="/changelog/chainstack-updates-april-15-2026">Read more</Button>
+</Update>
+
+<Update label="Chainstack updates: April 9, 2026" description=" by Ake">
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) is live at `mcp.chainstack.com` — deploy and manage nodes, search docs, and check platform status from any AI coding agent, via skill install or MCP registration.
+
+<Button href="/changelog/chainstack-updates-april-9-2026">Read more</Button>
 </Update>
 
 <Update label="Chainstack updates: March 27, 2026" description=" by Ake">


### PR DESCRIPTION
## What
Adds the **9 missing `<Update>` feed blocks** to `changelog.mdx` for the MCP server releases — June 2 plus the 8 backfilled dates (May 28, May 22, May 12, April 27, April 20, April 18, April 15, April 9).

## Why
The standalone pages (`changelog/chainstack-updates-*.mdx`) and `docs.json` nav entries landed in #400 and #401, but `changelog.mdx` — the landing feed that drives `docs.chainstack.com/changelog` and the page TOC — was never updated. The `changelog/` pages are **not** auto-indexed, so those entries existed (reachable by URL/nav) but didn't show in the feed, which topped out at May 26.

## Result
Feed now runs June 2 → May 28 → May 26 → May 22 → … → April 9 (newest-first), each with a `Read more` button to its existing standalone page. `<Update>`/`<Button>` tags balanced; all links resolve.
