### PR TITLE
docs: add Vultr to Self-Hosted infrastructure partners

### DIFF
--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -194,6 +194,7 @@ Chainstack Self-Hosted works on any compatible infrastructure you provision your
 
 | Partner | | Promo |
 |---------|--|-------|
+| Vultr | [Deploy on Vultr](https://www.vultr.com/marketplace/apps/chainstack-self-hosted#general-information?utm_source=chainstack&utm_campaign=docs) | — |
 | Hostkey | [Deploy on Hostkey](https://hostkey.com/apps/developer-tools/chainstack/?utm_source=chainstack&utm_campaign=docs) | — |
 | Velia | [Deploy on Velia](https://checkout.velia.net/order/product/1e96d298-537d-4ed6-868c-84e120637085/?bcm=1&utm_source=chainstack&utm_campaign=docs) | Promocode `ChainstackSH80` — 80% off your first month on all Chainstack products |
 | Serverside | [Deploy on Serverside](https://serverside.com/en-gb/partners/chainstack?utm_source=chainstack&utm_campaign=docs) | 10% off — applied automatically via the link |


### PR DESCRIPTION
Adds Vultr to the Trusted infrastructure partners table on the Chainstack Self-Hosted requirements page.

Scope: one row only in `docs/self-hosted/requirements.mdx`, placed above Hostkey. No page copy, navigation, generated files, formatting, or unrelated docs changes.

Verification:
- `mint broken-links`
- Local Mintlify preview for `/docs/self-hosted/requirements`
