### PR TITLE
docs: rename ADIchain to ADI Chain

### DIFF
--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -14,7 +14,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Chain | Support | Elastic Mainnet Support | Elastic Testnet Support | Testnet networks | Debug and Trace | Deploy node |
 |-------|---------|-------------------------|--------------------------|------------------|-----------------|-------------|
 | AB Chain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| ADIchain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| ADI Chain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Apechain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |
 | Aptos | Elastic, Dedicated | Full, Archive | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Arbitrum | Elastic, Dedicated | Full, Archive | Full, Archive | Arbitrum Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3371,8 +3371,8 @@
       "testnets": [],
       "additional_notes": "Dedicated nodes only"
     },
-    "ADIchain": {
-      "protocol_name": "ADIchain",
+    "ADI Chain": {
+      "protocol_name": "ADI Chain",
       "supported_modes": [
         "N/A"
       ],


### PR DESCRIPTION
Fix the display name: **ADIchain → ADI Chain** in `node-options-master-list.json` and the Networks table.

Follow-up to #424.
