### PR TITLE
docs: add eth_sendRawTransactionSync reference page for Arbitrum

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2762,7 +2762,8 @@
                 "pages": [
                   "reference/arbitrum-evm-excecution-rpc-methods",
                   "reference/arbitrum-ethcall",
-                  "reference/arbitrum-sendrawtransaction"
+                  "reference/arbitrum-sendrawtransaction",
+                  "reference/arbitrum-sendrawtransactionsync"
                 ]
               },
               {

--- a/docs/arbitrum-methods.mdx
+++ b/docs/arbitrum-methods.mdx
@@ -47,6 +47,7 @@ See also [interactive Arbitrum API call examples](/reference/arbitrum-getting-st
 | eth\_uninstallFilter                     | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_unsubscribe                         | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_sendRawTransaction                  | <Icon icon="square-check"  iconType="solid" />            |         |
+| eth\_sendRawTransactionSync              | <Icon icon="square-check"  iconType="solid" />            |         |
 | net\_listening                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | net\_peerCount                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | net\_version                             | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransactionSync.json
+++ b/openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransactionSync.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "eth_sendRawTransactionSync example",
+    "version": "1.0.0",
+    "description": "This is an API example for eth_sendRawTransactionSync, a method to submit a pre-signed transaction and wait synchronously for the transaction receipt or timeout. Based on EIP-7966."
+  },
+  "servers": [
+    {
+      "url": "https://nd-000-364-211.p2pify.com"
+    }
+  ],
+  "paths": {
+    "/5b8d22690a57f293b3a1ed8758014e35": {
+      "post": {
+        "tags": [
+          "Ethereum Operations"
+        ],
+        "summary": "eth_sendRawTransactionSync",
+        "operationId": "sendRawTransactionSync",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "method",
+                  "id",
+                  "params"
+                ],
+                "properties": {
+                  "jsonrpc": {
+                    "type": "string",
+                    "default": "2.0"
+                  },
+                  "method": {
+                    "type": "string",
+                    "default": "eth_sendRawTransactionSync"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "default": 1
+                  },
+                  "params": {
+                    "type": "array",
+                    "default": [
+                      "0x02f86c82a4b1808398968084026b52e08307a1209468ba9f225b431dd66fdb0ad96a03c6a2f9a8124e8080c001a0f60d47b1eb93369d93a3b8ee1031a006ba23f1a247267f03e8b1c3140d6659f0a00d9af7a27561b62cd8155e4ad5be797b8e8e66b99a6ec476768980547dd8a9af"
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "examples": {
+                "example1": {
+                  "summary": "Submit raw transaction with hex-encoded timeout",
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_sendRawTransactionSync",
+                    "params": [
+                      "0x02f86c82a4b1808398968084026b52e08307a1209468ba9f225b431dd66fdb0ad96a03c6a2f9a8124e8080c001a0f60d47b1eb93369d93a3b8ee1031a006ba23f1a247267f03e8b1c3140d6659f0a00d9af7a27561b62cd8155e4ad5be797b8e8e66b99a6ec476768980547dd8a9af",
+                      "0x1388"
+                    ],
+                    "id": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful transaction submission with receipt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonrpc": {
+                      "type": "string",
+                      "example": "2.0"
+                    },
+                    "id": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "transactionHash": {
+                          "type": "string",
+                          "example": "0x6d72fa49665671891a9ca899e09e8b8032638b2e18a1519f571e4fcff42bcbe1"
+                        },
+                        "blockHash": {
+                          "type": "string",
+                          "example": "0xed81ff21dc9e8fcfa128f878466207c577fbdf8e4d1558c8db21082a9fb0dea6"
+                        },
+                        "blockNumber": {
+                          "type": "string",
+                          "example": "0x1c3d930c"
+                        },
+                        "gasUsed": {
+                          "type": "string",
+                          "example": "0x57af"
+                        },
+                        "gasUsedForL1": {
+                          "type": "string",
+                          "example": "0x5a7"
+                        },
+                        "l1BlockNumber": {
+                          "type": "string",
+                          "example": "0x182699e"
+                        },
+                        "status": {
+                          "type": "string",
+                          "example": "0x1"
+                        },
+                        "timeboosted": {
+                          "type": "boolean",
+                          "example": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/arbitrum-sendrawtransactionsync.mdx
+++ b/reference/arbitrum-sendrawtransactionsync.mdx
@@ -1,0 +1,45 @@
+---
+title: eth_sendRawTransactionSync | Arbitrum
+openapi: /openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransactionSync.json
+  POST /5b8d22690a57f293b3a1ed8758014e35
+description: "Arbitrum API method that submits a signed transaction and blocks until the transaction receipt is returned or the timeout expires."
+---
+
+Arbitrum API method `eth_sendRawTransactionSync` allows for the submission of a pre-signed transaction to the Arbitrum network and waits synchronously for the transaction receipt or a configurable timeout. This method reduces transaction submission latency by combining transaction submission and receipt retrieval into a single RPC call, based on [EIP-7966](https://eips.ethereum.org/EIPS/eip-7966).
+
+<Check>
+**Get your own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+
+## Parameters
+
+* `signedTransactionData` — the signed transaction data in hexadecimal format. This data includes the transaction details such as nonce, gas price, gas limit, to address, value, data, and the signature.
+* `timeout` (optional) — maximum time to wait for the transaction receipt, in milliseconds, passed as a `0x`-prefixed hex-encoded quantity, for example `0x1388` for 5000 ms. If omitted, the node's default applies (20 seconds in the standard Nitro configuration). Requests above the node's maximum (60 seconds by default) are silently capped to the maximum rather than rejected.
+
+<Note>
+Although [EIP-7966](https://eips.ethereum.org/EIPS/eip-7966) defines `timeout` as a plain integer, Arbitrum Nitro—a [go-ethereum](https://github.com/OffchainLabs/go-ethereum) fork—types it as a hex-encoded quantity (`hexutil.Uint64`), so you must pass it as a `0x`-prefixed hex string. Plain integers (`5000`) and non-hex strings (`"5000"`) are rejected with an `invalid argument 1` error.
+</Note>
+
+## Response
+
+* `result` — the complete transaction receipt object, the same structure returned by [eth_getTransactionReceipt](/reference/arbitrum-gettransactionreceipt): transaction hash, block information, gas usage, contract address (if applicable), logs, and status. If the timeout elapses before the transaction is mined, the call returns an error instead of a receipt.
+
+Alongside the standard receipt fields, Arbitrum includes:
+
+* `gasUsedForL1` — the amount of gas spent on parent chain (L1) calldata, in units of child chain gas.
+* `l1BlockNumber` — the block number of the first non-Arbitrum ancestor chain, usable for `block.number` calls.
+* `timeboosted` — `true` if the transaction was sequenced through the Arbitrum [Timeboost](https://docs.arbitrum.io/how-arbitrum-works/timeboost/gentle-introduction) express lane, `false` otherwise.
+
+## Use case
+
+The `eth_sendRawTransactionSync` method is particularly useful for:
+
+* High-frequency applications requiring immediate transaction confirmation feedback.
+* Layer 2 solutions with fast block times where rapid transaction throughput is critical.
+* DApps and wallets seeking to improve user experience with faster transaction confirmations.
+* Trading applications where transaction latency directly impacts performance.
+* Applications requiring stronger delivery guarantees than standard asynchronous transaction submission.


### PR DESCRIPTION
## What

Adds the `eth_sendRawTransactionSync` JSON-RPC method to the Arbitrum doc stack:

- New reference page `reference/arbitrum-sendrawtransactionsync.mdx` (with interactive playground)
- New OpenAPI spec `openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransactionSync.json`
- Nav entry under **Executing transactions | Arbitrum** in `docs.json`
- Row added to the `docs/arbitrum-methods` support matrix

## Why

Requested by the Arbitrum/Offchain Labs team in `#ext-arbitrum`. The method has been supported on Arbitrum since **Nitro v3.10.0** (go-ethereum v1.16.7 merge), but it was missing from our docs — so readers who saw it documented for Ethereum, Base, Optimism, and Polygon but not Arbitrum reasonably assumed it was unsupported.

## Accuracy notes

Researched against EIP-7966, the OffchainLabs/go-ethereum source, and docs.arbitrum.io, then verified end-to-end on **Arbitrum One mainnet**:

- **Synchronous full receipt** returned in a single call ✓
- Arbitrum-specific receipt fields documented: `gasUsedForL1`, `l1BlockNumber`, `timeboosted` ✓
- **`timeout` must be a `0x`-prefixed hex string** (`hexutil.Uint64`). Unlike Base/Optimism/Polygon and the EIP-7966 spec (plain integer), Arbitrum Nitro rejects a plain integer with `invalid argument 1`. This divergence is called out in a `<Note>` on the page.
- Default timeout 20s / max 60s (silently capped, not rejected) — from go-ethereum `TxSyncDefaultTimeout`/`TxSyncMaxTimeout`.

Verification tx: https://arbiscan.io/tx/0x439f719c74cbee6a01006d8d98fd54022990f34bc28921a270e34e571abfacb5