### PR TITLE
docs: document Ethereum native tracers (muxTracer, flatCallTracer, erc7562Tracer)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1519,6 +1519,7 @@
                   "reference/ethereum-traceblockbyhash",
                   "reference/ethereum-tracetransaction",
                   "reference/ethereum-tracecall",
+                  "reference/ethereum-tracecallmany",
                   "reference/ethereum-trace_transaction",
                   "reference/ethereum-trace_block",
                   "reference/ethereum-traceblockbynumber"

--- a/docs/error-reference.mdx
+++ b/docs/error-reference.mdx
@@ -43,6 +43,7 @@ These follow the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specificat
 | `-32602` | Invalid params | Parameter type, count, or value is wrong. Check the per-method reference in [API reference](/reference). |
 | `-32603` | Internal error | Server-side JSON-RPC error. Usually wraps a more specific `-32000` error below. |
 | `-32000` | Server error | Implementation-defined error from the node client. The `message` field has the details — for example `missing trie node`, `nonce too low`, `execution reverted`. See [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474) for common Ethereum-side codes. |
+| `-32612` | Custom tracers are disabled by default | You requested a tracer that isn't enabled on this node. Custom raw-JavaScript tracers need a [dedicated node](/docs/dedicated-node); native tracers beyond the defaults, such as `muxTracer`, are enabled per protocol (currently Ethereum). See [Custom tracers on EVMs](/docs/limits#custom-tracers-on-evms). |
 
 ### Common `-32000` messages
 

--- a/docs/ethereum-methods.mdx
+++ b/docs/ethereum-methods.mdx
@@ -74,6 +74,7 @@ See also [Interactive Ethereum API call examples](/reference/ethereum-getting-st
 | debug\_traceBlockByHash                  | <Icon icon="square-check"  iconType="solid" />            |                          |
 | debug\_traceBlockByNumber                | <Icon icon="square-check"  iconType="solid" />            |                          |
 | debug\_traceCall                         | <Icon icon="square-check"  iconType="solid" />            |                          |
+| debug\_traceCallMany                     | <Icon icon="square-check"  iconType="solid" />            |                          |
 | debug\_traceTransaction                  | <Icon icon="square-check"  iconType="solid" />            |                          |
 | trace\_block                             | <Icon icon="square-check"  iconType="solid" />            |                          |
 | trace\_call                              | <Icon icon="square-check"  iconType="solid" />            |                          |

--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -62,7 +62,40 @@ The following debug methods are disabled on EVM chains:
 
 ## Custom tracers on EVMs
 
-Custom JavaScript tracers are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+EVM debug and trace methods accept two kinds of tracers:
+
+- Native (built-in) tracers — selected by name, such as `callTracer`. Available on shared nodes, including [Global Nodes](/docs/global-elastic-node); the exact set depends on the protocol (see below).
+- Custom JavaScript tracers — where you pass raw JavaScript as the `tracer` argument. These are disabled on shared nodes and are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+
+### Available native tracers
+
+The following native tracers are enabled by default on all EVM chains:
+
+- `4byteTracer`
+- `callTracer`
+- `prestateTracer`
+- `noopTracer`
+
+Ethereum (Mainnet, Sepolia, and Hoodi) additionally supports:
+
+- `flatCallTracer`
+- `muxTracer`
+- `erc7562Tracer`
+
+See [Debug and Trace | Ethereum](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) for a description of each tracer.
+
+### Disabled tracer error
+
+Requesting a tracer that isn't enabled on the node—a custom JavaScript tracer, or a native tracer not available on that protocol—returns:
+
+```json
+{
+  "error": {
+    "code": -32612,
+    "message": "Custom tracers are disabled by default. See https://docs.chainstack.com/docs/limits for details."
+  }
+}
+```
 
 ## Ethereum `eth_simulateV1` supports only full node
 

--- a/docs/mastering-custom-javascript-tracing-for-ethereum-virtual-machine.mdx
+++ b/docs/mastering-custom-javascript-tracing-for-ethereum-virtual-machine.mdx
@@ -30,7 +30,7 @@ Ethereum provides built-in tracing functionality through its JSON-RPC API. There
 </CardGroup>
 
 <Info>
-  You can also find details about [built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) and [custom tracing](/reference/custom-js-tracing-ethereum) in the Chainstack documentation.
+  You can also find details about [built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) and [custom tracing](/reference/custom-js-tracing-ethereum) in the Chainstack documentation.
 </Info>
 
 **Basic tracing** and **Built-in tracers** serve as powerful debugging tools. They generate all the crucial data for most general purposes. Nevertheless, there can be situations that demand more specific details to align with particular requirements, or sometimes the standard tracer output too much data when only something specific is needed. This is where custom JavaScript tracing comes into play, allowing for enhanced customization of the tracing output.
@@ -309,7 +309,7 @@ To learn more about how these functions work, refer to [this official tutorial](
 
 ## Conclusion
 
-Custom JS tracing allows developers to create scripts that can be executed on the Ethereum node using popular methods like `debug_traceCall`, `debug_traceTransaction`, `debug_traceBlockByHash`, and `debug_traceBlockByHash`.
+Custom JS tracing allows developers to create scripts that can be executed on the Ethereum node using popular methods like `debug_traceCall`, `debug_traceTransaction`, `debug_traceBlockByHash`, and `debug_traceBlockByNumber`.
 
 The article provides practical examples of how to use custom JS tracing, including running sample requests to endpoints and implementing a custom tracer script using node.js, which serves as a more scalable approach compared to constructing tracer objects as strings.
 

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceCallMany.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceCallMany.json
@@ -1,0 +1,116 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Ethereum Node API",
+    "version": "1.0.0",
+    "description": "This is an API for interacting with an Ethereum node."
+  },
+  "servers": [
+    {
+      "url": "https://nd-422-757-666.p2pify.com"
+    }
+  ],
+  "paths": {
+    "/0a9d79d93fb2f4a4b1e04695da2b77a7": {
+      "post": {
+        "tags": [
+          "Ethereum Operations"
+        ],
+        "summary": "debug_traceCallMany",
+        "operationId": "traceCallMany",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "jsonrpc": {
+                    "type": "string",
+                    "default": "2.0"
+                  },
+                  "method": {
+                    "type": "string",
+                    "default": "debug_traceCallMany"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "default": 1
+                  },
+                  "params": {
+                    "type": "array",
+                    "description": "An array with three elements: the bundles to execute, the simulation context, and the trace configuration. The trace configuration below uses muxTracer to run callTracer and prestateTracer in a single pass.",
+                    "default": [
+                      [
+                        {
+                          "transactions": [
+                            {
+                              "from": "0x1985EA6E9c68E1C272d8209f3B478AC2Fdb25c87",
+                              "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                              "gas": "0xf4240",
+                              "gasPrice": "0x7896e72a",
+                              "data": "0xa9059cbb000000000000000000000000bc0E63965946815d105E7591407704e6e1964E590000000000000000000000000000000000000000000000000000000005f5e100"
+                            }
+                          ]
+                        }
+                      ],
+                      {
+                        "blockNumber": "latest"
+                      },
+                      {
+                        "tracer": "muxTracer",
+                        "tracerConfig": {
+                          "callTracer": {
+                            "onlyTopCall": true,
+                            "withLog": false
+                          },
+                          "prestateTracer": {
+                            "diffMode": true
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Detailed execution traces for each call in each bundle. With muxTracer, every trace object is keyed by the name of each sub-tracer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonrpc": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "result": {
+                      "type": "array",
+                      "description": "One array per bundle; each inner array holds one trace object per transaction. With muxTracer, each trace object is keyed by tracer name (for example, callTracer and prestateTracer).",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-readme": {
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  }
+}

--- a/reference/arbitrum-debug-and-trace-rpc-methods.mdx
+++ b/reference/arbitrum-debug-and-trace-rpc-methods.mdx
@@ -56,9 +56,9 @@ Use the following `arbtrace_*` methods for calling on blocks prior to 22,207,815
 ## Pre-built tracers
 
 <Info>
-  ### Custom tracers are available on customized dedicated nodes only
+  ### Custom JavaScript tracers need a dedicated node
 
-  Custom JavaScript tracers outside of the ones listed below are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+  The tracers listed below are native (built-in) tracers—you select one by name. Custom JavaScript tracers, where you pass raw JavaScript as the `tracer`, are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
 </Info>
 
 Developers can customize the type of tracing using various debug and trace methods, and there are numerous pre-built tracers available to choose from. Here is a list of the pre-built tracers that can be utilized:

--- a/reference/avalanche-debug-trace-rpc-methods.mdx
+++ b/reference/avalanche-debug-trace-rpc-methods.mdx
@@ -21,12 +21,12 @@ Developers can access the debug and trace tools with the following methods:
   <Card title="debug_traceTransaction" href="/reference/avalanche-tracetransaction" icon="angle-right" horizontal />
 </CardGroup>
 
-## Pre-built JavaScript-based tracers
+## Pre-built native tracers
 
 <Info>
-  ### Custom tracers are available on customized dedicated nodes only
+  ### Custom JavaScript tracers need a dedicated node
 
-  Custom JavaScript tracers outside of the ones listed below are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+  The tracers listed below are native (built-in) tracers—you select one by name. Custom JavaScript tracers, where you pass raw JavaScript as the `tracer`, are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
 </Info>
 
 Developers can customize the type of tracing using various debug and trace methods, and there are numerous pre-built tracers available to choose from. Further is a list of the pre-built tracers that can be utilized.

--- a/reference/avalanche-tracecall.mdx
+++ b/reference/avalanche-tracecall.mdx
@@ -46,7 +46,7 @@ See the [default block parameter](https://eth.wiki/json-rpc/API#the-default-bloc
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/avalanche-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/avalanche-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 

--- a/reference/avalanche-tracetransaction.mdx
+++ b/reference/avalanche-tracetransaction.mdx
@@ -29,7 +29,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/avalanche-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/avalanche-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 

--- a/reference/bnb-customtracer.mdx
+++ b/reference/bnb-customtracer.mdx
@@ -13,7 +13,7 @@ Custom JavaScript tracers are available as customized solutions on the [Enterpri
 In the context of BNB transactions, custom JavaScript tracing is a method used to filter and extract particular data from the comprehensive data produced during a transaction's execution inside the Ethereum Virtual Machine (EVM). Custom JavaScript tracers enable customers to concentrate on specific data points pertinent to their needs rather than reviewing the entire transaction trail, which might be a massive quantity of data.
 
 <Note>
-[Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) are also available, but allow for less fine tuning.
+[Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) are also available, but allow for less fine tuning.
 </Note>
 
 

--- a/reference/bnb-tracecall.mdx
+++ b/reference/bnb-tracecall.mdx
@@ -48,7 +48,7 @@ See the [default block parameter](https://ethereum.org/en/developers/docs/apis/j
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 

--- a/reference/bnb-tracetransaction.mdx
+++ b/reference/bnb-tracetransaction.mdx
@@ -28,7 +28,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 

--- a/reference/custom-js-tracer-fantom.mdx
+++ b/reference/custom-js-tracer-fantom.mdx
@@ -13,7 +13,7 @@ description: "Reference for the Custom JS tracer JSON-RPC method on the Fantom b
 In the context of Fantom transactions, custom JavaScript tracing is a method used to filter and extract particular data from the comprehensive data produced during a transaction's execution inside the Ethereum Virtual Machine (EVM). Custom JavaScript tracers enable customers to concentrate on specific data points pertinent to their needs rather than reviewing the entire transaction trail, which might be a massive quantity of data.
 
 <Info>
-  [Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) are also available, but allow for less fine tuning.
+  [Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) are also available, but allow for less fine tuning.
 </Info>
 
 These JavaScript-written tracers can be constructed using a number of different methods to specify how they interact with transaction data. Users can design unique tracers that meet their needs by giving a JavaScript expression and the tracer option when using one of the tracing methods.

--- a/reference/custom-js-tracing-ethereum.mdx
+++ b/reference/custom-js-tracing-ethereum.mdx
@@ -13,7 +13,7 @@ Custom JavaScript tracers are available as customized solutions on the [Enterpri
 In the context of Ethereum transactions, custom JavaScript tracing is a method used to filter and extract particular data from the comprehensive data produced during the execution of a transaction inside the Ethereum Virtual Machine (EVM). Custom JavaScript tracers enable customers to concentrate on specific data points pertinent to their needs rather than reviewing the entire transaction trail, which might be a massive quantity of data.
 
 <Note>
-[Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) are also available, but allow for less fine tuning.
+[Pre-built tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) are also available, but allow for less fine tuning.
 </Note>
 
 

--- a/reference/debug_tracetransaction-fantom.mdx
+++ b/reference/debug_tracetransaction-fantom.mdx
@@ -26,7 +26,7 @@ description: "Fantom debug_traceTransaction method — replay a transaction to g
   * `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Info>
-  Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+  Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Info>
 
 You can also use additional configuration parameters. The following settings are available:

--- a/reference/ethereum-debug-trace-rpc-methods.mdx
+++ b/reference/ethereum-debug-trace-rpc-methods.mdx
@@ -24,12 +24,12 @@ Developers can access the debug and trace tools on the Ethereum blockchain with 
   <Card title="trace_block" icon="angle-right" iconType="solid" href="/reference/ethereum-trace_block" horizontal/>
 </CardGroup>
 
-## Pre-built JavaScript-based tracers
+## Pre-built native tracers
 
 <Info>
-  ### Custom tracers are available on customized dedicated nodes only
+  ### Custom JavaScript tracers need a dedicated node
 
-  Custom JavaScript tracers outside of the ones listed below are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+  The tracers listed below are native (built-in) tracers—you select one by name, and they run on all Ethereum nodes. Custom JavaScript tracers, where you pass raw JavaScript as the `tracer`, are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
 </Info>
 
 Developers can customize the type of tracing using various debug and trace methods, and there are numerous pre-built tracers available to choose from. Here is a list of the pre-built tracers that can be utilized:
@@ -49,6 +49,24 @@ This tracer returns sufficient information about an account to create a local ex
 ## `noopTracer`
 
 This tracer does nothing but respond with a blank object. This a no operations tracer for testing setup.
+
+## `flatCallTracer`
+
+This tracer returns call traces in the flat, Parity-style format—the same structure as the `trace_*` namespace. Instead of the nested tree produced by `callTracer`, it returns a flattened list of call frames, which is convenient for tooling built around the OpenEthereum/Parity trace format.
+
+<Note>Available on Ethereum only.</Note>
+
+## `muxTracer`
+
+This tracer runs several native tracers in a single pass and returns their combined output. Pass a `tracerConfig` object keyed by tracer name—for example, `callTracer` and `prestateTracer`, each with its own configuration—and the response is an object keyed by each tracer's name. This avoids re-executing the transaction once per tracer.
+
+<Note>Available on Ethereum only.</Note>
+
+## `erc7562Tracer`
+
+This tracer enforces the [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562) account-abstraction validation rules, tracking opcode and storage access during the validation phase of an ERC-4337 user operation. Bundlers use it to detect rule violations before a user operation enters the mempool.
+
+<Note>Available on Ethereum only.</Note>
 
 ## Custom JavaScript tracers
 

--- a/reference/ethereum-traceblockbyhash.mdx
+++ b/reference/ethereum-traceblockbyhash.mdx
@@ -27,6 +27,9 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `4byteTracer` — tracer that captures the function signatures and call data sizes for all functions executed during a transaction, creating a map that links each selector and size combination to the number of times it occurred. This provides valuable information about the frequency and usage of each function within the transaction.
   + `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
+  + `flatCallTracer` — tracer that returns call traces in the flat, Parity-style format used by the `trace_*` namespace, as a flattened list of call frames rather than a nested tree.
+  + `muxTracer` — tracer that runs several native tracers in a single pass, configured via a `tracerConfig` object keyed by tracer name, returning each tracer's output under its own key.
+  + `erc7562Tracer` — tracer that enforces the ERC-7562 account-abstraction validation rules, tracking opcode and storage access during the validation phase of an ERC-4337 user operation.
 
 ## Response types
 
@@ -71,7 +74,7 @@ const ethers = require("ethers");
 const chainstack = new ethers.ChainstackProvider("mainnet");
 
 const traceBlockByHash = async (blockHash) => {
-  // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+  // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
   const tracer = { tracer: "4byteTracer" };
   const traces = await chainstack.send("debug_traceBlockByHash", [
     blockHash,
@@ -127,7 +130,7 @@ web3 = Web3.HTTPProvider(node_url)
 
 block_hash = "0x4725335feac695de65deb8662235f52692522d4f623a81468cc6479b43dc9782"
 
-# Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+# Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
 tracer = { "tracer": '4byteTracer' }
 block_traces = web3.provider.make_request('debug_traceBlockByHash', [block_hash, tracer])
 print(block_traces)
@@ -165,7 +168,7 @@ web3.registerPlugin(new TraceBlockPlugin());
 
 async function traceTransferFunction(blockHash) {
     try {
-      // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+      // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
       const tracer = { tracer: '4byteTracer' };
       const response = await web3.trace.traceBlockByHash(blockHash, tracer);
       

--- a/reference/ethereum-traceblockbynumber.mdx
+++ b/reference/ethereum-traceblockbynumber.mdx
@@ -39,6 +39,9 @@ See the [default block parameter](https://ethereum.org/en/developers/docs/apis/j
   + `4byteTracer` — tracer that captures the function signatures and call data sizes for all functions executed during a transaction, creating a map that links each selector and size combination to the number of times it occurred. This provides valuable information about the frequency and usage of each function within the transaction.
   + `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
+  + `flatCallTracer` — tracer that returns call traces in the flat, Parity-style format used by the `trace_*` namespace, as a flattened list of call frames rather than a nested tree.
+  + `muxTracer` — tracer that runs several native tracers in a single pass, configured via a `tracerConfig` object keyed by tracer name, returning each tracer's output under its own key.
+  + `erc7562Tracer` — tracer that enforces the ERC-7562 account-abstraction validation rules, tracking opcode and storage access during the validation phase of an ERC-4337 user operation.
 
 ## Response types
 
@@ -83,7 +86,7 @@ const ethers = require("ethers");
 const chainstack = new ethers.ChainstackProvider("mainnet");
 
 const traceBlockByNumber = async (block) => {
-  // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+  // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
   const tracer = { tracer: "callTracer" };
   const traces = await chainstack.send("debug_traceBlockByNumber", [
     block,
@@ -117,7 +120,7 @@ web3.registerPlugin(new TraceBlockPlugin());
 
 async function traceBlockByNumber(block) {
 
-    // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+    // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
     const tracer = { tracer: 'callTracer' };
     const result = await web3.trace.traceBlockByNumber(block, tracer);
     console.log(result);
@@ -133,7 +136,7 @@ web3 = Web3.HTTPProvider(node_url)
 
 block = "latest"
 
-# Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer
+# Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer
 tracer = { "tracer": 'callTracer' }
 block_traces = web3.provider.make_request('debug_traceBlockByNumber', [block, tracer])
 print(block_traces)

--- a/reference/ethereum-tracecall.mdx
+++ b/reference/ethereum-tracecall.mdx
@@ -46,9 +46,12 @@ See the [default block parameter](https://ethereum.org/en/developers/docs/apis/j
   + `4byteTracer` — tracer that captures the function signatures and call data sizes for all functions executed during a transaction, creating a map that links each selector and size combination to the number of times it occurred. This provides valuable information about the frequency and usage of each function within the transaction.
   + `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
+  + `flatCallTracer` — tracer that returns call traces in the flat, Parity-style format used by the `trace_*` namespace, as a flattened list of call frames rather than a nested tree.
+  + `muxTracer` — tracer that runs several native tracers in a single pass, configured via a `tracerConfig` object keyed by tracer name, returning each tracer's output under its own key.
+  + `erc7562Tracer` — tracer that enforces the ERC-7562 account-abstraction validation rules, tracking opcode and storage access during the validation phase of an ERC-4337 user operation.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 
@@ -141,7 +144,7 @@ const traceCall = async () => {
 
   const block = "latest";
 
-  // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+  // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
   const tracer = {};
   const traces = await chainstack.send("debug_traceCall", [
     call,
@@ -186,7 +189,7 @@ async function traceCall() {
   
     const block = 'latest'
   
-    // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+    // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
     const tracer = {'tracer' : '4byteTracer'};
     const result = await web3.trace.traceCall(call, block, tracer);
     console.log(result);
@@ -210,7 +213,7 @@ call = {
 
 block = 'latest'
 
-# Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+# Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
 tracer = { "tracer": 'prestateTracer' }
 tx_traces = web3.provider.make_request('debug_traceCall', [call, block, tracer])
 print(tx_traces)
@@ -251,7 +254,7 @@ web3.registerPlugin(new TraceBlockPlugin());
 
 async function traceCall(call, block) {
     try {
-      // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer.
+      // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer.
       // Leave empty {} for Struct/opcode logger.
       const tracer = { tracer: 'callTracer' };
   

--- a/reference/ethereum-tracecallmany.mdx
+++ b/reference/ethereum-tracecallmany.mdx
@@ -1,0 +1,70 @@
+---
+title: debug_traceCallMany | Ethereum
+openapi: /openapi/ethereum_node_api/debug_and_trace/debug_traceCallMany.json POST /0a9d79d93fb2f4a4b1e04695da2b77a7
+description: "Ethereum API method that executes a list of bundles and returns an execution trace for each call, without creating transactions on the blockchain."
+---
+
+Ethereum API method that executes one or more bundles—each a list of transactions—against a given block and returns an execution trace for each call, without creating transactions on the blockchain. Calls within a bundle execute in sequence, so each call sees the state changes made by the calls before it. This method is akin to [eth_call](/reference/ethereum-ethcall) batched across multiple transactions, but it returns detailed execution traces, making it invaluable for debugging complex multi-transaction interactions.
+
+<Note>
+Learn how to [deploy a node](/docs/debug-and-trace-apis#ethereum) with the debug and trace API methods enabled.
+</Note>
+
+<Check>
+**Get your own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+
+## Parameters
+
+`debug_traceCallMany` takes three positional parameters:
+
+* `array` — a list of bundles to execute. Each bundle is an object with:
+  + `transactions` — an array of transaction call objects. Each object accepts the same fields as [debug_traceCall](/reference/ethereum-tracecall): `from` (optional), `to`, `gas`, `gasPrice`, `value`, and `data`.
+  + `blockOverrides` — (optional) an object that overrides fields of the execution block header, such as `number`, `time`, or `baseFeePerGas`.
+* `object` — the simulation context that pins where the bundles execute:
+  + `blockNumber` — the block number or tag (for example, `latest`) to execute against.
+  + `transactionIndex` — (optional) the index within the block at which to start; `-1` runs after all transactions in the block.
+* `object` — (optional) the trace configuration. Set `tracer` to one of the native tracers and pass tracer-specific options in `tracerConfig`.
+
+<Note>
+Find the complete [list of available native tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
+</Note>
+
+
+### Combining tracers with `muxTracer`
+
+`muxTracer` runs several native tracers in a single pass, which is the most efficient way to collect more than one trace type for a bundle. Pass a `tracerConfig` object keyed by tracer name, and each tracer's result is returned under its own key:
+
+```json muxTracer config
+{
+  "tracer": "muxTracer",
+  "tracerConfig": {
+    "callTracer": {
+      "onlyTopCall": true,
+      "withLog": false
+    },
+    "prestateTracer": {
+      "diffMode": true
+    }
+  }
+}
+```
+
+
+## Response
+
+* `result` — an array with one entry per bundle. Each entry is an array holding one trace per transaction in the bundle, in execution order. When `muxTracer` is used, each trace is an object keyed by tracer name—for example, `callTracer` and `prestateTracer`—each holding that tracer's output.
+
+
+## Use case
+
+`debug_traceCallMany` is essential for:
+
+* Simulating a sequence of dependent transactions—such as an approval followed by a swap—and inspecting how each call changes state before committing anything on-chain.
+* Forensic analysis of transaction bundles, where you need both the call tree and the prestate diff in one round trip via `muxTracer`.
+* MEV and risk tooling that pre-screens bundles against the current chain state.

--- a/reference/ethereum-tracetransaction.mdx
+++ b/reference/ethereum-tracetransaction.mdx
@@ -27,9 +27,12 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `4byteTracer` — tracer that captures the function signatures and call data sizes for all functions executed during a transaction, creating a map that links each selector and size combination to the number of times it occurred. This provides valuable information about the frequency and usage of each function within the transaction.
   + `callTracer` — tracer that captures information on all call frames executed during a transaction. The resulting nested list of call frames is organized into a tree structure that reflects the way the Ethereum Virtual Machine works and can be used for debugging and analysis purposes.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
+  + `flatCallTracer` — tracer that returns call traces in the flat, Parity-style format used by the `trace_*` namespace, as a flattened list of call frames rather than a nested tree.
+  + `muxTracer` — tracer that runs several native tracers in a single pass, configured via a `tracerConfig` object keyed by tracer name, returning each tracer's output under its own key.
+  + `erc7562Tracer` — tracer that enforces the ERC-7562 account-abstraction validation rules, tracking opcode and storage access during the validation phase of an ERC-4337 user operation.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/ethereum-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 
@@ -112,7 +115,7 @@ const ethers = require("ethers");
 const chainstack = new ethers.ChainstackProvider("mainnet");
 
 const traceTransaction = async (txhash) => {
-  // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+  // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
   const tracer = {};
   const traces = await chainstack.send("debug_traceTransaction", [
     txhash,
@@ -148,7 +151,7 @@ web3.registerPlugin(new TraceBlockPlugin());
 
 async function traceTransaction(txHash) {
 
-    // Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+    // Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
     const tracer = { tracer: 'callTracer' };
     const result = await web3.trace.traceTransaction(txHash, tracer);
     console.log(result);
@@ -164,7 +167,7 @@ web3 = Web3.HTTPProvider(node_url)
 
 tx_hash = "0x61ec8f42d408a4351a7aa1e341a7421bd42594d7752fb79962667614d6d12730"
 
-# Specify the type of tracer: 4byteTracer, callTracer, or prestateTracer. Leave empty {} for Struct/opcode logger.
+# Specify the type of tracer: 4byteTracer, callTracer, prestateTracer, or muxTracer. Leave empty {} for Struct/opcode logger.
 tracer = { "tracer": '4byteTracer' }
 tx_traces = web3.provider.make_request('debug_traceTransaction', [tx_hash, tracer])
 print(tx_traces)

--- a/reference/polygon-debug-trace-rpc-methods.mdx
+++ b/reference/polygon-debug-trace-rpc-methods.mdx
@@ -22,12 +22,12 @@ Developers can access the debug and trace tools with the following methods:
 <Card title="trace_block" href="/reference/polygon-trace_block" icon="angle-right" iconType="solid" horizontal />
 </CardGroup>
 
-## Pre-built JavaScript-based tracers
+## Pre-built native tracers
 
 <Info>
-  ### Custom tracers are available on customized dedicated nodes only
+  ### Custom JavaScript tracers need a dedicated node
 
-  Custom JavaScript tracers outside of the ones listed below are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
+  The tracers listed below are native (built-in) tracers—you select one by name. Custom JavaScript tracers, where you pass raw JavaScript as the `tracer`, are available as customized solutions on the [Enterprise plan](https://chainstack.com/pricing/) on [dedicated nodes](/docs/dedicated-node).
 </Info>
 
 Developers can customize the type of tracing using various debug and trace methods, and there are numerous pre-built tracers available to choose from. Further is a list of the pre-built tracers that can be utilized.

--- a/reference/polygon-tracecall.mdx
+++ b/reference/polygon-tracecall.mdx
@@ -46,7 +46,7 @@ See the [default block parameter](https://ethereum.org/en/developers/docs/apis/j
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/polygon-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/polygon-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 

--- a/reference/polygon-tracetransaction.mdx
+++ b/reference/polygon-tracetransaction.mdx
@@ -28,7 +28,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
   + `prestateTracer` — tracer with two modes: `prestate` and `diff`, where the former returns the accounts needed to execute a transaction, and the latter returns the differences between the pre and post-states of the transaction. The tracer operates by re-executing the transaction and tracking every state change made, resulting in an object with the account addresses as keys and the corresponding trie leaves as values.
 
 <Note>
-Find a complete [list of available built-in tracers](/reference/polygon-debug-trace-rpc-methods#pre-built-javascript-based-tracers) in the debug and trace overview.
+Find a complete [list of available built-in tracers](/reference/polygon-debug-trace-rpc-methods#pre-built-native-tracers) in the debug and trace overview.
 </Note>
 
 


### PR DESCRIPTION
## What

Documents the native tracers **muxTracer**, **flatCallTracer**, and **erc7562Tracer**, enabled on Ethereum (Mainnet, Sepolia, Hoodi) reth nodes via [masternodes PR #5389](https://github.com/chainstack/masternodes/pull/5389) ([INFRA-9799](https://chainstack.myjetbrains.com/youtrack/issue/INFRA-9799)). Originated from a [#product thread](https://chainstackhq.slack.com/archives/CHK4Q7MMK/p1781084087680819) where Blockaid requested `muxTracer` on shared infra.

## Scope

**Ethereum only** — every other EVM chain still runs the default allowlist (`4byteTracer`, `callTracer`, `prestateTracer`, `noopTracer`) and returns `-32612` for the three new tracers, so their overview pages are intentionally left unchanged.

## Changes

- **Ethereum debug/trace overview** — added the three tracers (each tagged "Available on Ethereum only"); renamed "Pre-built JavaScript-based tracers" → "Pre-built native tracers"; rewrote the dedicated-node callout to separate native (by-name) from custom raw-JavaScript tracers.
- **Ethereum per-method pages** (`debug_traceCall`, `debug_traceTransaction`, `debug_traceBlockByHash`, `debug_traceBlockByNumber`) — added the three tracers as individual param bullets + updated code comments.
- **New page** — `debug_traceCallMany` reference page + OpenAPI spec (the method Blockaid used), with a `muxTracer` example; added to nav and to `ethereum-methods.mdx`.
- **Limits** — restructured "Custom tracers on EVMs" into lists (universal defaults vs. Ethereum-only set) and documented the `-32612` payload.
- **Error reference** — added the `-32612` row (previously undocumented despite the live error pointing to `/docs/limits`).
- **Terminology + anchors** — applied the native-vs-JS heading fix to Avalanche/Polygon/Arbitrum overviews and repointed all 13 affected `#pre-built-native-tracers` anchors.
- **Bug fix** — corrected a pre-existing duplicate-method typo in the custom JS tracing guide.

## Verification

- All touched pages render 200 on `mintlify dev`; `docs.json` and the new OpenAPI spec validate.
- "Available on Ethereum only" tags confirmed absent from non-Ethereum pages.