### PR TITLE
docs(aptos,starknet): document full vs archive billing

### DIFF
--- a/docs/aptos-methods.mdx
+++ b/docs/aptos-methods.mdx
@@ -4,7 +4,7 @@ description: Complete reference of supported Aptos API methods on Chainstack nod
 ---
 
 <Note>
-For how these methods are billed (full vs archive), see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope). In short: most endpoints are full (1 RU); `/v1/accounts/{address}/transactions` is always archive (2 RUs); block/version endpoints are archive when the requested block height or ledger version is 128 or more behind the tip.
+For how these methods are billed (full vs archive), see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope). In short: most endpoints are full (1 RU); `/v1/accounts/{address}/transactions` is always archive (2 RUs); block-height endpoints are archive when the requested height is more than 128 behind the tip, and ledger-version endpoints when the requested version is more than 256 behind.
 </Note>
 
 | Method                                                         | Availability | Comment |

--- a/docs/aptos-methods.mdx
+++ b/docs/aptos-methods.mdx
@@ -3,6 +3,10 @@ title: "Aptos methods"
 description: Complete reference of supported Aptos API methods on Chainstack nodes, including accounts, blocks, events, transactions, and view function calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope). In short: most endpoints are full (1 RU); `/v1/accounts/{address}/transactions` is always archive (2 RUs); block/version endpoints are archive when the requested block height or ledger version is 128 or more behind the tip.
+</Note>
+
 | Method                                                         | Availability | Comment |
 | -------------------------------------------------------------- | ------------ | ------- |
 | /v1                                                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -26,7 +26,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |
-| Starknet | Most requests are **full**. Trace methods are always **archive**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
+| Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Bitcoin, Sui, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
@@ -165,7 +165,7 @@ A request that omits the block or version parameter, or targets one within the t
 
 Starknet requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in three cases.
 
-**Always archive** — these trace methods are billed as archive (2 RUs) regardless of block age, the same as the EVM `debug_*`/`trace_*` rule:
+**Always 2 RUs** — these trace methods are billed at the trace rate (2 RUs) regardless of block age, the same as the EVM `debug_*`/`trace_*` rule:
 
 - `starknet_traceBlockTransactions`
 - `starknet_traceTransaction`

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -163,7 +163,7 @@ A request that omits the block or version parameter, or targets one within the t
 
 ### Starknet method scope
 
-Starknet requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in three cases.
+Starknet requests are billed as full (1 RU) by default. Three cases are billed at 2 RUs.
 
 **Always 2 RUs** — these trace methods are billed at the trace rate (2 RUs) regardless of block age, the same as the EVM `debug_*`/`trace_*` rule:
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -25,7 +25,9 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, Moonbeam, MegaETH, Ronin, Fantom, zkSync Era, Polygon zkEVM, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested block is 128 or more seqno behind the tip. See [TON method scope](#ton-method-scope) below. |
-| Bitcoin, Sui, Aptos, Starknet, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
+| Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block/version methods are **archive** when the requested block height or ledger version is 128 or more behind the tip. See [Aptos method scope](#aptos-method-scope) below. |
+| Starknet | Most requests are **full**. Block-scoped methods are **archive** when the requested block is 128 or more behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
+| Bitcoin, Sui, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
 
@@ -125,6 +127,50 @@ These methods return an account's transaction history keyed by address (and logi
 - v3: `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
 
 The threshold is evaluated against the latest seqno of the workchain referenced by the request — the masterchain by default. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
+
+### Aptos method scope
+
+Aptos requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in two cases.
+
+**Always archive**, regardless of parameters:
+
+- `/v1/accounts/{address}/transactions`
+
+This endpoint returns an account's transaction history keyed by address, not by block or version. The depth of the result cannot be determined before the request is served, so it is always classified as archive.
+
+**Archive only when targeting a historical block or version** — these endpoints take a block height or ledger version parameter and are billed as archive (2 RUs) when the requested block height or version is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block/version, or no such parameter):
+
+- `/v1/blocks/by_height/{block_height}`
+- `/v1/blocks/by_version/{version}`
+- `/v1/transactions`
+- `/v1/transactions/by_version/{txn_version}`
+- `/v1/transactions/by_hash/{txn_hash}`
+- `/v1/accounts/{address}/resources`
+- `/v1/accounts/{address}/resource/{resource_type}`
+- `/v1/tables/{table_handle}/item`
+- `/v1/tables/{table_handle}/raw_item`
+- `/v1/view`
+
+All other Aptos endpoints are billed as full (1 RU).
+
+### Starknet method scope
+
+Starknet requests are billed as full (1 RU) by default. These block-scoped methods are billed as archive (2 RUs) when the requested block is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block, or a `latest`/`pending` block tag):
+
+- `starknet_getBlockWithTxHashes`
+- `starknet_getBlockWithTxs`
+- `starknet_getBlockWithReceipts`
+- `starknet_getStateUpdate`
+- `starknet_getBlockTransactionCount`
+- `starknet_getTransactionByBlockIdAndIndex`
+- `starknet_getClass`
+- `starknet_getNonce`
+- `starknet_getClassHashAt`
+- `starknet_getClassAt`
+- `starknet_call`
+- `starknet_getStorageAt`
+
+All other Starknet methods are billed as full (1 RU) regardless of the block they target.
 
 ## HTTP requests vs WebSocket subscriptions
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -24,9 +24,9 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | --- | --- |
 | Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, Moonbeam, MegaETH, Ronin, Fantom, zkSync Era, Polygon zkEVM, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
-| TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested block is 128 or more seqno behind the tip. See [TON method scope](#ton-method-scope) below. |
-| Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block/version methods are **archive** when the requested block height or ledger version is 128 or more behind the tip. See [Aptos method scope](#aptos-method-scope) below. |
-| Starknet | Most requests are **full**. Block-scoped methods are **archive** when the requested block is 128 or more behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
+| TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
+| Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |
+| Starknet | Most requests are **full**. Trace methods are always **archive**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Bitcoin, Sui, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Method rules
@@ -121,7 +121,7 @@ TON requests are billed as full (1 RU) by default. Archive billing (2 RUs) appli
 
 These methods return an account's transaction history keyed by address (and logical time), not by block. The depth of the result cannot be determined before the request is served, so they are always classified as archive.
 
-**Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block, or no block parameter):
+**Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or no block parameter):
 
 - v2: `getBlockTransactions`, `getBlockTransactionsExt`, `getBlockHeader`, `lookupBlock`, `shards` / `getShards`, `getShardAccountCell`, `getShardBlockProof`, `getMasterchainBlockSignatures`, `getAddressState`, `getConfigParam`, `getConfigAll`
 - v3: `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
@@ -130,7 +130,12 @@ The threshold is evaluated against the latest seqno of the workchain referenced 
 
 ### Aptos method scope
 
-Aptos requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in two cases.
+Aptos requests are billed as full (1 RU) by default. Aptos sequences data two ways, and the archive threshold differs by which an endpoint takes:
+
+- **Ledger version** — a global counter that increments on every transaction, including the system transactions Aptos adds to each block. The threshold is **256** versions.
+- **Block height** — one increment per block. Because each block spans several versions, the threshold is **128** blocks — roughly the same depth in time as 256 versions.
+
+Archive billing (2 RUs) applies in three cases.
 
 **Always archive**, regardless of parameters:
 
@@ -138,24 +143,34 @@ Aptos requests are billed as full (1 RU) by default. Archive billing (2 RUs) app
 
 This endpoint returns an account's transaction history keyed by address, not by block or version. The depth of the result cannot be determined before the request is served, so it is always classified as archive.
 
-**Archive only when targeting a historical block or version** — these endpoints take a block height or ledger version parameter and are billed as archive (2 RUs) when the requested block height or version is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block/version, or no such parameter):
+**Archive when targeting a historical block height** — billed as archive (2 RUs) when the requested height is more than 128 behind the chain tip, and full (1 RU) otherwise:
 
 - `/v1/blocks/by_height/{block_height}`
-- `/v1/blocks/by_version/{version}`
-- `/v1/transactions`
-- `/v1/transactions/by_version/{txn_version}`
-- `/v1/transactions/by_hash/{txn_hash}`
-- `/v1/accounts/{address}/resources`
-- `/v1/accounts/{address}/resource/{resource_type}`
-- `/v1/tables/{table_handle}/item`
-- `/v1/tables/{table_handle}/raw_item`
-- `/v1/view`
 
-All other Aptos endpoints are billed as full (1 RU).
+**Archive when targeting a historical ledger version** — billed as archive (2 RUs) when the requested version is more than 256 behind the latest version, and full (1 RU) otherwise:
+
+- `/v1/blocks/by_version/{version}`
+- `/v1/transactions` — the `start` version
+- `/v1/transactions/by_version/{txn_version}`
+- `/v1/transactions/by_hash/{txn_hash}` — resolved to its ledger version
+- `/v1/accounts/{address}/resources` — the `ledger_version` parameter
+- `/v1/accounts/{address}/resource/{resource_type}` — the `ledger_version` parameter
+- `/v1/tables/{table_handle}/item` — the `ledger_version` parameter
+- `/v1/tables/{table_handle}/raw_item` — the `ledger_version` parameter
+- `/v1/view` — the `ledger_version` parameter
+
+A request that omits the block or version parameter, or targets one within the threshold, is billed as full (1 RU). All other Aptos endpoints are billed as full (1 RU).
 
 ### Starknet method scope
 
-Starknet requests are billed as full (1 RU) by default. These block-scoped methods are billed as archive (2 RUs) when the requested block is 128 or more behind the chain tip, and full (1 RU) otherwise (recent block, or a `latest`/`pending` block tag):
+Starknet requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in three cases.
+
+**Always archive** — these trace methods are billed as archive (2 RUs) regardless of block age, the same as the EVM `debug_*`/`trace_*` rule:
+
+- `starknet_traceBlockTransactions`
+- `starknet_traceTransaction`
+
+**Archive when targeting a historical block** — these block-scoped methods are billed as archive (2 RUs) when the requested block is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or a `latest`/`pending` block tag):
 
 - `starknet_getBlockWithTxHashes`
 - `starknet_getBlockWithTxs`
@@ -169,6 +184,8 @@ Starknet requests are billed as full (1 RU) by default. These block-scoped metho
 - `starknet_getClassAt`
 - `starknet_call`
 - `starknet_getStorageAt`
+
+**Archive when the event range is historical** — `starknet_getEvents` is billed as archive (2 RUs) when its `from_block` or `to_block` is more than 128 behind the tip, and full (1 RU) otherwise. This parallels the `eth_getLogs` rule in the EVM section.
 
 All other Starknet methods are billed as full (1 RU) regardless of the block they target.
 

--- a/docs/starknet-methods.mdx
+++ b/docs/starknet-methods.mdx
@@ -5,6 +5,10 @@ description: "Complete Starknet RPC API methods reference. Includes starknet_ an
 
 See also [interactive Starknet API call examples](/reference/getting-started-starknet).
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` are archive (2 RUs) when the requested block is 128 or more behind the tip.
+</Note>
+
 | Method                                    | Availability | Comment |
 | ----------------------------------------- | ------------ | ------- |
 | starknet\_specVersion                     | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/starknet-methods.mdx
+++ b/docs/starknet-methods.mdx
@@ -6,7 +6,7 @@ description: "Complete Starknet RPC API methods reference. Includes starknet_ an
 See also [interactive Starknet API call examples](/reference/getting-started-starknet).
 
 <Note>
-For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); trace methods (`starknet_traceBlockTransactions`, `starknet_traceTransaction`) are always archive (2 RUs); block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` — and `starknet_getEvents` by its block range — are archive when the requested block is more than 128 behind the tip.
+For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); trace methods (`starknet_traceBlockTransactions`, `starknet_traceTransaction`) are always 2 RUs; block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` — and `starknet_getEvents` by its block range — are archive when the requested block is more than 128 behind the tip.
 </Note>
 
 | Method                                    | Availability | Comment |

--- a/docs/starknet-methods.mdx
+++ b/docs/starknet-methods.mdx
@@ -6,7 +6,7 @@ description: "Complete Starknet RPC API methods reference. Includes starknet_ an
 See also [interactive Starknet API call examples](/reference/getting-started-starknet).
 
 <Note>
-For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` are archive (2 RUs) when the requested block is 128 or more behind the tip.
+For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); trace methods (`starknet_traceBlockTransactions`, `starknet_traceTransaction`) are always archive (2 RUs); block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` — and `starknet_getEvents` by its block range — are archive when the requested block is more than 128 behind the tip.
 </Note>
 
 | Method                                    | Availability | Comment |


### PR DESCRIPTION
## What

Documents full vs archive RU billing for **Aptos** and **Starknet**, mirroring the TON classifier (#403). Both protocols were previously listed as \"no archive split — every request full\"; their traffic is now classified for billing.

### Aptos
- `/v1/accounts/{address}/transactions` — **always archive** (account history keyed by address; depth unknown before the request is served).
- Block/version endpoints (`/v1/blocks/by_height/*`, `/v1/blocks/by_version/*`, `/v1/transactions*`, `/v1/accounts/{address}/resource*`, `/v1/tables/*`, `/v1/view`) — **archive** when the requested block height or ledger version is 128 or more behind the tip, **full** otherwise.
- All other endpoints — **full**.

### Starknet
- Block-scoped methods (`starknet_getBlockWith*`, `starknet_getStateUpdate`, `starknet_call`, `starknet_getStorageAt`, `starknet_getNonce`, `starknet_getClass*`, `starknet_getBlockTransactionCount`, `starknet_getTransactionByBlockIdAndIndex`) — **archive** when the requested block is 128 or more behind the tip, **full** otherwise.
- All other methods — **full**.

## Changes
- `docs/request-units.mdx` — moved Aptos and Starknet out of the flat \"no archive split\" row, added per-protocol rows and \"Aptos method scope\" / \"Starknet method scope\" sections.
- `docs/aptos-methods.mdx`, `docs/starknet-methods.mdx` — added a billing note linking to the method scope.

## Testing
- `docs.json` valid; `mint broken-links` passes with no broken links (new anchors resolve).

> Note: like the TON change (#403), this ships without a changelog entry. Happy to add a release note if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)