### PR TITLE
Update TON billing notes across all 58 reference pages

### DIFF
--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -81,7 +81,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Taiko | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
 | Tempo | Elastic, Dedicated | Full, Archive | Full, Archive | Moderato Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| TON | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
+| TON | Elastic, Dedicated | Archive | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Treasure | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TRON | Elastic, Dedicated | Full, Archive | Full | Nile Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Unichain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -629,7 +629,6 @@
     "TON": {
       "protocol_name": "TON",
       "supported_modes": [
-        "Full",
         "Archive"
       ],
       "full_mode_query_limit": "Both v2 and v3 (indexer) are supported",
@@ -681,7 +680,7 @@
           ]
         }
       ],
-      "additional_notes": "No difference between full and archive nodes in data availability or pricing"
+      "additional_notes": "All data is available on every TON node; archival requests bill as archive (2 RUs) - see the TON method scope in request units"
     },
     "Unichain": {
       "protocol_name": "Unichain",

--- a/reference/getting-started-ton.mdx
+++ b/reference/getting-started-ton.mdx
@@ -29,9 +29,9 @@ TON employs a Proof-of-Stake consensus mechanism where validators stake TON coin
 </Check>
 
 <Info>
-  ### TON pricing is the same for full, archive, v2, v3
+  ### TON billing: full vs archive
 
-  There's no difference between a full node an archive node in data availability or pricing. All data is always available and all node requests are consumed as 1 request unit.
+  v2 and v3 are priced the same, and all data is available. Most TON requests are billed as full (1 request unit); requests that read historical data are archive (2 request units) — `getTransactions` and `getTransactionsStd` are always archive, and block/seqno methods are archive when the requested block is 128 or more seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope) for the full method list.
 </Info>
 
 <Check>

--- a/reference/ton-account-v3.mdx
+++ b/reference/ton-account-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-accountstates-v3.mdx
+++ b/reference/ton-accountstates-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-actions-v3.mdx
+++ b/reference/ton-actions-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-addressbook-v3.mdx
+++ b/reference/ton-addressbook-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-addressinformation-v3.mdx
+++ b/reference/ton-addressinformation-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-adjacenttransactions-v3.mdx
+++ b/reference/ton-adjacenttransactions-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-detectaddress-v2.mdx
+++ b/reference/ton-detectaddress-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-estimatefee-v3.mdx
+++ b/reference/ton-estimatefee-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-events-v3.mdx
+++ b/reference/ton-events-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-getaddressbalance-v2.mdx
+++ b/reference/ton-getaddressbalance-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getaddressinformation-v2.mdx
+++ b/reference/ton-getaddressinformation-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getaddressstate-v2.mdx
+++ b/reference/ton-getaddressstate-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getblockheader-v2.mdx
+++ b/reference/ton-getblockheader-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getblocktransactions-v2.mdx
+++ b/reference/ton-getblocktransactions-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getblocktransactionsext-v2.mdx
+++ b/reference/ton-getblocktransactionsext-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getconsensusblock-v2.mdx
+++ b/reference/ton-getconsensusblock-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getextendedaddressinformation-v2.mdx
+++ b/reference/ton-getextendedaddressinformation-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 

--- a/reference/ton-getmasterchainblocksignatures-v2.mdx
+++ b/reference/ton-getmasterchainblocksignatures-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getmasterchaininfo-v2.mdx
+++ b/reference/ton-getmasterchaininfo-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-getshardblockproof-v2.mdx
+++ b/reference/ton-getshardblockproof-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-gettokendata-v2.mdx
+++ b/reference/ton-gettokendata-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-gettransactions-v2.mdx
+++ b/reference/ton-gettransactions-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: this method is always archive (2 RUs)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+Account transaction history can reach arbitrarily far back, so this method is always billed as archive. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 

--- a/reference/ton-getwalletinformation-v2.mdx
+++ b/reference/ton-getwalletinformation-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 

--- a/reference/ton-jetton-burns-v3.mdx
+++ b/reference/ton-jetton-burns-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-jetton-masters-v3.mdx
+++ b/reference/ton-jetton-masters-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-jetton-transfers-v3.mdx
+++ b/reference/ton-jetton-transfers-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-jetton-wallets-v3.mdx
+++ b/reference/ton-jetton-wallets-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-jsonrpc-v2.mdx
+++ b/reference/ton-jsonrpc-v2.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: follows the wrapped method**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+Requests through the `/jsonRPC` envelope are billed by the method they carry — most are full (1 RU); `getTransactions` is always archive (2 RUs), and block/seqno methods are archive when the requested block is 128 or more seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-lookupblock-v2.mdx
+++ b/reference/ton-lookupblock-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-masterchainblockshards-v3.mdx
+++ b/reference/ton-masterchainblockshards-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-masterchainblockshardstate-v3.mdx
+++ b/reference/ton-masterchainblockshardstate-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-masterchaininfo-v3.mdx
+++ b/reference/ton-masterchaininfo-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-message-v3.mdx
+++ b/reference/ton-message-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-messages-v3.mdx
+++ b/reference/ton-messages-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-metadata-v3.mdx
+++ b/reference/ton-metadata-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-multisig-orders-v3.mdx
+++ b/reference/ton-multisig-orders-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-multisig-wallets-v3.mdx
+++ b/reference/ton-multisig-wallets-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-nft-collections-v3.mdx
+++ b/reference/ton-nft-collections-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-nft-items-v3.mdx
+++ b/reference/ton-nft-items-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-nft-transfers-v3.mdx
+++ b/reference/ton-nft-transfers-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-packaddress-v2.mdx
+++ b/reference/ton-packaddress-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-pendingtraces-v3.mdx
+++ b/reference/ton-pendingtraces-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-pendingtransactions-v3.mdx
+++ b/reference/ton-pendingtransactions-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-rungetmethod-v3.mdx
+++ b/reference/ton-rungetmethod-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-shards-v2.mdx
+++ b/reference/ton-shards-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-topaccountsbybalance-v3.mdx
+++ b/reference/ton-topaccountsbybalance-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-traces-v3.mdx
+++ b/reference/ton-traces-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-transactions-v3.mdx
+++ b/reference/ton-transactions-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-transactionsbymasterchainblock-v3.mdx
+++ b/reference/ton-transactionsbymasterchainblock-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full or archive by block age**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is billed as archive (2 RUs) when the requested block is 128 or more seqno behind the tip, and full (1 RU) otherwise. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-transactionsbymessage-v3.mdx
+++ b/reference/ton-transactionsbymessage-v3.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-trylocateresulttx-v2.mdx
+++ b/reference/ton-trylocateresulttx-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-trylocatesourcetx-v2.mdx
+++ b/reference/ton-trylocatesourcetx-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-trylocatetx-v2.mdx
+++ b/reference/ton-trylocatetx-v2.mdx
@@ -16,10 +16,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-unpackaddress-v2.mdx
+++ b/reference/ton-unpackaddress-v2.mdx
@@ -15,10 +15,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-vesting-v3.mdx
+++ b/reference/ton-vesting-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters

--- a/reference/ton-wallet-v3.mdx
+++ b/reference/ton-wallet-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.  
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
   

--- a/reference/ton-walletstates-v3.mdx
+++ b/reference/ton-walletstates-v3.mdx
@@ -17,10 +17,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 
 <Note>
-**TON pricing is the same for full, archive, v2, v3**
+**TON billing: full (1 RU)**
 
-There's no difference between a full node an archive node in data availability or pricing.
-All data is always available and all node requests are consumed as 1 request unit.
+This method is always billed as full. See [Request units — TON method scope](/docs/request-units#ton-method-scope).
 </Note>
 
 ## Parameters


### PR DESCRIPTION
## What

Every TON reference page carried this callout:

> **TON pricing is the same for full, archive, v2, v3** — all node requests are consumed as 1 request unit.

That stopped being true when archival billing went live on TON Mainnet. The guide-side docs were updated previously (request-units TON method scope, ton-choosing-v2-or-v3, ton-methods), but the reference section — the pages developers actually work from — still said everything bills flat. 58 pages affected, including `getTransactions`, which is now always archive.

## Change

Replace the stale callout with a per-method billing note matching the live classification:

| Note | Pages |
| --- | --- |
| Always archive (2 RUs) | `ton-gettransactions-v2` |
| Archive when the requested block is 128+ seqno behind the tip | the 14 block/seqno method pages |
| Follows the wrapped method | `ton-jsonrpc-v2` (the envelope) |
| Always full (1 RU) | the remaining 41 method pages |
| Full vs archive overview | `getting-started-ton` |

Each note links to [Request units — TON method scope](https://docs.chainstack.com/docs/request-units#ton-method-scope) as the single source of truth for the method lists.

Mechanical note: the reference pages use CRLF line endings — preserved, so the diff is the note swap only (+116/−173 across 58 files).