### PR TITLE
Clarify Beacon Chain endpoint in Google BNE migration guide

### DIFF
--- a/docs/migrating-from-google-cloud-blockchain-node-engine-to-chainstack.mdx
+++ b/docs/migrating-from-google-cloud-blockchain-node-engine-to-chainstack.mdx
@@ -212,7 +212,7 @@ Swap the BNE `wss://ws.NODE_ID.blockchainnodeengine.com` URL for your Chainstack
 
 ### Beacon Chain API
 
-If you used BNE's `beacon.NODE_ID.blockchainnodeengine.com` endpoint for consensus-layer data, Chainstack exposes the standard [Beacon Chain API](/reference/beacon-chain) on Ethereum nodes. The REST paths are the same as any standard Beacon node, so point your client at the Chainstack Beacon endpoint and keep your existing calls.
+BNE exposed consensus-layer data through a separate `beacon.NODE_ID.blockchainnodeengine.com` endpoint. On Chainstack, every Ethereum node comes with both an execution-layer endpoint and a consensus-layer (Beacon Chain) endpoint, so it's a direct replacement. The REST paths follow the standard [Beacon API specification](https://ethereum.github.io/beacon-APIs/), so point your client at the Chainstack Beacon Chain endpoint and keep your existing calls. See the [Beacon Chain API reference](/reference/beacon-chain) for examples.
 
 ## Archive data
 


### PR DESCRIPTION
Follow-up to #442. Verified that Chainstack exposes the consensus-layer (Beacon Chain) API on every Ethereum node (per the [Beacon Chain API reference](https://docs.chainstack.com/reference/beacon-chain)), so the guide's claim and link were correct.

This is a precision tweak: state explicitly that each Ethereum node ships **both** an execution-layer and a consensus-layer (Beacon Chain) endpoint — a 1:1 replacement for BNE's separate `beacon.{id}` endpoint — and link the standard Beacon API spec plus the reference.