### PR TITLE
Revert MCP anchor to the Font Awesome plug icon

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3840,7 +3840,7 @@
         {
           "anchor": "MCP",
           "href": "/docs/chainstack-mcp-server",
-          "icon": "/images/mcp.svg"
+          "icon": "plug"
         },
         {
           "anchor": "llms-full.txt",

--- a/images/mcp.svg
+++ b/images/mcp.svg
@@ -1,6 +1,0 @@
-<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Official Model Context Protocol mark, monochrome. stroke="currentColor" so it follows the sidebar text color in light/dark. -->
-  <path d="M23.5996 85.2532L86.2021 22.6507C94.8457 14.0071 108.86 14.0071 117.503 22.6507C126.147 31.2942 126.147 45.3083 117.503 53.9519L70.2254 101.23" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
-  <path d="M70.8789 100.578L117.504 53.952C126.148 45.3083 140.163 45.3083 148.806 53.952L149.132 54.278C157.776 62.9216 157.776 76.9357 149.132 85.5792L92.5139 142.198C89.6327 145.079 89.6327 149.75 92.5139 152.631L104.14 164.257" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
-  <path d="M101.853 38.3013L55.553 84.6011C46.9094 93.2447 46.9094 107.258 55.553 115.902C64.1966 124.546 78.2106 124.546 86.8543 115.902L133.154 69.6025" stroke="currentColor" stroke-width="11.0667" stroke-linecap="round"/>
-</svg>


### PR DESCRIPTION
Reverts #422.

The official MCP SVG renders as an **accent-colored tile** in the sidebar anchor — Mintlify wraps custom image icons in a filled rounded box (bright blue in light mode, near-invisible dark in dark mode), which clashes with the flat Font Awesome icons next to it (Status, Discord, …).

This restores the `plug` glyph, which renders as a clean flat icon and themes correctly, and removes the now-unused `images/mcp.svg`.
