### PR TITLE
docs(request-units): expand EVM block-age list to ~20 methods after useExtendedMethodsList rollout

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -38,10 +38,6 @@ These EVM methods are billed at 2 RUs regardless of block age:
 
 For per-protocol debug and trace capabilities, see [Debug and trace APIs](/docs/debug-and-trace-apis).
 
-<Note>
-On Cronos, `debug_*` and `trace_*` methods follow the EVM block-age rule instead — within 127 blocks of the tip they bill as full (1 RU); beyond, archive (2 RUs).
-</Note>
-
 ### EVM methods affected by block age
 
 The block-age rule in the [table above](#full-vs-archive-by-protocol) applies to these EVM methods:

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -31,24 +31,43 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 ### Always 2 RUs
 
-All `debug_*` and `trace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block` — are billed at 2 RUs regardless of block age, as they require archive state.
+These EVM methods are billed at 2 RUs regardless of block age:
+
+- All `debug_*` and `trace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block`.
+- `eth_callMany`.
 
 For per-protocol debug and trace capabilities, see [Debug and trace APIs](/docs/debug-and-trace-apis).
+
+<Note>
+On Cronos, `debug_*` and `trace_*` methods follow the EVM block-age rule instead — within 127 blocks of the tip they bill as full (1 RU); beyond, archive (2 RUs).
+</Note>
 
 ### EVM methods affected by block age
 
 The block-age rule in the [table above](#full-vs-archive-by-protocol) applies to these EVM methods:
 
-- `eth_getBalance`
-- `eth_getCode`
-- `eth_getTransactionCount`
-- `eth_getStorageAt`
 - `eth_call`
-- `eth_getProof`
-- `eth_callMany`
 - `eth_createAccessList`
+- `eth_estimateGas`
+- `eth_feeHistory`
+- `eth_getAccount`
+- `eth_getBalance`
+- `eth_getBlockByNumber`
+- `eth_getBlockReceipts`
+- `eth_getBlockTransactionCountByHash`
+- `eth_getBlockTransactionCountByNumber`
+- `eth_getCode`
+- `eth_getLogs`
+- `eth_getProof`
+- `eth_getStorageAt`
+- `eth_getTransactionByBlockNumberAndIndex`
+- `eth_getTransactionCount`
+- `eth_getUncleCountByBlockHash`
+- `eth_getUncleCountByBlockNumber`
+- `eth_newFilter`
+- `eth_simulateV1`
 
-All other EVM methods are billed as full (1 RU) regardless of the block they target.
+For `eth_getLogs` and `eth_newFilter`, the rule is evaluated against the `fromBlock` / `toBlock` range. All other EVM methods are billed as full (1 RU) regardless of the block they target.
 
 ### Solana method scope
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -33,8 +33,8 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 These EVM methods are billed at 2 RUs regardless of block age:
 
-- All `debug_*` and `trace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block`.
-- `eth_callMany`.
+- All `debug_*`, `trace_*`, and `arbtrace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block`.
+- `eth_callMany`
 
 For per-protocol debug and trace capabilities, see [Debug and trace APIs](/docs/debug-and-trace-apis).
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -67,7 +67,9 @@ The block-age rule in the [table above](#full-vs-archive-by-protocol) applies to
 - `eth_newFilter`
 - `eth_simulateV1`
 
-For `eth_getLogs` and `eth_newFilter`, the rule is evaluated against the `fromBlock` / `toBlock` range. All other EVM methods are billed as full (1 RU) regardless of the block they target.
+For `eth_getLogs` and `eth_newFilter`, the block evaluated for billing is `fromBlock` if set, otherwise `toBlock` if set, otherwise `latest`. For example, `eth_getLogs({fromBlock: 1, toBlock: latest})` bills as archive because `fromBlock` is far below the tip — even though the range extends to `latest`.
+
+All other EVM methods are billed as full (1 RU) regardless of the block they target.
 
 ### Solana method scope
 


### PR DESCRIPTION
## Summary

Updates `/docs/request-units` after ilias finished rolling out `useExtendedMethodsList: true` across every Chainstack chainy with the `evm` classifier ([masternodes PRs #5228](https://github.com/chainstack/masternodes/pull/5228), [#5230](https://github.com/chainstack/masternodes/pull/5230), [#5232](https://github.com/chainstack/masternodes/pull/5232), [#5234](https://github.com/chainstack/masternodes/pull/5234), [#5235](https://github.com/chainstack/masternodes/pull/5235), [#5236](https://github.com/chainstack/masternodes/pull/5236)). The legacy 8-method block-age list the doc has been publishing is no longer accurate — production now classifies the full ~20-method extractor set.

## Changes

- **Expanded the EVM block-age method list** from 8 to 20 methods. Source: every method with a `BlockNumber`- or `BlockHash`-typed entry in [`smart-proxy/jsonrpc2/evm/extractor.go`](https://github.com/chainstack/smart-proxy/blob/master/jsonrpc2/evm/extractor.go). New entries include `eth_getLogs`, `eth_getBlockByNumber`, `eth_getBlockReceipts`, `eth_estimateGas`, `eth_feeHistory`, `eth_simulateV1`, and others. Added a note that `eth_getLogs` and `eth_newFilter` evaluate the rule against the `fromBlock` / `toBlock` range.

- **Moved `eth_callMany` from block-age list to "Always 2 RUs."** The method routes through `requestTypeOverrideArchive` in [`smart-proxy/plugin/classifier/type_evm.go:77-79,95`](https://github.com/chainstack/smart-proxy/blob/master/plugin/classifier/type_evm.go#L77-L97) regardless of block age. Per Eugene this is intentional ([YouTrack CORE-11644](https://chainstack.myjetbrains.com/youtrack/issue/CORE-11644/Classify-ethcallMany-as-an-always-archive-method)).

- **Added Cronos debug/trace exception.** Cronos GEE LBs are the only LBs in production with `useBlockNumberForDebugTrace: true` (3 LBs across regions). Per ilias, this flag is functionally required for Cronos only. Effect: `debug_*` and `trace_*` on Cronos within F=127 bill as full (1 RU); everywhere else they're always 2 RUs.

## Verified against

- Survey of every `chainy-gee-*-lb` config in `chainstack/masternodes` confirms `useExtendedMethodsList: true` is now universal across all EVM chains and regions, including testnets.
- `smart-proxy` classifier code at `plugin/classifier/type_evm.go` (`checkArchive`, `checkDT`, `resolveBlockRange`, `requestTypeOverrideArchive`).
- Slack thread `#devex` ([linked here](https://chainstackhq.slack.com/archives/CHVM0Q8CA/p1779453166152939?thread_ts=1777031920.790959)) with Eugene + ilias confirmations.

## Out of scope (separate work)

opBNB picked up `useExtendedMethodsList: true` in ilias's rollout but still has no `forwardFromBlock` set (effective F=0). This widens the IaC-vs-product-policy gap on opBNB but the doc continues to reflect product policy (opBNB in the single-class row). Tracking separately with engineering.

## Test plan

- [x] Internal anchors and outbound links resolve
- [x] Method lists match the smart-proxy extractor map (alphabetized)
- [x] Style guide compliance (sentence case headings, em dashes, oxford commas, list-item bullets don't start with bold)