### PR TITLE
docs: make Safe guide create-a-node card full width

### DIFF
--- a/docs/adding-a-custom-rpc-endpoint-to-safe.mdx
+++ b/docs/adding-a-custom-rpc-endpoint-to-safe.mdx
@@ -8,11 +8,9 @@ description: "Point Safe at a Chainstack RPC endpoint. Safe doesn't add networks
 * The setting lives inside a Safe account — open or create a Safe first, then go to **Settings** > **Environment variables**, paste your Chainstack HTTPS endpoint into **RPC provider**, and click **Save**.
 * The override is stored locally in your browser, so the endpoint must match the network your Safe is deployed on.
 
-<CardGroup>
-  <Card title="Create a node on Chainstack" href="https://console.chainstack.com/" icon="server" horizontal>
-    Deploy an RPC node across 70+ protocols in minutes, then copy its HTTPS endpoint to use as your Safe RPC provider.
-  </Card>
-</CardGroup>
+<Card title="Create a node on Chainstack" href="https://console.chainstack.com/" icon="server" horizontal>
+  Deploy an RPC node across 70+ protocols in minutes, then copy its HTTPS endpoint to use as your Safe RPC provider.
+</Card>
 
 ## Why override the RPC in Safe
 


### PR DESCRIPTION
## What

Follow-up to #418. The create-a-node CTA card was wrapped in a `<CardGroup>`, which lays out a 2-column grid — a single card filled only one column and left empty space to the right.

Switches to a standalone `<Card>` so the CTA spans the full content width.