### PR TITLE
docs(protocols): remove Botanix (network winding down Jul 9, 2026)

### DIFF
--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -25,7 +25,6 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Bitlayer | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-bitlayer/#request) |
 | Blast | Elastic | Full, Archive | - | - | Yes | - |
 | BNB Smart Chain | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Botanix | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-botanix/#request) |
 | Cardano | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-cardano/#request) |
 | Celestia | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Celo | Elastic, Dedicated | Full, Archive | Full | - | Yes | [Deploy through platform](https://console.chainstack.com) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -2554,24 +2554,6 @@
       "testnets": [],
       "additional_notes": "Dedicated nodes only"
     },
-    "Botanix": {
-      "protocol_name": "Botanix",
-      "supported_modes": [
-        "N/A"
-      ],
-      "full_mode_query_limit": "N/A",
-      "archive_mode_available": false,
-      "debug_trace_available": false,
-      "warp_transactions_available": false,
-      "dedicated_node_availability": "Contact us",
-      "mainnet": {
-        "network_name": "N/A",
-        "faucet_url": "N/A",
-        "locations": []
-      },
-      "testnets": [],
-      "additional_notes": "Dedicated nodes only"
-    },
     "Cardano": {
       "protocol_name": "Cardano",
       "supported_modes": [


### PR DESCRIPTION
## What

[Botanix Labs announced](https://x.com/botanix/status/2064420116578590941) the wind-down of the Botanix network (Spiderchain Bitcoin L2) on Jun 9, 2026. Users must withdraw all assets by **Jul 9, 2026**, after which the federation sweeps remaining BTC and anything left is unrecoverable.

Chainstack only ever offered Botanix as request-based dedicated nodes ("Contact us" / "Request deployment"). This removes it so we stop advertising deployment for a chain that's being decommissioned.

## Changes

- **`node-options-master-list.json`** — remove the Botanix entry (source of truth).
- **`docs/protocols-networks.mdx`** — remove the regenerated Botanix table row.

Botanix had no locations, so it was not present in `nodes-clouds-regions-and-locations.mdx`, and there are no Botanix tutorials, reference pages, or changelog entries to clean up.

## Out of scope / follow-up

- The marketing landing `chainstack.com/build-better-with-botanix/` (separate repo) should also be retired so the old "request deployment" link doesn't dangle.
- Any existing Botanix dedicated-node customers should be handled with infra/sales around the Jul 9 withdrawal deadline.