### PR TITLE
Add MCP to left-nav anchors; promote llms-full.txt and drop llms.txt link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3838,6 +3838,16 @@
     "global": {
       "anchors": [
         {
+          "anchor": "MCP",
+          "href": "/docs/chainstack-mcp-server",
+          "icon": "plug"
+        },
+        {
+          "anchor": "llms-full.txt",
+          "href": "https://docs.chainstack.com/llms-full.txt",
+          "icon": "brain"
+        },
+        {
           "anchor": "Status",
           "href": "https://status.chainstack.com/",
           "icon": "signal"
@@ -3856,16 +3866,6 @@
           "anchor": "Blog",
           "href": "https://chainstack.com/blog/",
           "icon": "newspaper"
-        },
-        {
-          "anchor": "llms.txt",
-          "href": "https://docs.chainstack.com/llms.txt",
-          "icon": "sparkle"
-        },
-        {
-          "anchor": "llms-full.txt",
-          "href": "https://docs.chainstack.com/llms-full.txt",
-          "icon": "brain"
         }
       ]
     }


### PR DESCRIPTION
## What

Reorders the global left-pane anchors in `docs.json`:

1. **MCP** (new) → `/docs/chainstack-mcp-server`
2. **llms-full.txt** (promoted)
3. Status · Discord · Telegram · Blog (unchanged)
- **llms.txt** anchor removed

Nav-only change — no page content touched.

## Why

Q2 docs analytics showed site search is heavily used as a chatbot: the top two queries by volume are conversational (`can I ask `, `I ask you a question please?`), all 0% CTR. Putting the **MCP server at the #1 anchor** gives that audience a real AI-native entry point.

## Removing the llms.txt link is safe

- The anchor is just a nav link; the file is auto-generated by Mintlify and served at `/llms.txt` regardless (verified live: HTTP 200, ~100 KB).
- Q2: `/llms.txt` saw ~10.7k views but **~1 human unique visitor** — agents fetch it by the well-known URL, not via the sidebar. The link drives ≈0 clicks, so removing it loses no traffic. The file is untouched and remains the #2 most-fetched URL.

## To verify
- `mint dev` to confirm the **MCP** anchor (relative href) renders and links correctly before merge.
