### PR TITLE
docs: add dedicated node options for additional chains

### DIFF
--- a/docs/dedicated-node.mdx
+++ b/docs/dedicated-node.mdx
@@ -7,6 +7,8 @@ description: "Learn about Chainstack dedicated nodes with exclusive compute reso
 
 A dedicated node is a node that exclusively deployed for and belongs to a particular customer, with its compute resources are not being shared with anybody else. Such nodes are highly customizable and can offer more additional services than other node types. This means that each dedicated node can be configured to perfectly match the case and needs of a particular customer.
 
+For the full list of chains available as dedicated nodes, see [Networks](/docs/protocols-networks).
+
 <Info>
   ### Dedicated node plans
 

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -6,7 +6,7 @@ description: Browse available cloud providers, regions, and geographic locations
 <Info>
   ### Dedicated nodes are also available
 
-  Dedicated nodes are also available for the chains not listed here. For the full list, see the [Dedicated Node](/docs/dedicated-node) page.
+  Dedicated nodes are also available for the chains not listed here. For the full list, see the [Networks](/docs/protocols-networks) page.
 </Info>
 
 <Info>

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -13,18 +13,18 @@ description: Browse all supported blockchain networks on Chainstack including Et
 
 | Chain | Support | Elastic Mainnet Support | Elastic Testnet Support | Testnet networks | Debug and Trace | Deploy node |
 |-------|---------|-------------------------|--------------------------|------------------|-----------------|-------------|
-| AB Chain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| ADIchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Apechain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |
+| AB Chain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| ADIchain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Apechain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |
 | Aptos | Elastic, Dedicated | Full, Archive | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Arbitrum | Elastic, Dedicated | Full, Archive | Full, Archive | Arbitrum Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Astar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-astar/#request) |
+| Astar | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-astar/#request) |
 | Avalanche | Elastic, Dedicated | Full, Archive | Full, Archive | Fuji Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| B^2 | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-b2/#request) |
+| B^2 | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-b2/#request) |
 | Base | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Berachain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Bitcoin | Elastic, Dedicated | Full | Full | Signet, Testnet | No | [Deploy through platform](https://console.chainstack.com) |
-| Bitlayer | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-bitlayer/#request) |
+| Bitlayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-bitlayer/#request) |
 | Bittensor | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Blast | Elastic | Full, Archive | - | - | Yes | - |
 | BNB Smart Chain | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
@@ -32,78 +32,78 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Celestia | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Celo | Elastic, Dedicated | Full, Archive | Full | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Centrifuge | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-centrifuge/#request) |
-| Core | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-core/#request) |
-| Corn | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-corn/#request) |
+| Core | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-core/#request) |
+| Corn | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-corn/#request) |
 | Cronos | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Cronos zkEVM | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Cronos zkEVM | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Dogecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-dogecoin/#request) |
 | dYdX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Etherlink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-etherlink/#request) |
+| Etherlink | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-etherlink/#request) |
 | Ethereum | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet, Hoodi Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Everclear | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Everclear | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fantom | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Filecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Fluent | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Fraxchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-fraxchain/#request) |
+| Fluent | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Fraxchain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-fraxchain/#request) |
 | Gnosis Chain | Elastic, Dedicated | Full, Archive | Full | Chiado Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Harmony | Elastic, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
-| Hashkey | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-hashkey/#request) |
+| Hashkey | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-hashkey/#request) |
 | Hedera | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Hemi | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Hemi | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Hyperliquid | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Ink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-ink/#request) |
-| Jovay | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Ink | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-ink/#request) |
+| Jovay | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Kaia | Elastic, Dedicated | Full | Full | Kairos Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Katana | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-katana/#request) |
-| Kroma | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-kroma/#request) |
-| L3X | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Lens | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-lens/#request) |
+| Katana | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-katana/#request) |
+| Kroma | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-kroma/#request) |
+| L3X | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Lens | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-lens/#request) |
 | Linea | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Litecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Mantle | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | MegaETH | Elastic, Dedicated | Archive | - | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Merlin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-merlin/#request) |
-| Metis | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-metis/#request) |
-| Mind | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-mind/#request) |
-| Mint | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-mint/#request) |
+| Merlin | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-merlin/#request) |
+| Metis | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-metis/#request) |
+| Mind | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-mind/#request) |
+| Mint | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-mint/#request) |
 | Monad | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Moonbeam | Elastic | Full, Archive | - | - | Yes | - |
 | NEAR | Dedicated | - | - | Testnet | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| NeoX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| NeoX | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Oasis Sapphire | Elastic | Full | Full | Testnet | No | - |
 | opBNB | Elastic | Full | - | - | Yes | - |
 | Optimism | Elastic, Dedicated | Full, Archive | Full, Archive | Optimism Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Pharos | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Pharos | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Plasma | Elastic, Dedicated | Archive | Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Plume | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-plume/#request) |
+| Plume | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-plume/#request) |
 | Polkadot | Elastic, Dedicated | Full, Archive | - | - | No | [Deploy through platform](https://console.chainstack.com) |
 | Polygon | Elastic, Dedicated | Full, Archive | Full, Archive | Amoy Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Polygon zkEVM | Elastic, Dedicated | Full, Archive | - | - | No | [Deploy through platform](https://console.chainstack.com) |
 | Ronin | Elastic, Dedicated | Full, Archive | Full, Archive | Saigon Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Scroll | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Shibarium | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-shibarium/#request) |
+| Shibarium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-shibarium/#request) |
 | Solana | Elastic, Dedicated | Full, Archive | Full, Archive | Devnet | No | [Deploy through platform](https://console.chainstack.com) |
-| Soneium | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
+| Soneium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Elastic, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Sui | Elastic, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
-| Superseed | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Superseed | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Taiko | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
+| Taiko | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
 | Tempo | Elastic, Dedicated | Full, Archive | Full, Archive | Moderato Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Tezos | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TON | Elastic, Dedicated | Archive | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
-| Treasure | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Treasure | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TRON | Elastic, Dedicated | Full, Archive | Full | Nile Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Unichain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Vana | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| WEMIX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
-| XDC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| XLayer | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
+| Vana | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| WEMIX | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
+| XDC | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| XLayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
 | Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Zircuit | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-zircuit/#request) |
-| zkLink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-zklink/#request) |
+| Zircuit | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-zircuit/#request) |
+| zkLink | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-zklink/#request) |
 | ZKsync Era | Elastic, Dedicated | Full, Archive | Full, Archive | zkSync Era Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Zora | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -37,11 +37,13 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Cronos | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Cronos zkEVM | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Dogecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-dogecoin/#request) |
+| dYdX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Etherlink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-etherlink/#request) |
 | Ethereum | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet, Hoodi Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Everclear | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fantom | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Filecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Fluent | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fraxchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-fraxchain/#request) |
 | Gnosis Chain | Elastic, Dedicated | Full, Archive | Full | Chiado Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Harmony | Elastic, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
@@ -66,6 +68,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Mint | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-mint/#request) |
 | Monad | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Moonbeam | Elastic | Full, Archive | - | - | Yes | - |
+| NEAR | Dedicated | - | - | Testnet | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | NeoX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Oasis Sapphire | Elastic | Full | Full | Testnet | No | - |
 | opBNB | Elastic | Full | - | - | Yes | - |
@@ -83,6 +86,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Soneium | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Elastic, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Sui | Elastic, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Superseed | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -13,6 +13,8 @@ description: Browse all supported blockchain networks on Chainstack including Et
 
 | Chain | Support | Elastic Mainnet Support | Elastic Testnet Support | Testnet networks | Debug and Trace | Deploy node |
 |-------|---------|-------------------------|--------------------------|------------------|-----------------|-------------|
+| AB Chain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| ADIchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Apechain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |
 | Aptos | Elastic, Dedicated | Full, Archive | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Arbitrum | Elastic, Dedicated | Full, Archive | Full, Archive | Arbitrum Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
@@ -23,6 +25,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Berachain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Bitcoin | Elastic, Dedicated | Full | Full | Signet, Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Bitlayer | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-bitlayer/#request) |
+| Bittensor | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Blast | Elastic | Full, Archive | - | - | Yes | - |
 | BNB Smart Chain | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Cardano | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-cardano/#request) |
@@ -36,6 +39,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Dogecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-dogecoin/#request) |
 | Etherlink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-etherlink/#request) |
 | Ethereum | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet, Hoodi Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Everclear | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fantom | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Filecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Fraxchain | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-fraxchain/#request) |
@@ -46,12 +50,14 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Hemi | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Hyperliquid | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Ink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-ink/#request) |
+| Jovay | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Kaia | Elastic, Dedicated | Full | Full | Kairos Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Katana | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-katana/#request) |
 | Kroma | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-kroma/#request) |
 | L3X | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Lens | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-lens/#request) |
 | Linea | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Litecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Mantle | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | MegaETH | Elastic, Dedicated | Archive | - | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Merlin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-merlin/#request) |
@@ -64,6 +70,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Oasis Sapphire | Elastic | Full | Full | Testnet | No | - |
 | opBNB | Elastic | Full | - | - | Yes | - |
 | Optimism | Elastic, Dedicated | Full, Archive | Full, Archive | Optimism Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Pharos | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Plasma | Elastic, Dedicated | Archive | Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Plume | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-plume/#request) |
 | Polkadot | Elastic, Dedicated | Full, Archive | - | - | No | [Deploy through platform](https://console.chainstack.com) |
@@ -77,17 +84,25 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Sonic | Elastic, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Sui | Elastic, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
+| Superseed | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Taiko | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
 | Tempo | Elastic, Dedicated | Full, Archive | Full, Archive | Moderato Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Tezos | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TON | Elastic, Dedicated | Archive | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Treasure | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TRON | Elastic, Dedicated | Full, Archive | Full | Nile Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Unichain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Vana | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | WEMIX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
 | XDC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | XLayer | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
+| Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Zircuit | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-zircuit/#request) |
 | zkLink | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-zklink/#request) |
 | ZKsync Era | Elastic, Dedicated | Full, Archive | Full, Archive | zkSync Era Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Zora | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+
+<Note>
+  Chainstack also deploys bespoke dedicated nodes for chains not listed here. [Contact us](https://chainstack.com/contact/) to discuss your chain.
+</Note>

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3547,6 +3547,84 @@
       },
       "testnets": [],
       "additional_notes": "Dedicated nodes only"
+    },
+    "dYdX": {
+      "protocol_name": "dYdX",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Fluent": {
+      "protocol_name": "Fluent",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "NEAR": {
+      "protocol_name": "NEAR",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "N/A",
+          "locations": []
+        }
+      ],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Stellar": {
+      "protocol_name": "Stellar",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
     }
   }
 }

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3349,6 +3349,204 @@
         }
       ],
       "additional_notes": "Tempo is a Reth-based blockchain. Debug and trace methods available."
+    },
+    "AB Chain": {
+      "protocol_name": "AB Chain",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "ADIchain": {
+      "protocol_name": "ADIchain",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Bittensor": {
+      "protocol_name": "Bittensor",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Everclear": {
+      "protocol_name": "Everclear",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Jovay": {
+      "protocol_name": "Jovay",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Litecoin": {
+      "protocol_name": "Litecoin",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Pharos": {
+      "protocol_name": "Pharos",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Superseed": {
+      "protocol_name": "Superseed",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Tezos": {
+      "protocol_name": "Tezos",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Vana": {
+      "protocol_name": "Vana",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
+    },
+    "Zcash": {
+      "protocol_name": "Zcash",
+      "supported_modes": [
+        "N/A"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Contact us",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [],
+      "additional_notes": "Dedicated nodes only"
     }
   }
 }

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1,6 +1,9 @@
 {
   "metadata": {
-    "description": "Unified master data for Chainstack nodes availability & configurations"
+    "description": "Unified master data for Chainstack nodes availability & configurations",
+    "notes": {
+      "debug_and_trace": "For dedicated-only networks (Support = Dedicated; deployed on request, no Global/Trader presence), set Debug and Trace to Yes when the network is EVM-compatible, and No otherwise. Example: Apechain (EVM) = Yes; Bitcoin, Solana, Cardano (non-EVM) = No."
+    }
   },
   "node_type_definitions": {
     "global": {
@@ -2489,7 +2492,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2507,7 +2510,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2525,7 +2528,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2543,7 +2546,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2597,7 +2600,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2615,7 +2618,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2633,7 +2636,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2669,7 +2672,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2705,7 +2708,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2723,7 +2726,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2759,7 +2762,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2777,7 +2780,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2795,7 +2798,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2813,7 +2816,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2831,7 +2834,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2849,7 +2852,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2867,7 +2870,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2885,7 +2888,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2903,7 +2906,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2921,7 +2924,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2939,7 +2942,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2957,7 +2960,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2975,7 +2978,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -2993,7 +2996,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3011,7 +3014,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3029,7 +3032,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3047,7 +3050,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3083,7 +3086,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3154,7 +3157,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3242,7 +3245,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3260,7 +3263,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3357,7 +3360,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3375,7 +3378,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3411,7 +3414,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3429,7 +3432,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3465,7 +3468,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3483,7 +3486,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3519,7 +3522,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {
@@ -3573,7 +3576,7 @@
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
-      "debug_trace_available": false,
+      "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Contact us",
       "mainnet": {


### PR DESCRIPTION
## What

Add 11 chains as dedicated node options and surface them on the Networks page:

AB Chain, ADIchain, Bittensor, Everclear, Jovay, Litecoin, Pharos, Superseed, Tezos, Vana, Zcash.

## Changes

- `node-options-master-list.json` — 11 new dedicated-only entries (`dedicated_node_availability: "Contact us"`), matching the existing dedicated-only convention.
- `protocols-networks.mdx` — regenerated table with the 11 chains (Support: Dedicated → Request deployment), plus a note that additional chains are available as dedicated nodes on request.
- `nodes-clouds-regions-and-locations.mdx` — the "dedicated nodes are also available" note now links to [Networks](/docs/protocols-networks) (which has the full list) instead of the Dedicated Node page.
- `dedicated-node.mdx` — added a link to [Networks](/docs/protocols-networks).

## Notes

- The clouds & locations tables are unchanged: dedicated-only chains carry no location data, so they add no rows there.
