### PR TITLE
docs(add-ons): convert Warp transactions and MEV protection to node add-ons

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: June 11, 2026" description=" by Ake">
+
+**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) you install per node from the node's **Add-ons** tab. MEV protection installs by default on Ethereum, BNB Smart Chain, Arbitrum, and Base, so existing behavior continues unchanged, and every node that already had Warp or MEV enabled was migrated automatically. Nothing changes for the existing wizard or the public API.
+
+<Button href="/changelog/chainstack-updates-june-11-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: June 2, 2026" description=" by Ake">
 
 **MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) now migrates your project to Chainstack from another RPC provider — QuickNode, Alchemy, or any other — assessing your usage, estimating your savings, and repointing endpoints from inside your AI coding agent.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,7 +8,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: June 11, 2026" description=" by Ake">
 
-**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) you install per node from the node's **Add-ons** tab. MEV protection installs by default on Ethereum, BNB Smart Chain, Arbitrum, and Base, so existing behavior continues unchanged, and every node that already had Warp or MEV enabled was migrated automatically. Nothing changes for the existing wizard or the public API.
+**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) rather than baked-in node toggles. You install and manage them per node from the node's **Add-ons** tab.
 
 <Button href="/changelog/chainstack-updates-june-11-2026">Read more</Button>
 </Update>

--- a/changelog/chainstack-updates-june-11-2026.mdx
+++ b/changelog/chainstack-updates-june-11-2026.mdx
@@ -3,9 +3,6 @@ title: "Chainstack updates: June 11, 2026"
 description: "Warp transactions and MEV protection are now Chainstack node add-ons you install per node from the node's Add-ons tab."
 ---
 
-**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) rather than baked-in node toggles. You install and manage them per node from the node's **Add-ons** tab:
+**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) rather than baked-in node toggles. You install and manage them per node from the node's **Add-ons** tab.
 
-* **Warp transactions** — install it on a Trader or Global node to route transaction submission through bloXroute for faster propagation and earlier block inclusion. Billed separately.
-* **MEV protection** — a free add-on that installs by default on Ethereum, BNB Smart Chain, Arbitrum, and Base, shielding transactions from front-running, sandwich attacks, and other value extraction.
-
-The default-on behavior means nothing breaks across the existing wizard, the public API, or the new node creation flow. Every node that already had Warp or MEV enabled was migrated automatically — no manual re-enabling, no disruption.
+For what each add-on does and how to install or uninstall it, see [Warp transactions](/docs/warp-transactions), [MEV protection](/docs/mev-protection), and [add-ons](/docs/add-ons).

--- a/changelog/chainstack-updates-june-11-2026.mdx
+++ b/changelog/chainstack-updates-june-11-2026.mdx
@@ -1,0 +1,11 @@
+---
+title: "Chainstack updates: June 11, 2026"
+description: "Warp transactions and MEV protection are now Chainstack node add-ons you install per node from the node's Add-ons tab."
+---
+
+**Add-ons**. [Warp transactions](/docs/warp-transactions) and [MEV protection](/docs/mev-protection) are now Chainstack [node add-ons](/docs/add-ons) rather than baked-in node toggles. You install and manage them per node from the node's **Add-ons** tab:
+
+* **Warp transactions** — install it on a Trader or Global node to route transaction submission through bloXroute for faster propagation and earlier block inclusion. Billed separately.
+* **MEV protection** — a free add-on that installs by default on Ethereum, BNB Smart Chain, Arbitrum, and Base, shielding transactions from front-running, sandwich attacks, and other value extraction.
+
+The default-on behavior means nothing breaks across the existing wizard, the public API, or the new node creation flow. Every node that already had Warp or MEV enabled was migrated automatically — no manual re-enabling, no disruption.

--- a/docs.json
+++ b/docs.json
@@ -960,7 +960,6 @@
               "docs/manage-your-networks",
               "docs/manage-your-node",
               "docs/see-statistics",
-              "docs/mev-protection",
               "docs/faucets",
               "docs/rss-feeds"
             ]
@@ -989,6 +988,7 @@
             "group": "Add-ons",
             "pages": [
               "docs/add-ons",
+              "docs/mev-protection",
               "docs/yellowstone-grpc-geyser-plugin",
               "docs/unlimited-node-add-on"
             ]
@@ -3566,6 +3566,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-june-11-2026",
           "changelog/chainstack-updates-june-2-2026",
           "changelog/chainstack-updates-may-28-2026",
           "changelog/chainstack-updates-may-26-2026",

--- a/docs/add-ons.mdx
+++ b/docs/add-ons.mdx
@@ -3,9 +3,28 @@ title: "Chainstack add-ons: marketplace extensions for RPC nodes"
 description: Enhance your Chainstack RPC nodes with add-ons including debug and trace APIs, archive data access, and MEV protection for Ethereum and EVM chains.
 ---
 
-Add-ons are [Marketplace](https://console.chainstack.com/marketplace) items that you can add to your organization and setup.
+Add-ons are [Marketplace](https://console.chainstack.com/marketplace) items that extend your Chainstack nodes with extra capabilities.
 
 Current add-ons:
 
+- [Warp transactions](/docs/warp-transactions) — route transaction submission through bloXroute for faster propagation and earlier block inclusion. Available on Trader and Global nodes. Billed separately.
+- [MEV protection](/docs/mev-protection) — shield transactions from front-running, sandwich attacks, and other value extraction on Ethereum, BNB Smart Chain, Arbitrum, and Base. Free, and installed by default on applicable chains.
 - [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin)
 - [Unlimited Node](/docs/unlimited-node)
+
+## Manage node add-ons
+
+Node add-ons such as Warp transactions and MEV protection attach to a specific node. You manage them on the node's **Add-ons** tab.
+
+<Steps>
+  <Step title="Open the Add-ons tab">
+    On Chainstack, open your node and select the **Add-ons** tab.
+  </Step>
+  <Step title="Install or manage the add-on">
+    Click **Install** next to the add-on (or **Manage** if it's already installed), select a plan, and click **Apply changes**.
+  </Step>
+</Steps>
+
+MEV protection installs by default on applicable chains, so it shows **Manage** out of the box. Warp transactions shows **Install** until you add it.
+
+To remove a node add-on, open it from the **Add-ons** tab, click **Manage** > **Uninstall**, type `delete app` to confirm, and click **Yes, I'm sure**. Uninstalling is irreversible.

--- a/docs/add-ons.mdx
+++ b/docs/add-ons.mdx
@@ -7,8 +7,8 @@ Add-ons are [Marketplace](https://console.chainstack.com/marketplace) items that
 
 Current add-ons:
 
-- [Warp transactions](/docs/warp-transactions) — route transaction submission through bloXroute for faster propagation and earlier block inclusion. Available on Trader and Global nodes. Billed separately.
-- [MEV protection](/docs/mev-protection) — shield transactions from front-running, sandwich attacks, and other value extraction on Ethereum, BNB Smart Chain, Arbitrum, and Base. Free, and installed by default on applicable chains.
+- [Warp transactions](/docs/warp-transactions) — route transaction submission through bloXroute for faster propagation and earlier block inclusion.
+- [MEV protection](/docs/mev-protection) — shield transactions from front-running, sandwich attacks, and other value extraction.
 - [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin)
 - [Unlimited Node](/docs/unlimited-node)
 
@@ -25,6 +25,6 @@ Node add-ons such as Warp transactions and MEV protection attach to a specific n
   </Step>
 </Steps>
 
-MEV protection installs by default on applicable chains, so it shows **Manage** out of the box. Warp transactions shows **Install** until you add it.
+An add-on shows **Install** until you add it, and **Manage** once it's installed.
 
-To remove a node add-on, open it from the **Add-ons** tab, click **Manage** > **Uninstall**, type `delete app` to confirm, and click **Yes, I'm sure**. Uninstalling is irreversible.
+To remove a node add-on, open it from the **Add-ons** tab, click **Manage** > **Uninstall**, then type `delete app` and confirm. You can install it again later from the same tab.

--- a/docs/bnb-trader-nodes.mdx
+++ b/docs/bnb-trader-nodes.mdx
@@ -15,6 +15,8 @@ Chainstack nodes with Warp transactions combine reliable nodes for pre-transacti
 
 All calls go through Chainstack's infrastructure, except for `eth_sendRawTransaction`, which is routed directly to bloXroute.
 
+To enable Warp transactions, install the [Warp transactions](/docs/warp-transactions) add-on on your Trader or Global node's **Add-ons** tab.
+
 ## Sample use case
 
 1. A token liquidity is deployed on BNB Smart Chain.

--- a/docs/ethereum-trader-nodes.mdx
+++ b/docs/ethereum-trader-nodes.mdx
@@ -15,6 +15,8 @@ Chainstack nodes with Warp transactions combine reliable nodes for pre-transacti
 
 All calls go through Chainstack's infrastructure, except for `eth_sendRawTransaction`, which is routed directly to bloXroute.
 
+To enable Warp transactions, install the [Warp transactions](/docs/warp-transactions) add-on on your Trader or Global node's **Add-ons** tab.
+
 ## Sample use case
 
 1. A token liquidity is deployed on Ethereum.

--- a/docs/mev-protection.mdx
+++ b/docs/mev-protection.mdx
@@ -9,6 +9,8 @@ This currently applies to:
 * Arbitrum mainnet
 * Base mainnet
 
+MEV protection is a free Marketplace [add-on](/docs/add-ons) that installs by default on all applicable chains, so your nodes stay protected with no action required. You manage it from your node's **Add-ons** tab.
+
 ### How it works
 
 1. You construct and sign your transaction as usual and send it through our endpoint. This is sent as `eth_sendRawTransaction`.
@@ -33,6 +35,17 @@ and so on.
 * Reduced front-running risk — your transaction isn’t visible in the public mempool, minimizing the chance of adversary trades.
 * Reliable delivery — direct builder routes ensure predictable inclusion.
 
-### Opting out
+### Managing MEV protection
 
-If you prefer the traditional public mempool route, you can disable private routing. Just switch **MEV protection** to off on the node details page.
+To manage or disable MEV protection:
+
+<Steps>
+  <Step title="Open the add-on">
+    On Chainstack, open your node, select the **Add-ons** tab, and click **Manage** next to **MEV protection**.
+  </Step>
+  <Step title="Uninstall">
+    Click **Uninstall**, type `delete app` to confirm, and click **Yes, I'm sure**.
+  </Step>
+</Steps>
+
+Once uninstalled, your transactions route through the public mempool as usual. Uninstalling is irreversible — to enable MEV protection again, install the add-on from the **Add-ons** tab.

--- a/docs/mev-protection.mdx
+++ b/docs/mev-protection.mdx
@@ -9,7 +9,7 @@ This currently applies to:
 * Arbitrum mainnet
 * Base mainnet
 
-MEV protection is a free Marketplace [add-on](/docs/add-ons) that installs by default on all applicable chains, so your nodes stay protected with no action required. You manage it from your node's **Add-ons** tab.
+MEV protection is a Marketplace [add-on](/docs/add-ons) you manage from your node's **Add-ons** tab.
 
 ### How it works
 
@@ -48,4 +48,4 @@ To manage or disable MEV protection:
   </Step>
 </Steps>
 
-Once uninstalled, your transactions route through the public mempool as usual. Uninstalling is irreversible — to enable MEV protection again, install the add-on from the **Add-ons** tab.
+Once uninstalled, your transactions route through the public mempool as usual. You can install MEV protection again from the **Add-ons** tab whenever you need it.

--- a/docs/solana-trader-nodes.mdx
+++ b/docs/solana-trader-nodes.mdx
@@ -17,6 +17,8 @@ See also the [Solana Warp transactions](https://chainstack.com/solana-trader-nod
 
 Note that Warp transactions only work over the HTTP protocol. The WebSocket protocol is not supported.
 
+To enable Warp transactions, install the [Warp transactions](/docs/warp-transactions) add-on on your Trader or Global node's **Add-ons** tab.
+
 ## Overview
 
 Chainstack Solana Trader nodes with Warp transactions offer the following benefits:

--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -19,7 +19,10 @@ For Trader Nodes deployed on the most of public chains, Chainstack supports the 
 
 * Full — a node that stores full blockchain data. However, it has limitations to how many blocks are available for querying.
 * Archive — a node that stores full blockchain data and an archive of historical states, which makes it possible to query any block since the chain genesis.
-  * Warp transactions — nodes dedicated to propagating and landing transaction at the fastest speed possible. See [Warp transactions](/docs/warp-transactions).
+
+## Warp transactions
+
+[Warp transactions](/docs/warp-transactions) propagate and land your transactions at the fastest speed possible. They are now a node [add-on](/docs/add-ons) you install on Trader and Global nodes from the node's **Add-ons** tab, rather than a deployment-time option.
 
 ## Dedicated gateways
 

--- a/docs/warp-transactions.mdx
+++ b/docs/warp-transactions.mdx
@@ -4,7 +4,7 @@ description: "Send Warp transactions through Chainstack Trader Nodes for faster 
 sidebarTitle: Overview
 ---
 
-With the *Warp transactions* setting on, your transactions will be distributed in either through the high-speed transaction relay network if it's an EVM network or to directly to the leader if it's Solana. This will make your transaction be available for the validators to pick up and include in the block much faster than with the regular propagation.
+With the *Warp transactions* add-on installed on your node, your transactions are distributed either through the high-speed transaction relay network if it's an EVM network or directly to the leader if it's Solana. This makes your transaction available for the validators to pick up and include in the block much faster than with the regular propagation.
 
 <Note>
 The Warp transactions feature is available starting from the [paid plans](https://chainstack.com/pricing/).
@@ -44,6 +44,21 @@ The Warp transactions feature is available starting from the [paid plans](https:
 
 Warp transactions (not requests, just the transactions) consumed are billed separately. For details, see [Pricing](https://chainstack.com/pricing/) with the [extra usage](/docs/manage-your-billing#manage-the-extra-usage-setting) setting enabled.
 
+## Enable Warp transactions
+
+Warp transactions is a node [add-on](/docs/add-ons) you install per node on Trader and Global nodes.
+
+<Steps>
+  <Step title="Open the Add-ons tab">
+    On Chainstack, open your Trader or Global node and select the **Add-ons** tab.
+  </Step>
+  <Step title="Install the add-on">
+    Click **Install** next to **Warp transactions**, select the plan, and click **Apply changes**.
+  </Step>
+</Steps>
+
+Once installed, the node shows a **Warp** badge, and `eth_sendRawTransaction` (EVM) or `sendTransaction` (Solana) calls route through bloXroute. To remove it, click **Manage** > **Uninstall**, type `delete app` to confirm, and click **Yes, I'm sure**.
+
 ## Usage
 
 Under the hood, a Warp transaction is a transaction sent to your node with:
@@ -53,6 +68,6 @@ Under the hood, a Warp transaction is a transaction sent to your node with:
 
 For example, if you send your transaction with your MetaMask connected to a Chainstack node, the transaction will be sent using `eth_sendRawTransaction`.
 
-With the *Warp transactions* setting on, only `eth_sendRawTransaction` on EVM networks or `sendTransaction` transactions are consumed as Warp transactions. Other requests to the node are consumed as regular requests.
+With the *Warp transactions* add-on installed, only `eth_sendRawTransaction` on EVM networks or `sendTransaction` transactions are consumed as Warp transactions. Other requests to the node are consumed as regular requests.
 
 For EVMs, see also [Sending Trader node warp transaction with web3.js, ethers.js, web3.py, and ethClient.go](/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo).


### PR DESCRIPTION
## What

Reflects the migration (announced by Anton, Jun 10, 2026) of **Warp transactions** and **MEV protection** from baked-in node toggles to first-class Marketplace **node add-ons**, managed on the node's **Add-ons** tab.

## Changes

- **`docs/add-ons.mdx`** — list Warp transactions + MEV protection; new "Manage node add-ons" section with the install/manage/uninstall flow (incl. the `delete app` confirmation).
- **`docs/mev-protection.mdx`** — note it's a free, default-on add-on; replace the stale "switch off on the node details page" opt-out with the Manage → Uninstall flow.
- **`docs/warp-transactions.mdx`** — reframe "setting on" → "add-on installed"; add an "Enable Warp transactions" section. Pricing stays link-based (no hardcoded per-tx figure).
- **`docs/trader-node.mdx`** — drop the malformed "Warp = mode" bullet; add a short Warp-as-add-on section.
- **`docs/ethereum-/bnb-/solana-trader-nodes.mdx`** — one-line pointer each to install the add-on (linked, not duplicated).
- **`docs.json`** — move `docs/mev-protection` into the **Add-ons** nav group.
- **Changelog** — new Jun 11, 2026 entry.

## Notes / open questions

- **Naming:** kept sentence case (`Warp transactions`, `MEV protection`) per the dev-portal style guide. The console ships `MEV Protection` (title case) and Eugene asked for `Warp Transactions` in the announcement thread — docs intentionally stay sentence case.
- **Warp nav:** left `warp-transactions` in its existing **Advanced APIs → Warp transactions** cluster rather than duplicating it into the Add-ons group (avoids ambiguous sidebar/breadcrumbs). MEV now sits under Add-ons; Warp under Advanced APIs. Happy to move the Warp cluster if we want them as siblings.
- **`default-on` nuance:** documented as "installs by default on applicable chains" without claiming it's unconditional — the announcement says it's quota-driven. Worth confirming there's no tier where it doesn't auto-install.