### PR TITLE
docs(compare): repoint Compare links and refresh for relaunch

### DIFF
--- a/docs/chainstack-compare-dashboard.mdx
+++ b/docs/chainstack-compare-dashboard.mdx
@@ -5,8 +5,9 @@ description: Analyze and compare blockchain RPC node performance metrics across 
 
 **TLDR**:
 
-* The Chainstack Compare Dashboard provides real-time performance metrics (response times, success rates, transaction confirmation) for major RPC providers across multiple blockchains and regions.
-* Built with Vercel (data collection) and Grafana Cloud (dashboards), it keeps data refreshed every minute with 14 days of history.
+* Chainstack Compare provides real-time RPC provider performance — availability, latency (P50/P95/P99), success rates, and transaction confirmation — for major providers across multiple blockchains and regions.
+* Built with Vercel (data collection) and Grafana Cloud (dashboards), it refreshes data every 1–3 minutes and keeps 14 days of history.
+* The landing page ranks providers at a glance per network; one more click opens the full Grafana dashboard with per-method and per-region breakdowns.
 * The ranking system prioritizes fast, reliable providers, while special metrics (e.g., transaction landing on Solana) help fine-tune your choice of provider.
 * Fork the GitHub repository for full technical details and customization of this open dashboard solution.
 
@@ -14,7 +15,7 @@ description: Analyze and compare blockchain RPC node performance metrics across 
 
 Choosing the right RPC provider for your blockchain or trading project can be challenging. Performance varies by region and protocol, and it changes over time. How do you make an informed decision?
 
-[Chainstack Compare Dashboard](https://chainstack.grafana.net/public-dashboards/65c0fcb02f994faf845d4ec095771bd0) solves this problem by providing real-time performance data for major RPC providers across different regions and blockchains. The dashboard has been built with the help of Vercel (Pro plan) and Grafana Cloud (Free plan). You can either use the dashboard hosted by Chainstack or fork the [GitHub repository](https://github.com/chainstacklabs/chainstack-rpc-dashboard-functions) and customize it to your needs.
+[Chainstack Compare](https://compare.chainstack.com/) solves this problem by providing real-time performance data for major RPC providers across different regions and blockchains. The dashboard has been built with the help of Vercel (Pro plan) and Grafana Cloud (Free plan). You can either use the dashboard hosted by Chainstack or fork the [GitHub repository](https://github.com/chainstacklabs/chainstack-rpc-dashboard-functions) and customize it to your needs.
 
 <Info>
   ### Run nodes on Chainstack
@@ -24,37 +25,38 @@ Choosing the right RPC provider for your blockchain or trading project can be ch
 
 ## Solution overview
 
-The solution consists of the two main components: data collection services and dashboard. The data collection service sends API calls to all providers, measures response times, and pushes collected data to the dashboard every minute.
+The solution consists of the two main components: data collection services and dashboard. The data collection service sends API calls to all providers, measures response times, and pushes collected data to the dashboard every 1–3 minutes.
 
 The data collection service only records response times and marks requests based on whether they were successful or not. All calculations, including averages and other aggregated values, are performed by the dashboard.
 
 ### Quick start
 
-1. Visit the [dashboard](https://chainstack.grafana.net/public-dashboards/65c0fcb02f994faf845d4ec095771bd0?orgId=1)
+1. Visit [Chainstack Compare](https://compare.chainstack.com/)
 
-2. Select your blockchain network
+2. Select your blockchain network — Ethereum, Solana, BNB Chain, Arbitrum, Base, TON, Hyperliquid, or Monad
 
-3. Choose your region of interest
+3. Review the provider ranking, availability, and latency (P50/P95/P99) per region, and switch between the 24h and 7d windows
 
-4. Review performance metrics
+4. For per-method breakdowns and success rates, open the linked Grafana dashboard
 ### What you can do
 
 With Chainstack Compare Dashboard, you can:
 
-1. Compare RPC provider performance across regions
+1. Compare RPC provider availability and latency (P50/P95/P99) across regions
 2. Monitor response times and success rates
-3. Monitor transaction confirmation metrics (only for Solana)
+3. Open per-method breakdowns in the Grafana dashboard
+4. Monitor transaction confirmation metrics (Solana only)
 
 The dashboard currently supports:
 
-* Blockchains: Ethereum, Base, Solana, TON
-* Regions: US West, Germany, Singapore
-* Providers: Alchemy, Chainstack, QuickNode, Helius, TonCenter
+* Blockchains: Ethereum, Solana, BNB Chain, Arbitrum, Base, TON, Hyperliquid, Monad
+* Regions: United States, Germany, Singapore
+* Providers (vary by network): Alchemy, Chainstack, QuickNode, Helius, dRPC, TonCenter
 
 <Info>
   ### Data and paid tiers
 
-  All metrics, except for the transaction landing metrics, are updated every minute, with 14 days of historical data available. The transaction landing metrics are updated every 15 minutes.
+  All metrics, except for the transaction landing metrics, are updated every 1–3 minutes, with 14 days of historical data available. The transaction landing metrics are updated every 15 minutes.
 
   For the dashboard, we used paid tiers of the mentioned providers, except for TonCenter where we used the free tier.
 </Info>
@@ -101,7 +103,7 @@ We added a few enhanced endpoints for providers which offer such services. Enhan
 
 ### Vercel: data collection services
 
-We chose Vercel as our hosting solution due to its simplicity and time-to-production. The [data collection services](https://github.com/chainstacklabs/chainstack-rpc-dashboard-functions) are Vercel serverless functions deployed to multiple regions. Metrics for each blockchain are collected by a dedicated function which is triggered by Vercel cron jobs every minute. Once data is collected, it is pushed to a Grafana Cloud Prometheus instance.
+We chose Vercel as our hosting solution due to its simplicity and time-to-production. The [data collection services](https://github.com/chainstacklabs/chainstack-rpc-dashboard-functions) are Vercel serverless functions deployed to multiple regions. Metrics for each blockchain are collected by a dedicated function which is triggered by Vercel cron jobs every 1–3 minutes. Once data is collected, it is pushed to a Grafana Cloud Prometheus instance.
 
 The service has the following performance thresholds:
 
@@ -135,19 +137,19 @@ For developers interested in the technical implementation and contribution to th
 ## FAQ
 <AccordionGroup>
   <Accordion title="What providers do you monitor?">
-    Alchemy, Chainstack, QuickNode, Helius, and TonCenter. Paid tiers (except for TonCenter).
+    Alchemy, Chainstack, QuickNode, Helius, dRPC, and TonCenter. Paid tiers (except for TonCenter). Provider coverage varies by network.
   </Accordion>
   <Accordion title="Why do I need this dashboard?">
     It helps choose the right RPC provider based on real data and monitor their performance across regions.
   </Accordion>
   <Accordion title="How often is data updated?">
-    Every minute. Transaction landing metrics is updated every 15 minutes.
+    Every 1–3 minutes; the landing page refreshes every 3 minutes. Transaction landing metrics update every 15 minutes.
   </Accordion>
   <Accordion title="What counts as a failed request?">
     Any response slower than 55 seconds, non-200 status codes, or responses containing error messages (as per JSON-RPC specification). For blocks, delays over 55 seconds count as failures.
   </Accordion>
   <Accordion title="Can I see historical data?">
-    Yes, dashboards keep 14 days of performance history.
+    Yes. The landing page shows 24h and 7d views, and the Grafana dashboard keeps 14 days of performance history.
   </Accordion>
   <Accordion title="How do you collect the metrics?">
     We use serverless functions in three regions, measuring response times and success rates from each location.


### PR DESCRIPTION
## What

Updates `docs/chainstack-compare-dashboard.mdx` for the relaunched [compare.chainstack.com](https://compare.chainstack.com/).

Context: per #product-compare, the new landing page replaces the previous benchmarking front end and the old `performance-tool-backend` was uninstalled. The landing page is a presentation layer over the same Grafana dashboard (still reachable via "Per-method breakdowns available in Grafana"), so all underlying mechanics still hold.

## Changes

- Repoint the two raw Grafana dashboard links → `https://compare.chainstack.com/`
- Networks 4 → 8 (added BNB Chain, Arbitrum, Hyperliquid, Monad)
- Add **dRPC** to provider lists; note coverage varies by network
- Collection cadence "every minute" → "every 1–3 minutes"
- Quick start / "What you can do" now describe the landing layer (availability, P50/P95/P99, 24h/7d) and point to Grafana for per-method/success-rate detail
- FAQ refreshed for providers, cadence, and history window

## Kept intact (still accurate)

Ranking formula, Solana transaction-landing section + enhanced-endpoints table, Vercel→Grafana architecture, 14-day retention, and the `chainstack-rpc-dashboard-functions` repo references.