### PR TITLE
Use the official MCP logo for the MCP nav anchor

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3840,7 +3840,7 @@
         {
           "anchor": "MCP",
           "href": "/docs/chainstack-mcp-server",
-          "icon": "plug"
+          "icon": "/images/mcp.svg"
         },
         {
           "anchor": "llms-full.txt",

--- a/images/mcp.svg
+++ b/images/mcp.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Official Model Context Protocol mark, monochrome. stroke="currentColor" so it follows the sidebar text color in light/dark. -->
+  <path d="M23.5996 85.2532L86.2021 22.6507C94.8457 14.0071 108.86 14.0071 117.503 22.6507C126.147 31.2942 126.147 45.3083 117.503 53.9519L70.2254 101.23" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
+  <path d="M70.8789 100.578L117.504 53.952C126.148 45.3083 140.163 45.3083 148.806 53.952L149.132 54.278C157.776 62.9216 157.776 76.9357 149.132 85.5792L92.5139 142.198C89.6327 145.079 89.6327 149.75 92.5139 152.631L104.14 164.257" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
+  <path d="M101.853 38.3013L55.553 84.6011C46.9094 93.2447 46.9094 107.258 55.553 115.902C64.1966 124.546 78.2106 124.546 86.8543 115.902L133.154 69.6025" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Swaps the `plug` placeholder on the **MCP** left-nav anchor for the **official Model Context Protocol mark**.

## Change
- Adds `images/mcp.svg` — the official MCP mark (sourced from the MCP project's `favicon.svg`), with the background box removed and strokes set to `currentColor`.
- Points the MCP anchor `icon` at `/images/mcp.svg`.

## Why `currentColor`
Anchor icons render in the sidebar's text color and flip with the light/dark theme — the same way the adjacent Font Awesome icons (Status, Discord, …) do. Drawing the mark with `stroke="currentColor"` makes it inherit that color instead of being a fixed black/white, so it stays legible in both themes.

## To verify (please eyeball the preview)
This is the site's first custom-SVG nav icon, so confirm on the Mintlify **preview deployment** for this PR:
- The MCP mark renders in the left pane (top anchor).
- It's visible and correctly colored in **both light and dark** mode.

If it doesn't tint with the theme (e.g. shows black in dark mode), I'll fall back to a theme-neutral fill or a Font Awesome icon.
