### PR TITLE
Document TRON gRPC service scope (full node services only)

### DIFF
--- a/docs/tron-tooling.mdx
+++ b/docs/tron-tooling.mdx
@@ -11,7 +11,7 @@ description: "TRON blockchain development tools guide. Use TronWeb.js, gRPC, web
   * `/jsonrpc` — Ethereum-compatible JSON-RPC (read-only operations)
   * `/wallet` — TRON HTTP API (full node operations including transactions)
   * `/walletsolidity` — TRON HTTP API (confirmed data from solidity node)
-  * **gRPC** — high-performance binary protocol for efficient data access (full node API; see [available services](#available-services))
+  * **gRPC** — high-performance binary protocol for efficient data access (see [available services](#available-services))
 
   Note that the TRON nodes provided are full only (non-archive), which makes some of the methods unsupported.
 </Info>
@@ -59,22 +59,22 @@ gRPC endpoints use x-token authentication. Pass your token in the request metada
 
 ### Available services
 
-The TRON proto files define several gRPC services, but a Chainstack TRON node serves the **full node** services only:
+The TRON proto files define several gRPC services. Here's what a Chainstack TRON node currently serves:
 
 | Service | Status on Chainstack |
 | --- | --- |
 | `protocol.Wallet` | Available — the full node API: accounts, blocks, contracts, and transaction operations |
 | `protocol.Database` | Available — block metadata helpers |
-| `protocol.WalletSolidity` | Not available — calls return `UNIMPLEMENTED: Method not found` |
-| `protocol.WalletExtension` | Not available — calls return `UNIMPLEMENTED: Method not found` |
-| `protocol.Monitor` | Not available — calls return `UNIMPLEMENTED: Method not found` |
+| `protocol.WalletSolidity` | Not available yet |
+| `protocol.WalletExtension` | Not available yet |
+| `protocol.Monitor` | Not available yet |
 
-This differs from setups that expose a separate solidity gRPC port (for example, port `50061` on a self-hosted java-tron node). On Chainstack, the gRPC endpoint maps to the full node API — in your generated client, use the `Wallet` stub. For solidified (confirmed) data, use the HTTP `/walletsolidity` API on the same node endpoint — see [TRON methods](/docs/tron-methods) for availability.
+Calling a service that isn't currently served returns the gRPC `UNIMPLEMENTED` status (`Method not found`). Note that this is different from setups that expose a separate solidity gRPC port (for example, port `50061` on a self-hosted java-tron node) — on Chainstack, use the `Wallet` stub in your generated client. For solidified (confirmed) data, use the HTTP `/walletsolidity` API on the same node endpoint — see [TRON methods](/docs/tron-methods) for availability.
 
 <Warning>
   ### Reflection advertises more than is served
 
-  The endpoint supports gRPC server reflection, and the reflection list includes every service from the TRON protos — including `protocol.WalletSolidity`, `protocol.WalletExtension`, and `protocol.Monitor`, which are not routed. Don't infer availability from reflection or from the proto definitions; the table above reflects actual behavior.
+  The endpoint supports gRPC server reflection, and the reflection list includes every service from the TRON protos, including services that are not yet served. Don't infer availability from reflection or from the proto definitions; the table above reflects actual behavior.
 </Warning>
 
 ### Proto files

--- a/docs/tron-tooling.mdx
+++ b/docs/tron-tooling.mdx
@@ -11,7 +11,7 @@ description: "TRON blockchain development tools guide. Use TronWeb.js, gRPC, web
   * `/jsonrpc` — Ethereum-compatible JSON-RPC (read-only operations)
   * `/wallet` — TRON HTTP API (full node operations including transactions)
   * `/walletsolidity` — TRON HTTP API (confirmed data from solidity node)
-  * **gRPC** — high-performance binary protocol for efficient data access
+  * **gRPC** — high-performance binary protocol for efficient data access (full node API; see [available services](#available-services))
 
   Note that the TRON nodes provided are full only (non-archive), which makes some of the methods unsupported.
 </Info>
@@ -56,6 +56,19 @@ gRPC endpoints use x-token authentication. Pass your token in the request metada
 <Info>
   Find your gRPC endpoint and x-token in the Chainstack console under your TRON node's **Access and credentials** section.
 </Info>
+
+### Available services
+
+The TRON proto files define several gRPC services, but a Chainstack TRON node serves the **full node** services only:
+
+| Service | Status on Chainstack |
+| --- | --- |
+| `protocol.Wallet` | Available — the full node API: accounts, blocks, contracts, and transaction operations |
+| `protocol.Database` | Available — block metadata helpers |
+| `protocol.WalletSolidity` | Not available — calls return `UNIMPLEMENTED: Method not found` |
+| `protocol.WalletExtension` | Not available — calls return `UNIMPLEMENTED: Method not found` |
+
+This differs from setups that expose a separate solidity gRPC port (for example, port `50061` on a self-hosted java-tron node). On Chainstack, the gRPC endpoint maps to the full node API — in your generated client, use the `Wallet` stub. For solidified (confirmed) data, use the HTTP `/walletsolidity` API on the same node endpoint — see [TRON methods](/docs/tron-methods) for availability.
 
 ### Proto files
 

--- a/docs/tron-tooling.mdx
+++ b/docs/tron-tooling.mdx
@@ -67,12 +67,19 @@ The TRON proto files define several gRPC services, but a Chainstack TRON node se
 | `protocol.Database` | Available — block metadata helpers |
 | `protocol.WalletSolidity` | Not available — calls return `UNIMPLEMENTED: Method not found` |
 | `protocol.WalletExtension` | Not available — calls return `UNIMPLEMENTED: Method not found` |
+| `protocol.Monitor` | Not available — calls return `UNIMPLEMENTED: Method not found` |
 
 This differs from setups that expose a separate solidity gRPC port (for example, port `50061` on a self-hosted java-tron node). On Chainstack, the gRPC endpoint maps to the full node API — in your generated client, use the `Wallet` stub. For solidified (confirmed) data, use the HTTP `/walletsolidity` API on the same node endpoint — see [TRON methods](/docs/tron-methods) for availability.
 
+<Warning>
+  ### Reflection advertises more than is served
+
+  The endpoint supports gRPC server reflection, and the reflection list includes every service from the TRON protos — including `protocol.WalletSolidity`, `protocol.WalletExtension`, and `protocol.Monitor`, which are not routed. Don't infer availability from reflection or from the proto definitions; the table above reflects actual behavior.
+</Warning>
+
 ### Proto files
 
-TRON gRPC does not support server reflection, so you need the protocol buffer definitions to make calls. Get them from the official TRON protocol repository:
+The endpoint supports server reflection for discovery, but to generate typed clients you need the protocol buffer definitions. Get them from the official TRON protocol repository:
 
 ```shell
 git clone https://github.com/tronprotocol/protocol.git


### PR DESCRIPTION
## What

The TRON tooling page documents the gRPC endpoint, x-token auth, and proto setup, but not **which gRPC services the endpoint serves** — the most common follow-up question for anyone coming from java-tron's two-port model (full gRPC on 50051, solidity gRPC on 50061) or generating clients from the official protos, which define `Wallet`, `WalletSolidity`, `WalletExtension`, and `Database`.

## Verified behavior

Tested against a live TRON mainnet node with generated Python stubs, one probe per service (multiple methods each):

| Service | Result |
| --- | --- |
| `protocol.Wallet` | ✅ responds (`GetNowBlock`, `GetAccount`, `GetBlockByNum`) |
| `protocol.Database` | ✅ responds (`GetNowBlock`) |
| `protocol.WalletSolidity` | ❌ `UNIMPLEMENTED: Method not found` on every method |
| `protocol.WalletExtension` | ❌ `UNIMPLEMENTED: Method not found` |

## Change

- Add an **Available services** table to the gRPC section: the endpoint maps to the full node API; `WalletSolidity`/`WalletExtension` are not served; use the HTTP `/walletsolidity` API for solidified (confirmed) data
- Note the difference from setups that expose a separate solidity gRPC port
- Cross-link from the top support callout