### PR TITLE
docs: add create-a-node CTA to Safe custom RPC guide

### DIFF
--- a/docs/adding-a-custom-rpc-endpoint-to-safe.mdx
+++ b/docs/adding-a-custom-rpc-endpoint-to-safe.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Adding a custom RPC endpoint to Safe"
-description: "Point Safe at a Chainstack RPC endpoint. Safe doesn't add networks the way MetaMask does — instead you override the default RPC provider under Settings, so your Safe reads balances, builds, and broadcasts transactions through a node you control."
+description: "Point Safe at a Chainstack RPC endpoint. Safe doesn't add networks the way MetaMask does — instead you override the default RPC provider under Settings so the Safe app makes its on-chain reads through a node you control."
 ---
 
 **TLDR:**
 * Safe ships a fixed list of supported networks, so there's no "add network" flow — instead you override the default public RPC with your own endpoint.
 * The setting lives inside a Safe account — open or create a Safe first, then go to **Settings** > **Environment variables**, paste your Chainstack HTTPS endpoint into **RPC provider**, and click **Save**.
 * The override is stored locally in your browser, so the endpoint must match the network your Safe is deployed on.
+
+<CardGroup>
+  <Card title="Create a node on Chainstack" href="https://console.chainstack.com/" icon="server" horizontal>
+    Deploy an RPC node across 70+ protocols in minutes, then copy its HTTPS endpoint to use as your Safe RPC provider.
+  </Card>
+</CardGroup>
 
 ## Why override the RPC in Safe
 


### PR DESCRIPTION
## What

Follow-up to #417. Adds a prominent **create-a-node CTA** near the top of `docs/adding-a-custom-rpc-endpoint-to-safe.mdx`, linking to the [Chainstack console](https://console.chainstack.com/) — the primary action the guide depends on (you need a node endpoint before you can set it in Safe).

Also fixes the frontmatter `description`, which still carried the old overclaim ("reads balances, builds, and broadcasts transactions through a node you control") that was already corrected in the page body.

## Changes

- Add a `<CardGroup>` / `<Card>` CTA after the TLDR, matching the house pattern (horizontal card linking to the console).
- Correct the frontmatter description to "the Safe app makes its on-chain reads through a node you control."