### PR TITLE
docs(ton): document full vs archive billing for TON

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -24,7 +24,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | --- | --- |
 | Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, Moonbeam, MegaETH, Ronin, Fantom, zkSync Era, Polygon zkEVM, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
-| TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested block is more than ~128 seqno behind the tip. See [TON method scope](#ton-method-scope) below. |
+| TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested block is 128 or more seqno behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Bitcoin, Sui, Aptos, Starknet, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
@@ -102,12 +102,12 @@ TON requests are billed as full (1 RU) by default. Archive billing (2 RUs) appli
 
 These methods return an account's transaction history keyed by address (and logical time), not by block. The depth of the result cannot be determined before the request is served, so they are always classified as archive.
 
-**Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is more than ~128 behind the chain tip, and full (1 RU) otherwise (recent block, or no block specified):
+**Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block, or no block parameter):
 
-- **v2:** `getBlockTransactions`, `getBlockTransactionsExt`, `getBlockHeader`, `lookupBlock`, `shards` / `getShards`, `getShardAccountCell`, `getShardBlockProof`, `getMasterchainBlockSignatures`, `getAddressState`, `getConfigParam`, `getConfigAll`
-- **v3:** `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
+- v2: `getBlockTransactions`, `getBlockTransactionsExt`, `getBlockHeader`, `lookupBlock`, `shards` / `getShards`, `getShardAccountCell`, `getShardBlockProof`, `getMasterchainBlockSignatures`, `getAddressState`, `getConfigParam`, `getConfigAll`
+- v3: `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
 
-The seqno threshold is evaluated per workchain (masterchain or shardchain) against the latest seqno. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
+The threshold is evaluated against the latest seqno of the workchain referenced by the request — the masterchain by default. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
 
 ## HTTP requests vs WebSocket subscriptions
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -24,7 +24,8 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | --- | --- |
 | Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, Moonbeam, MegaETH, Ronin, Fantom, zkSync Era, Polygon zkEVM, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
-| Bitcoin, TON, Sui, Aptos, Starknet, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
+| TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested block is more than ~128 seqno behind the tip. See [TON method scope](#ton-method-scope) below. |
+| Bitcoin, Sui, Aptos, Starknet, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
 
@@ -89,6 +90,24 @@ For a sequence of calls:
 | **Total** | | **8 RUs** |
 
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
+
+### TON method scope
+
+TON requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in two cases.
+
+**Always archive**, regardless of parameters:
+
+- `getTransactions`
+- `getTransactionsStd`
+
+These methods return an account's transaction history keyed by address (and logical time), not by block. The depth of the result cannot be determined before the request is served, so they are always classified as archive.
+
+**Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is more than ~128 behind the chain tip, and full (1 RU) otherwise (recent block, or no block specified):
+
+- **v2:** `getBlockTransactions`, `getBlockTransactionsExt`, `getBlockHeader`, `lookupBlock`, `shards` / `getShards`, `getShardAccountCell`, `getShardBlockProof`, `getMasterchainBlockSignatures`, `getAddressState`, `getConfigParam`, `getConfigAll`
+- **v3:** `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
+
+The seqno threshold is evaluated per workchain (masterchain or shardchain) against the latest seqno. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
 
 ## HTTP requests vs WebSocket subscriptions
 

--- a/docs/ton-choosing-v2-or-v3.mdx
+++ b/docs/ton-choosing-v2-or-v3.mdx
@@ -4,9 +4,9 @@ description: "Compare TON API v2 vs v3: real-time node requests vs indexed data.
 ---
 
 <Info>
-  ### TON pricing is the same for full, archive, v2, v3
+  ### TON billing: full vs archive
 
-  There's no difference between a full node an archive node in data availability or pricing. All data is always available and all node requests are consumed as 1 request unit.
+  v2 and v3 are priced the same, and all data is available. Billing follows the request: most TON requests are **full** (1 request unit), while requests that read historical data are **archive** (2 request units). `getTransactions` and `getTransactionsStd` are always archive; block/seqno methods are archive when the requested block is more than ~128 seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope) for the full method list.
 </Info>
 
 Check out our [TON API reference](/reference/getting-started-ton), which has both v2 and v3 methods.

--- a/docs/ton-choosing-v2-or-v3.mdx
+++ b/docs/ton-choosing-v2-or-v3.mdx
@@ -6,7 +6,7 @@ description: "Compare TON API v2 vs v3: real-time node requests vs indexed data.
 <Info>
   ### TON billing: full vs archive
 
-  v2 and v3 are priced the same, and all data is available. Billing follows the request: most TON requests are **full** (1 request unit), while requests that read historical data are **archive** (2 request units). `getTransactions` and `getTransactionsStd` are always archive; block/seqno methods are archive when the requested block is more than ~128 seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope) for the full method list.
+  v2 and v3 are priced the same, and all data is available. Billing follows the request: most TON requests are **full** (1 request unit), while requests that read historical data are **archive** (2 request units). `getTransactions` and `getTransactionsStd` are always archive; block/seqno methods are archive when the requested block is 128 or more seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope) for the full method list.
 </Info>
 
 Check out our [TON API reference](/reference/getting-started-ton), which has both v2 and v3 methods.

--- a/docs/ton-methods.mdx
+++ b/docs/ton-methods.mdx
@@ -5,6 +5,10 @@ description: "Complete TON blockchain API methods reference. Includes v2 and v3 
 
 See also [interactive TON API call examples](/reference/getting-started-ton).
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — TON method scope](/docs/request-units#ton-method-scope). In short: most methods are full (1 RU); `getTransactions` and `getTransactionsStd` are always archive (2 RUs); block/seqno methods are archive when the requested block is more than ~128 seqno behind the tip.
+</Note>
+
 | Method                             | Availability | Comment |
 | ---------------------------------- | ------------ | ------- |
 | /v2/getAddressInformation          | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/ton-methods.mdx
+++ b/docs/ton-methods.mdx
@@ -6,7 +6,7 @@ description: "Complete TON blockchain API methods reference. Includes v2 and v3 
 See also [interactive TON API call examples](/reference/getting-started-ton).
 
 <Note>
-For how these methods are billed (full vs archive), see [Request units — TON method scope](/docs/request-units#ton-method-scope). In short: most methods are full (1 RU); `getTransactions` and `getTransactionsStd` are always archive (2 RUs); block/seqno methods are archive when the requested block is more than ~128 seqno behind the tip.
+For how these methods are billed (full vs archive), see [Request units — TON method scope](/docs/request-units#ton-method-scope). In short: most methods are full (1 RU); `getTransactions` and `getTransactionsStd` are always archive (2 RUs); block/seqno methods are archive when the requested block is 128 or more seqno behind the tip.
 </Note>
 
 | Method                             | Availability | Comment |


### PR DESCRIPTION
## What

Documents full vs archive billing for TON. The docs previously stated TON had no archive split (every request billed as full, 1 RU); TON now follows the same full/archive model as other protocols.

## Classification

- `getTransactions` / `getTransactionsStd` — always **archive** (2 RUs). These return an account's history keyed by address and logical time, not by block, so result depth can't be determined before the request is served.
- Block/seqno methods — **archive** when the requested block is 128 or more seqno behind the tip of the workchain referenced by the request (masterchain by default); **full** otherwise (recent block, or no block parameter).
- All other methods — **full** (1 RU).

## Files

- `request-units.mdx` — TON row in the per-protocol table + a `TON method scope` section with the always-archive and conditional method lists
- `ton-choosing-v2-or-v3.mdx` — update the pricing callout
- `ton-methods.mdx` — billing note linking to the method scope