### PR TITLE
docs: backfill billing references and tidy request-units structure

### DIFF
--- a/docs/aptos-methods.mdx
+++ b/docs/aptos-methods.mdx
@@ -3,9 +3,7 @@ title: "Aptos methods"
 description: Complete reference of supported Aptos API methods on Chainstack nodes, including accounts, blocks, events, transactions, and view function calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope). In short: most endpoints are full (1 RU); `/v1/accounts/{address}/transactions` is always archive (2 RUs); block-height endpoints are archive when the requested height is more than 128 behind the tip, and ledger-version endpoints when the requested version is more than 256 behind.
-</Note>
+For full vs archive billing, see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope).
 
 | Method                                                         | Availability | Comment |
 | -------------------------------------------------------------- | ------------ | ------- |

--- a/docs/aptos-methods.mdx
+++ b/docs/aptos-methods.mdx
@@ -3,7 +3,7 @@ title: "Aptos methods"
 description: Complete reference of supported Aptos API methods on Chainstack nodes, including accounts, blocks, events, transactions, and view function calls.
 ---
 
-For full vs archive billing, see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which Aptos methods are full vs archive, see [Request units — Aptos method scope](/docs/request-units#aptos-method-scope).
 
 | Method                                                         | Availability | Comment |
 | -------------------------------------------------------------- | ------------ | ------- |

--- a/docs/arbitrum-methods.mdx
+++ b/docs/arbitrum-methods.mdx
@@ -3,7 +3,7 @@ title: "Arbitrum methods"
 description: Complete reference of supported Arbitrum JSON-RPC methods on Chainstack, including method availability, debug, and trace API support.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Arbitrum API call examples](/reference/arbitrum-getting-started).
 

--- a/docs/arbitrum-methods.mdx
+++ b/docs/arbitrum-methods.mdx
@@ -3,6 +3,10 @@ title: "Arbitrum methods"
 description: Complete reference of supported Arbitrum JSON-RPC methods on Chainstack, including method availability, debug, and trace API support.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Arbitrum API call examples](/reference/arbitrum-getting-started).
 
 | Method                                   | Availability | Comment |

--- a/docs/arbitrum-methods.mdx
+++ b/docs/arbitrum-methods.mdx
@@ -3,9 +3,7 @@ title: "Arbitrum methods"
 description: Complete reference of supported Arbitrum JSON-RPC methods on Chainstack, including method availability, debug, and trace API support.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Arbitrum API call examples](/reference/arbitrum-getting-started).
 

--- a/docs/aurora-methods.mdx
+++ b/docs/aurora-methods.mdx
@@ -3,7 +3,7 @@ title: "Aurora methods"
 description: Complete reference of supported Aurora JSON-RPC methods available on Chainstack nodes, covering eth, net, and web3 namespace calls.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/aurora-methods.mdx
+++ b/docs/aurora-methods.mdx
@@ -3,6 +3,10 @@ title: "Aurora methods"
 description: Complete reference of supported Aurora JSON-RPC methods available on Chainstack nodes, covering eth, net, and web3 namespace calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/aurora-methods.mdx
+++ b/docs/aurora-methods.mdx
@@ -3,9 +3,7 @@ title: "Aurora methods"
 description: Complete reference of supported Aurora JSON-RPC methods available on Chainstack nodes, covering eth, net, and web3 namespace calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/avalanche-methods.mdx
+++ b/docs/avalanche-methods.mdx
@@ -3,7 +3,7 @@ title: "Avalanche methods"
 description: Complete reference of supported Avalanche C-Chain and P-Chain JSON-RPC methods on Chainstack, including method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Avalanche API call examples](/reference/avalanche-getting-started).
 

--- a/docs/avalanche-methods.mdx
+++ b/docs/avalanche-methods.mdx
@@ -3,6 +3,10 @@ title: "Avalanche methods"
 description: Complete reference of supported Avalanche C-Chain and P-Chain JSON-RPC methods on Chainstack, including method availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Avalanche API call examples](/reference/avalanche-getting-started).
 
 ## Contract chain (C-Chain)

--- a/docs/avalanche-methods.mdx
+++ b/docs/avalanche-methods.mdx
@@ -3,9 +3,7 @@ title: "Avalanche methods"
 description: Complete reference of supported Avalanche C-Chain and P-Chain JSON-RPC methods on Chainstack, including method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Avalanche API call examples](/reference/avalanche-getting-started).
 

--- a/docs/base-methods.mdx
+++ b/docs/base-methods.mdx
@@ -3,6 +3,10 @@ title: "Base methods"
 description: Complete reference of supported Base JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Base API call examples](/reference/base-api-reference).
 
 | Method                                   | Availability | Comment               |

--- a/docs/base-methods.mdx
+++ b/docs/base-methods.mdx
@@ -3,9 +3,7 @@ title: "Base methods"
 description: Complete reference of supported Base JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Base API call examples](/reference/base-api-reference).
 

--- a/docs/base-methods.mdx
+++ b/docs/base-methods.mdx
@@ -3,7 +3,7 @@ title: "Base methods"
 description: Complete reference of supported Base JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Base API call examples](/reference/base-api-reference).
 

--- a/docs/bitcoin-methods.mdx
+++ b/docs/bitcoin-methods.mdx
@@ -3,7 +3,7 @@ title: "Bitcoin methods"
 description: Complete reference of supported Bitcoin JSON-RPC methods on Chainstack nodes, covering blockchain queries, raw transactions, and network information.
 ---
 
-All Bitcoin methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
+Our pricing is simple: 1 RU per request. Bitcoin has no archive class — see [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 <Note>
   On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.

--- a/docs/bitcoin-methods.mdx
+++ b/docs/bitcoin-methods.mdx
@@ -4,6 +4,10 @@ description: Complete reference of supported Bitcoin JSON-RPC methods on Chainst
 ---
 
 <Note>
+For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All Bitcoin methods are billed as full (1 RU); there is no archive split.
+</Note>
+
+<Note>
   On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.
 
   Historical address queries (transaction history, balance at a past block) need an indexer like [electrs](https://github.com/Blockstream/electrs) — available as a [Bitcoin dedicated node customization](/docs/features-availability-across-subscription-plans#node-customization). [Contact us](https://chainstack.com/contact/) to enable it.

--- a/docs/bitcoin-methods.mdx
+++ b/docs/bitcoin-methods.mdx
@@ -3,9 +3,7 @@ title: "Bitcoin methods"
 description: Complete reference of supported Bitcoin JSON-RPC methods on Chainstack nodes, covering blockchain queries, raw transactions, and network information.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All Bitcoin methods are billed as full (1 RU); there is no archive split.
-</Note>
+All Bitcoin methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 <Note>
   On smart-contract-enabled chains, a Full node keeps recent state; an Archive node adds all historical state from genesis. Bitcoin has no per-block historical state — chain state is the UTXO set, derived from the chain itself — so there is no separate Archive class. Chainstack Bitcoin nodes are non-pruned with `txindex` enabled: every block and every transaction from genesis is queryable. Full does not mean pruned.

--- a/docs/blast-methods.mdx
+++ b/docs/blast-methods.mdx
@@ -3,6 +3,9 @@ title: "Blast methods"
 description: Complete reference of supported Blast L2 JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and net namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/blast-methods.mdx
+++ b/docs/blast-methods.mdx
@@ -3,7 +3,7 @@ title: "Blast methods"
 description: Complete reference of supported Blast L2 JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and net namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/blast-methods.mdx
+++ b/docs/blast-methods.mdx
@@ -3,9 +3,7 @@ title: "Blast methods"
 description: Complete reference of supported Blast L2 JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and net namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/bnb-smart-chain-methods.mdx
+++ b/docs/bnb-smart-chain-methods.mdx
@@ -3,6 +3,10 @@ title: "BNB Smart Chain methods"
 description: Complete reference of supported BNB Smart Chain JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive BNB Smart Chain API call examples](/reference/getting-started-bnb-chain).
 
 <Warning>

--- a/docs/bnb-smart-chain-methods.mdx
+++ b/docs/bnb-smart-chain-methods.mdx
@@ -3,9 +3,7 @@ title: "BNB Smart Chain methods"
 description: Complete reference of supported BNB Smart Chain JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive BNB Smart Chain API call examples](/reference/getting-started-bnb-chain).
 

--- a/docs/bnb-smart-chain-methods.mdx
+++ b/docs/bnb-smart-chain-methods.mdx
@@ -3,7 +3,7 @@ title: "BNB Smart Chain methods"
 description: Complete reference of supported BNB Smart Chain JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive BNB Smart Chain API call examples](/reference/getting-started-bnb-chain).
 

--- a/docs/celo-methods.mdx
+++ b/docs/celo-methods.mdx
@@ -3,7 +3,7 @@ title: "Celo methods"
 description: Complete reference of supported Celo JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and web3 namespace availability for each call.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/celo-methods.mdx
+++ b/docs/celo-methods.mdx
@@ -3,6 +3,10 @@ title: "Celo methods"
 description: Complete reference of supported Celo JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and web3 namespace availability for each call.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/celo-methods.mdx
+++ b/docs/celo-methods.mdx
@@ -3,9 +3,7 @@ title: "Celo methods"
 description: Complete reference of supported Celo JSON-RPC methods on Chainstack nodes, including eth, debug, trace, and web3 namespace availability for each call.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/cronos-methods.mdx
+++ b/docs/cronos-methods.mdx
@@ -2,6 +2,11 @@
 title: "Cronos methods"
 description: Complete reference of supported Cronos JSON-RPC methods on Chainstack, including method availability for eth, net, and web3 namespace calls.
 ---
+
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Cronos API call examples](/reference/getting-started-cronos).
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/cronos-methods.mdx
+++ b/docs/cronos-methods.mdx
@@ -3,9 +3,7 @@ title: "Cronos methods"
 description: Complete reference of supported Cronos JSON-RPC methods on Chainstack, including method availability for eth, net, and web3 namespace calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Cronos API call examples](/reference/getting-started-cronos).
 | Method                                   | Availability | Comment |

--- a/docs/cronos-methods.mdx
+++ b/docs/cronos-methods.mdx
@@ -3,7 +3,7 @@ title: "Cronos methods"
 description: Complete reference of supported Cronos JSON-RPC methods on Chainstack, including method availability for eth, net, and web3 namespace calls.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Cronos API call examples](/reference/getting-started-cronos).
 | Method                                   | Availability | Comment |

--- a/docs/ethereum-methods.mdx
+++ b/docs/ethereum-methods.mdx
@@ -3,6 +3,10 @@ title: "Ethereum methods"
 description: Complete reference of supported Ethereum JSON-RPC methods on Chainstack, including eth, debug, trace, engine, and web3 namespace availability.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [Interactive Ethereum API call examples](/reference/ethereum-getting-started).
 
 ## Execution layer

--- a/docs/ethereum-methods.mdx
+++ b/docs/ethereum-methods.mdx
@@ -3,9 +3,7 @@ title: "Ethereum methods"
 description: Complete reference of supported Ethereum JSON-RPC methods on Chainstack, including eth, debug, trace, engine, and web3 namespace availability.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [Interactive Ethereum API call examples](/reference/ethereum-getting-started).
 

--- a/docs/ethereum-methods.mdx
+++ b/docs/ethereum-methods.mdx
@@ -3,7 +3,7 @@ title: "Ethereum methods"
 description: Complete reference of supported Ethereum JSON-RPC methods on Chainstack, including eth, debug, trace, engine, and web3 namespace availability.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [Interactive Ethereum API call examples](/reference/ethereum-getting-started).
 

--- a/docs/fantom-methods.mdx
+++ b/docs/fantom-methods.mdx
@@ -3,7 +3,7 @@ title: "Fantom methods"
 description: Complete reference of supported Fantom JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Fantom API call examples](/reference/getting-started-fantom).
 

--- a/docs/fantom-methods.mdx
+++ b/docs/fantom-methods.mdx
@@ -3,9 +3,7 @@ title: "Fantom methods"
 description: Complete reference of supported Fantom JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Fantom API call examples](/reference/getting-started-fantom).
 

--- a/docs/fantom-methods.mdx
+++ b/docs/fantom-methods.mdx
@@ -3,6 +3,10 @@ title: "Fantom methods"
 description: Complete reference of supported Fantom JSON-RPC methods on Chainstack, including eth, debug, trace, and net namespace method availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Fantom API call examples](/reference/getting-started-fantom).
 
 | Method                                   | Availability | Comment |

--- a/docs/harmony-methods.mdx
+++ b/docs/harmony-methods.mdx
@@ -3,6 +3,10 @@ title: "Harmony methods"
 description: Complete reference of supported Harmony JSON-RPC methods on Chainstack nodes, covering hmy, hmyv2, eth, net, and web3 namespace calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All Harmony methods are billed as full (1 RU); there is no archive split.
+</Note>
+
 | Method                                          | Availability | Comment |
 | ----------------------------------------------- | ------------ | ------- |
 | hmy\_getBalanceByBlockNumber                    | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/harmony-methods.mdx
+++ b/docs/harmony-methods.mdx
@@ -3,9 +3,7 @@ title: "Harmony methods"
 description: Complete reference of supported Harmony JSON-RPC methods on Chainstack nodes, covering hmy, hmyv2, eth, net, and web3 namespace calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All Harmony methods are billed as full (1 RU); there is no archive split.
-</Note>
+All Harmony methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 | Method                                          | Availability | Comment |
 | ----------------------------------------------- | ------------ | ------- |

--- a/docs/harmony-methods.mdx
+++ b/docs/harmony-methods.mdx
@@ -3,7 +3,7 @@ title: "Harmony methods"
 description: Complete reference of supported Harmony JSON-RPC methods on Chainstack nodes, covering hmy, hmyv2, eth, net, and web3 namespace calls.
 ---
 
-All Harmony methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
+Our pricing is simple: 1 RU per request. Harmony has no archive split — see [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 | Method                                          | Availability | Comment |
 | ----------------------------------------------- | ------------ | ------- |

--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -3,7 +3,7 @@ title: "Hyperliquid methods"
 description: Complete reference of supported Hyperliquid EVM JSON-RPC methods on Chainstack, including eth, net, and web3 namespace method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 <Note>
 Methods marked as "Hyperliquid public RPC" in the table below are proprietary to Hyperliquid DEX and have not been open sourced. These methods are currently only available on the public Hyperliquid infrastructure.

--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -3,9 +3,7 @@ title: "Hyperliquid methods"
 description: Complete reference of supported Hyperliquid EVM JSON-RPC methods on Chainstack, including eth, net, and web3 namespace method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 <Note>
 Methods marked as "Hyperliquid public RPC" in the table below are proprietary to Hyperliquid DEX and have not been open sourced. These methods are currently only available on the public Hyperliquid infrastructure.

--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -4,6 +4,10 @@ description: Complete reference of supported Hyperliquid EVM JSON-RPC methods on
 ---
 
 <Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
+<Note>
 Methods marked as "Hyperliquid public RPC" in the table below are proprietary to Hyperliquid DEX and have not been open sourced. These methods are currently only available on the public Hyperliquid infrastructure.
 
 If you receive a response similar to `Failed to deserialize the JSON body into the target type`, you need to switch to the Hyperliquid Public RPC to use these methods.

--- a/docs/kaia-methods.mdx
+++ b/docs/kaia-methods.mdx
@@ -3,7 +3,7 @@ title: "Kaia methods"
 description: Complete reference of supported Kaia JSON-RPC methods on Chainstack nodes, including kaia, eth, debug, and governance namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                       | Availability | Comment |
 | -------------------------------------------- | ------------ | ------- |

--- a/docs/kaia-methods.mdx
+++ b/docs/kaia-methods.mdx
@@ -3,6 +3,10 @@ title: "Kaia methods"
 description: Complete reference of supported Kaia JSON-RPC methods on Chainstack nodes, including kaia, eth, debug, and governance namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                       | Availability | Comment |
 | -------------------------------------------- | ------------ | ------- |
 | eth\_accounts                                | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/kaia-methods.mdx
+++ b/docs/kaia-methods.mdx
@@ -3,9 +3,7 @@ title: "Kaia methods"
 description: Complete reference of supported Kaia JSON-RPC methods on Chainstack nodes, including kaia, eth, debug, and governance namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                       | Availability | Comment |
 | -------------------------------------------- | ------------ | ------- |

--- a/docs/megaeth-methods.mdx
+++ b/docs/megaeth-methods.mdx
@@ -3,6 +3,10 @@ title: "MegaETH methods"
 description: Complete reference of supported MegaETH JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability                                              | Comment                       |
 | ---------------------------------------- | --------------------------------------------------------- | ----------------------------- |
 | eth\_accounts                            | <Icon icon="square-check" iconType="solid" />             |                               |

--- a/docs/megaeth-methods.mdx
+++ b/docs/megaeth-methods.mdx
@@ -3,9 +3,7 @@ title: "MegaETH methods"
 description: Complete reference of supported MegaETH JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability                                              | Comment                       |
 | ---------------------------------------- | --------------------------------------------------------- | ----------------------------- |

--- a/docs/megaeth-methods.mdx
+++ b/docs/megaeth-methods.mdx
@@ -3,7 +3,7 @@ title: "MegaETH methods"
 description: Complete reference of supported MegaETH JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability                                              | Comment                       |
 | ---------------------------------------- | --------------------------------------------------------- | ----------------------------- |

--- a/docs/moonbeam-methods.mdx
+++ b/docs/moonbeam-methods.mdx
@@ -3,9 +3,7 @@ title: "Moonbeam methods"
 description: Complete reference of supported Moonbeam JSON-RPC methods on Chainstack, including eth, debug, trace, and Substrate namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/moonbeam-methods.mdx
+++ b/docs/moonbeam-methods.mdx
@@ -3,7 +3,7 @@ title: "Moonbeam methods"
 description: Complete reference of supported Moonbeam JSON-RPC methods on Chainstack, including eth, debug, trace, and Substrate namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/moonbeam-methods.mdx
+++ b/docs/moonbeam-methods.mdx
@@ -3,6 +3,10 @@ title: "Moonbeam methods"
 description: Complete reference of supported Moonbeam JSON-RPC methods on Chainstack, including eth, debug, trace, and Substrate namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/oasis-sapphire-methods.mdx
+++ b/docs/oasis-sapphire-methods.mdx
@@ -3,9 +3,7 @@ title: "Oasis Sapphire methods"
 description: Complete reference of supported Oasis Sapphire JSON-RPC methods on Chainstack, including confidential compute and standard EVM namespace calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/oasis-sapphire-methods.mdx
+++ b/docs/oasis-sapphire-methods.mdx
@@ -3,6 +3,10 @@ title: "Oasis Sapphire methods"
 description: Complete reference of supported Oasis Sapphire JSON-RPC methods on Chainstack, including confidential compute and standard EVM namespace calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/oasis-sapphire-methods.mdx
+++ b/docs/oasis-sapphire-methods.mdx
@@ -3,7 +3,7 @@ title: "Oasis Sapphire methods"
 description: Complete reference of supported Oasis Sapphire JSON-RPC methods on Chainstack, including confidential compute and standard EVM namespace calls.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/optimism-methods.mdx
+++ b/docs/optimism-methods.mdx
@@ -3,6 +3,10 @@ title: "Optimism methods"
 description: Complete reference of supported Optimism JSON-RPC methods on Chainstack, including eth, debug, trace, and rollup namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Optimism API call examples](/reference/optimism-api-reference).
 
 | Method                                   | Availability | Comment |

--- a/docs/optimism-methods.mdx
+++ b/docs/optimism-methods.mdx
@@ -3,9 +3,7 @@ title: "Optimism methods"
 description: Complete reference of supported Optimism JSON-RPC methods on Chainstack, including eth, debug, trace, and rollup namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Optimism API call examples](/reference/optimism-api-reference).
 

--- a/docs/optimism-methods.mdx
+++ b/docs/optimism-methods.mdx
@@ -3,7 +3,7 @@ title: "Optimism methods"
 description: Complete reference of supported Optimism JSON-RPC methods on Chainstack, including eth, debug, trace, and rollup namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Optimism API call examples](/reference/optimism-api-reference).
 

--- a/docs/plasma-methods.mdx
+++ b/docs/plasma-methods.mdx
@@ -3,7 +3,7 @@ title: "Plasma methods"
 description: Complete reference of supported Plasma JSON-RPC methods on Chainstack, including method availability for eth, debug, trace, and net namespace calls.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Plasma API call examples](/reference/plasma-getting-started).
 

--- a/docs/plasma-methods.mdx
+++ b/docs/plasma-methods.mdx
@@ -3,6 +3,10 @@ title: "Plasma methods"
 description: Complete reference of supported Plasma JSON-RPC methods on Chainstack, including method availability for eth, debug, trace, and net namespace calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Plasma API call examples](/reference/plasma-getting-started).
 
 | Method                                   | Availability | Comment               |

--- a/docs/plasma-methods.mdx
+++ b/docs/plasma-methods.mdx
@@ -3,9 +3,7 @@ title: "Plasma methods"
 description: Complete reference of supported Plasma JSON-RPC methods on Chainstack, including method availability for eth, debug, trace, and net namespace calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Plasma API call examples](/reference/plasma-getting-started).
 

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -3,6 +3,10 @@ title: "Polygon methods"
 description: Complete reference of supported Polygon PoS JSON-RPC methods on Chainstack, including eth, debug, trace, and bor namespace availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 
 | Method                                   | Availability | Comment |

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -3,7 +3,7 @@ title: "Polygon methods"
 description: Complete reference of supported Polygon PoS JSON-RPC methods on Chainstack, including eth, debug, trace, and bor namespace availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -3,9 +3,7 @@ title: "Polygon methods"
 description: Complete reference of supported Polygon PoS JSON-RPC methods on Chainstack, including eth, debug, trace, and bor namespace availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 

--- a/docs/polygon-zkevm-methods.mdx
+++ b/docs/polygon-zkevm-methods.mdx
@@ -3,7 +3,7 @@ title: "Polygon zkEVM methods"
 description: Complete reference of supported Polygon zkEVM JSON-RPC methods on Chainstack, including eth, zkevm, and net namespace method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Polygon zkEVM API call examples](/reference/zkevm-getting-started).
 

--- a/docs/polygon-zkevm-methods.mdx
+++ b/docs/polygon-zkevm-methods.mdx
@@ -2,6 +2,11 @@
 title: "Polygon zkEVM methods"
 description: Complete reference of supported Polygon zkEVM JSON-RPC methods on Chainstack, including eth, zkevm, and net namespace method availability details.
 ---
+
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Polygon zkEVM API call examples](/reference/zkevm-getting-started).
 
 | Method                                   | Availability | Comment |

--- a/docs/polygon-zkevm-methods.mdx
+++ b/docs/polygon-zkevm-methods.mdx
@@ -3,9 +3,7 @@ title: "Polygon zkEVM methods"
 description: Complete reference of supported Polygon zkEVM JSON-RPC methods on Chainstack, including eth, zkevm, and net namespace method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Polygon zkEVM API call examples](/reference/zkevm-getting-started).
 

--- a/docs/pricing-introduction.mdx
+++ b/docs/pricing-introduction.mdx
@@ -41,16 +41,12 @@ Currently, the following payment methods can be used to top up your balance:
 
 If your request volume is extra high or you prefer specific payment methods, [contact us](https://chainstack.com/contact/) for a special offer.
 
-## Rate limits
-
-See [Limits](/docs/limits).
-
 <Info>
   ### Dedicated nodes
 
   You can also order [dedicated nodes](/docs/dedicated-node) and pay for the node resource consumption only instead of per-request billing.
 </Info>
 
-## Range limits
+## Limits
 
-See [Limits](/docs/limits).
+For rate limits, range limits, and other operational thresholds, see [Limits](/docs/limits).

--- a/docs/pricing-introduction.mdx
+++ b/docs/pricing-introduction.mdx
@@ -7,7 +7,7 @@ description: Understand Chainstack pricing plans, request unit billing, node cos
 
 Each Chainstack’s subscription plan has its own quota that represents the allocated resources and usage limits that users can spend within their chosen plan. In addition to the allocated quota, Chainstack also offers an extra usage setting. With it enabled, if you exceed your allocated quota, you can continue using Chainstack's services seamlessly, with any additional usage being automatically charged at the applicable rates. Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs.
 
-Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-are-request-units).
+Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-an-ru-is).
 
 In addition to basic services, you can purchase Chainstack’s add-ons that help you to enrich your experience with the platform and improve your DApp performance. Available add-ons and their cost can be found in the [pricing page](https://chainstack.com/pricing/).
 

--- a/docs/quotas.mdx
+++ b/docs/quotas.mdx
@@ -11,7 +11,7 @@ In addition to the allocated quota, Chainstack also offers an extra usage settin
 
 Visit Chainstack’s [pricing page](https://chainstack.com/pricing/) to get familiar with a quota for each plan and extra usage costs. See [Manage your billing](/docs/manage-your-billing#manage-the-extra-usage-setting) on how to enable or disable the extra usage setting.
 
-Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-are-request-units).
+Quota spending can vary depending on the combination of services that you use. Service cost is reflected in [request units](/docs/request-units#what-an-ru-is).
 
 You will receive at least two email notifications:
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -121,8 +121,26 @@ These methods return an account's transaction history keyed by address (and logi
 
 **Archive only when targeting a historical block** — these methods take a block/seqno parameter and are billed as archive (2 RUs) when the requested seqno is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or no block parameter):
 
-- v2: `getBlockTransactions`, `getBlockTransactionsExt`, `getBlockHeader`, `lookupBlock`, `shards` / `getShards`, `getShardAccountCell`, `getShardBlockProof`, `getMasterchainBlockSignatures`, `getAddressState`, `getConfigParam`, `getConfigAll`
-- v3: `transactions`, `transactionsByMasterchainBlock`, `blocks`, `traces`, `actions`, `masterchainBlockShards`, `masterchainBlockShardState`
+- v2:
+  - `getBlockTransactions`
+  - `getBlockTransactionsExt`
+  - `getBlockHeader`
+  - `lookupBlock`
+  - `shards` / `getShards`
+  - `getShardAccountCell`
+  - `getShardBlockProof`
+  - `getMasterchainBlockSignatures`
+  - `getAddressState`
+  - `getConfigParam`
+  - `getConfigAll`
+- v3:
+  - `transactions`
+  - `transactionsByMasterchainBlock`
+  - `blocks`
+  - `traces`
+  - `actions`
+  - `masterchainBlockShards`
+  - `masterchainBlockShardState`
 
 The threshold is evaluated against the latest seqno of the workchain referenced by the request — the masterchain by default. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -29,9 +29,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Bitcoin, Sui, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
-## Method rules
-
-### Always 2 RUs
+## Always 2 RUs
 
 These EVM methods are billed at 2 RUs regardless of block age:
 
@@ -40,7 +38,7 @@ These EVM methods are billed at 2 RUs regardless of block age:
 
 For per-protocol debug and trace capabilities, see [Debug and trace APIs](/docs/debug-and-trace-apis).
 
-### EVM methods affected by block age
+## EVM methods affected by block age
 
 The block-age rule in the [table above](#full-vs-archive-by-protocol) applies to these EVM methods:
 
@@ -69,7 +67,7 @@ For `eth_getLogs` and `eth_newFilter`, the block evaluated for billing is `fromB
 
 All other EVM methods are billed as full (1 RU) regardless of the block they target.
 
-### Solana method scope
+## Solana method scope
 
 Archive billing on Solana applies only to these methods:
 
@@ -88,12 +86,12 @@ A request is archive (2 RUs) when its target slot is below `firstAvailable + 5,0
 
 All other Solana methods are billed as full (1 RU) regardless of slot.
 
-#### Two values shape the Solana archive boundary
+### Two values shape the Solana archive boundary
 
 - **Ledger retention** — each Solana full node is configured with `--limit-ledger-size 400000000` (400 million shreds). [Shreds](https://github.com/solana-foundation/specs/blob/main/p2p/shred.md) are Solana's network-propagation units, and the number produced per slot varies with block density, so this caps disk usage rather than fixing the slot count retained.
 - **Safety buffer** — 5,000 slots immediately above the pruning floor. Requests targeting these slots are routed to the archive backend to avoid races where the full node prunes data mid-request. This sets the boundary that triggers archive billing.
 
-#### Putting it together
+### Putting it together
 
 A call's RU cost on Solana depends on the method and, for methods eligible for archive billing, the target slot. The ledger size (400M shreds) caps how far back the full node retains data; the 5,000-slot safety buffer above the pruning floor sets the actual billing boundary.
 
@@ -110,7 +108,7 @@ For a sequence of calls:
 
 See also [Solana archive methods availability](/docs/limits#solana-archive-methods-availability).
 
-### TON method scope
+## TON method scope
 
 TON requests are billed as full (1 RU) by default. Archive billing (2 RUs) applies in two cases.
 
@@ -128,7 +126,7 @@ These methods return an account's transaction history keyed by address (and logi
 
 The threshold is evaluated against the latest seqno of the workchain referenced by the request — the masterchain by default. All other TON methods — across v2 REST, v3 REST, and the `/jsonRPC` envelope — are billed as full (1 RU).
 
-### Aptos method scope
+## Aptos method scope
 
 Aptos requests are billed as full (1 RU) by default. Aptos sequences data two ways, and the archive threshold differs by which an endpoint takes:
 
@@ -161,7 +159,7 @@ This endpoint returns an account's transaction history keyed by address, not by 
 
 A request that omits the block or version parameter, or targets one within the threshold, is billed as full (1 RU). All other Aptos endpoints are billed as full (1 RU).
 
-### Starknet method scope
+## Starknet method scope
 
 Starknet requests are billed as full (1 RU) by default. Three cases are billed at 2 RUs.
 

--- a/docs/ronin-methods.mdx
+++ b/docs/ronin-methods.mdx
@@ -3,7 +3,7 @@ title: "Ronin methods"
 description: "Complete Ronin RPC methods reference for Chainstack nodes. Access Ethereum-compatible JSON-RPC and debug methods with availability status on Ronin blockchain."
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Ronin API call examples](/reference/getting-started-ronin).
 

--- a/docs/ronin-methods.mdx
+++ b/docs/ronin-methods.mdx
@@ -3,6 +3,10 @@ title: "Ronin methods"
 description: "Complete Ronin RPC methods reference for Chainstack nodes. Access Ethereum-compatible JSON-RPC and debug methods with availability status on Ronin blockchain."
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Ronin API call examples](/reference/getting-started-ronin).
 
 | Method                                   | Availability | Comment |

--- a/docs/ronin-methods.mdx
+++ b/docs/ronin-methods.mdx
@@ -3,9 +3,7 @@ title: "Ronin methods"
 description: "Complete Ronin RPC methods reference for Chainstack nodes. Access Ethereum-compatible JSON-RPC and debug methods with availability status on Ronin blockchain."
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Ronin API call examples](/reference/getting-started-ronin).
 

--- a/docs/scroll-methods.mdx
+++ b/docs/scroll-methods.mdx
@@ -3,9 +3,7 @@ title: "Scroll methods"
 description: Complete reference of supported Scroll JSON-RPC methods on Chainstack, including eth, debug, trace, and scroll namespace method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/scroll-methods.mdx
+++ b/docs/scroll-methods.mdx
@@ -3,6 +3,10 @@ title: "Scroll methods"
 description: Complete reference of supported Scroll JSON-RPC methods on Chainstack, including eth, debug, trace, and scroll namespace method availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/scroll-methods.mdx
+++ b/docs/scroll-methods.mdx
@@ -3,7 +3,7 @@ title: "Scroll methods"
 description: Complete reference of supported Scroll JSON-RPC methods on Chainstack, including eth, debug, trace, and scroll namespace method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/solana-methods.mdx
+++ b/docs/solana-methods.mdx
@@ -3,9 +3,7 @@ title: "Solana methods"
 description: Complete reference of supported Solana JSON-RPC and WebSocket methods on Chainstack, including account, block, transaction, and program query calls.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — Solana method scope](/docs/request-units#solana-method-scope). In short: most methods are full (1 RU); eight specific methods can be archive (2 RUs). `getFirstAvailableBlock` and `getSignaturesForAddress` are always archive; the rest are archive when targeting slots beyond the recent retention window.
-</Note>
+For full vs archive billing, see [Request units — Solana method scope](/docs/request-units#solana-method-scope).
 
 See also [interactive Solana API call examples](/reference/solana-getting-started).
 

--- a/docs/solana-methods.mdx
+++ b/docs/solana-methods.mdx
@@ -3,7 +3,7 @@ title: "Solana methods"
 description: Complete reference of supported Solana JSON-RPC and WebSocket methods on Chainstack, including account, block, transaction, and program query calls.
 ---
 
-For full vs archive billing, see [Request units — Solana method scope](/docs/request-units#solana-method-scope).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which Solana methods are full vs archive, see [Request units — Solana method scope](/docs/request-units#solana-method-scope).
 
 See also [interactive Solana API call examples](/reference/solana-getting-started).
 

--- a/docs/solana-methods.mdx
+++ b/docs/solana-methods.mdx
@@ -3,6 +3,10 @@ title: "Solana methods"
 description: Complete reference of supported Solana JSON-RPC and WebSocket methods on Chainstack, including account, block, transaction, and program query calls.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — Solana method scope](/docs/request-units#solana-method-scope). In short: most methods are full (1 RU); eight specific methods can be archive (2 RUs). `getFirstAvailableBlock` and `getSignaturesForAddress` are always archive; the rest are archive when targeting slots beyond the recent retention window.
+</Note>
+
 See also [interactive Solana API call examples](/reference/solana-getting-started).
 
 For per-method rate limits, plan restrictions, and archive data availability, see [Throughput guidelines](/docs/limits#solana-method-limits).

--- a/docs/sonic-methods.mdx
+++ b/docs/sonic-methods.mdx
@@ -3,9 +3,7 @@ title: "Sonic methods"
 description: "Complete reference of available Sonic blockchain RPC methods. Includes eth_, debug_, trace_, and web3_ API methods with availability status for developers."
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/sonic-methods.mdx
+++ b/docs/sonic-methods.mdx
@@ -3,7 +3,7 @@ title: "Sonic methods"
 description: "Complete reference of available Sonic blockchain RPC methods. Includes eth_, debug_, trace_, and web3_ API methods with availability status for developers."
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |

--- a/docs/sonic-methods.mdx
+++ b/docs/sonic-methods.mdx
@@ -3,6 +3,10 @@ title: "Sonic methods"
 description: "Complete reference of available Sonic blockchain RPC methods. Includes eth_, debug_, trace_, and web3_ API methods with availability status for developers."
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/starknet-methods.mdx
+++ b/docs/starknet-methods.mdx
@@ -5,7 +5,7 @@ description: "Complete Starknet RPC API methods reference. Includes starknet_ an
 
 See also [interactive Starknet API call examples](/reference/getting-started-starknet).
 
-For full vs archive billing, see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which Starknet methods are full vs archive, see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope).
 
 | Method                                    | Availability | Comment |
 | ----------------------------------------- | ------------ | ------- |

--- a/docs/starknet-methods.mdx
+++ b/docs/starknet-methods.mdx
@@ -5,9 +5,7 @@ description: "Complete Starknet RPC API methods reference. Includes starknet_ an
 
 See also [interactive Starknet API call examples](/reference/getting-started-starknet).
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope). In short: most methods are full (1 RU); trace methods (`starknet_traceBlockTransactions`, `starknet_traceTransaction`) are always 2 RUs; block-scoped methods such as `starknet_getBlockWithTxs`, `starknet_call`, and `starknet_getStorageAt` — and `starknet_getEvents` by its block range — are archive when the requested block is more than 128 behind the tip.
-</Note>
+For full vs archive billing, see [Request units — Starknet method scope](/docs/request-units#starknet-method-scope).
 
 | Method                                    | Availability | Comment |
 | ----------------------------------------- | ------------ | ------- |

--- a/docs/tempo-methods.mdx
+++ b/docs/tempo-methods.mdx
@@ -3,9 +3,7 @@ title: "Tempo methods"
 description: Complete reference of supported Tempo JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace method availability details.
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Tempo API call examples](/reference/tempo-getting-started).
 

--- a/docs/tempo-methods.mdx
+++ b/docs/tempo-methods.mdx
@@ -3,7 +3,7 @@ title: "Tempo methods"
 description: Complete reference of supported Tempo JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace method availability details.
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive Tempo API call examples](/reference/tempo-getting-started).
 

--- a/docs/tempo-methods.mdx
+++ b/docs/tempo-methods.mdx
@@ -3,6 +3,10 @@ title: "Tempo methods"
 description: Complete reference of supported Tempo JSON-RPC methods on Chainstack nodes, including eth, debug, and trace namespace method availability details.
 ---
 
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive Tempo API call examples](/reference/tempo-getting-started).
 
 | Method                                   | Availability | Comment               |

--- a/docs/ton-methods.mdx
+++ b/docs/ton-methods.mdx
@@ -5,9 +5,7 @@ description: "Complete TON blockchain API methods reference. Includes v2 and v3 
 
 See also [interactive TON API call examples](/reference/getting-started-ton).
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — TON method scope](/docs/request-units#ton-method-scope). In short: most methods are full (1 RU); `getTransactions` and `getTransactionsStd` are always archive (2 RUs); block/seqno methods are archive when the requested block is 128 or more seqno behind the tip.
-</Note>
+For full vs archive billing, see [Request units — TON method scope](/docs/request-units#ton-method-scope).
 
 | Method                             | Availability | Comment |
 | ---------------------------------- | ------------ | ------- |

--- a/docs/ton-methods.mdx
+++ b/docs/ton-methods.mdx
@@ -5,7 +5,7 @@ description: "Complete TON blockchain API methods reference. Includes v2 and v3 
 
 See also [interactive TON API call examples](/reference/getting-started-ton).
 
-For full vs archive billing, see [Request units — TON method scope](/docs/request-units#ton-method-scope).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which TON methods are full vs archive, see [Request units — TON method scope](/docs/request-units#ton-method-scope).
 
 | Method                             | Availability | Comment |
 | ---------------------------------- | ------------ | ------- |

--- a/docs/tron-methods.mdx
+++ b/docs/tron-methods.mdx
@@ -3,9 +3,7 @@ title: "TRON methods"
 description: "Complete TRON blockchain API methods reference. Includes JSON-RPC, wallet, walletsolidity, and gRPC endpoints for smart contracts, transactions, and accounts."
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All TRON methods are billed as full (1 RU); there is no archive split.
-</Note>
+All TRON methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 <Note>
 TRON also supports **gRPC** for high-performance access. For gRPC setup, authentication, and available methods, see [TRON tooling: gRPC API](/docs/tron-tooling#grpc-api).

--- a/docs/tron-methods.mdx
+++ b/docs/tron-methods.mdx
@@ -4,6 +4,10 @@ description: "Complete TRON blockchain API methods reference. Includes JSON-RPC,
 ---
 
 <Note>
+For how these methods are billed (full vs archive), see [Request units](/docs/request-units#full-vs-archive-by-protocol). All TRON methods are billed as full (1 RU); there is no archive split.
+</Note>
+
+<Note>
 TRON also supports **gRPC** for high-performance access. For gRPC setup, authentication, and available methods, see [TRON tooling: gRPC API](/docs/tron-tooling#grpc-api).
 </Note>
 

--- a/docs/tron-methods.mdx
+++ b/docs/tron-methods.mdx
@@ -3,7 +3,7 @@ title: "TRON methods"
 description: "Complete TRON blockchain API methods reference. Includes JSON-RPC, wallet, walletsolidity, and gRPC endpoints for smart contracts, transactions, and accounts."
 ---
 
-All TRON methods are billed as full (1 RU). See [Request units](/docs/request-units#full-vs-archive-by-protocol).
+Our pricing is simple: 1 RU per request. TRON has no archive split — see [Request units](/docs/request-units#full-vs-archive-by-protocol).
 
 <Note>
 TRON also supports **gRPC** for high-performance access. For gRPC setup, authentication, and available methods, see [TRON tooling: gRPC API](/docs/tron-tooling#grpc-api).

--- a/docs/zksync-era-methods.mdx
+++ b/docs/zksync-era-methods.mdx
@@ -2,6 +2,11 @@
 title: "ZKsync Era methods"
 description: "Complete ZKsync Era RPC API methods reference. Includes eth_, debug_, zks_ methods for L2 transactions, batches, bridges, and zero-knowledge proof queries."
 ---
+
+<Note>
+For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
+</Note>
+
 See also [interactive ZKsync Era API call examples](/reference/getting-started-zksync).
 
 | Method                                   | Availability | Comment |

--- a/docs/zksync-era-methods.mdx
+++ b/docs/zksync-era-methods.mdx
@@ -3,9 +3,7 @@ title: "ZKsync Era methods"
 description: "Complete ZKsync Era RPC API methods reference. Includes eth_, debug_, zks_ methods for L2 transactions, batches, bridges, and zero-knowledge proof queries."
 ---
 
-<Note>
-For how these methods are billed (full vs archive), see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age). In short: most methods are full (1 RU); methods that target a specific historical block are archive (2 RUs) when the block is 127 or more behind the tip. `debug_*`, `trace_*`, and `arbtrace_*` methods, plus `eth_callMany`, are always archive.
-</Note>
+For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive ZKsync Era API call examples](/reference/getting-started-zksync).
 

--- a/docs/zksync-era-methods.mdx
+++ b/docs/zksync-era-methods.mdx
@@ -3,7 +3,7 @@ title: "ZKsync Era methods"
 description: "Complete ZKsync Era RPC API methods reference. Includes eth_, debug_, zks_ methods for L2 transactions, batches, bridges, and zero-knowledge proof queries."
 ---
 
-For full vs archive billing, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM methods are full vs archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
 
 See also [interactive ZKsync Era API call examples](/reference/getting-started-zksync).
 


### PR DESCRIPTION
Follow-up to #413 (Aptos/Starknet billing) — closes the consistency gaps surfaced while reviewing.

## What

Three independent fixes bundled together.

### 1. Broken anchor links (real bug)

`docs/pricing-introduction.mdx` and `docs/quotas.mdx` both linked to `/docs/request-units#what-are-request-units`. That anchor doesn't exist — the section was renamed to *"What an RU is"* (anchor `#what-an-ru-is`) and the inbound links weren't updated. Currently both links scroll to the top of the page instead of the intended section.

### 2. Backfill billing `<Note>` blocks on per-protocol method-reference pages

#403 (TON) and #413 (Aptos, Starknet) established the pattern: a `<Note>` at the top of a methods page pointing to the right section of `/docs/request-units`. This PR backfills the same Note across the remaining method-reference pages:

- **EVM family** (24 pages): Ethereum, Arbitrum, Aurora, Avalanche, Base, Blast, BNB Smart Chain, Celo, Cronos, Fantom, Hyperliquid, Kaia, MegaETH, Moonbeam, Oasis Sapphire, Optimism, Plasma, Polygon, Polygon zkEVM, Ronin, Scroll, Sonic, Tempo, zkSync Era — point to `#evm-methods-affected-by-block-age`.
- **Solana**: points to `#solana-method-scope`.
- **Single-class** (Bitcoin, Harmony, TRON): point to the protocol table and state explicitly that all requests are 1 RU.

After this PR, every protocol methods page has a billing pointer.

### 3. Structural tidy of `request-units.mdx`

Promote method-scope subsections from H3 to H2. The page now has each protocol's billing rules as a top-level section instead of buried under a "Method rules" umbrella:

```
## Full vs archive by protocol
## Always 2 RUs                          (was H3)
## EVM methods affected by block age     (was H3)
## Solana method scope                   (was H3)
  ### Two values shape the Solana ...    (was H4)
  ### Putting it together                (was H4)
## TON method scope                      (was H3)
## Aptos method scope                    (was H3)
## Starknet method scope                 (was H3)
```

Heading text is preserved, so anchor IDs (`#solana-method-scope`, `#ton-method-scope`, etc.) don't change and existing cross-references keep working.

## Test plan

- [x] Verified the anchor `#what-an-ru-is` matches the actual heading text in `request-units.mdx`.
- [x] Spot-checked rendered output on Bitcoin and TRON pages — both have a pre-existing `<Note>` (modes Note on Bitcoin, gRPC Note on TRON). The new billing Note sits cleanly above the existing Note in both cases.
- [x] All in-doc anchor links to method-scope sections (`#solana-method-scope`, `#ton-method-scope`, `#aptos-method-scope`, `#starknet-method-scope`, `#full-vs-archive-by-protocol`, `#evm-methods-affected-by-block-age`) still resolve after the H3 → H2 promotion (heading text unchanged).