### PR TITLE
docs(request-units): document full vs archive billing for Polkadot

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -229,7 +229,7 @@ Polkadot is served over two transports — the Substrate node JSON-RPC and the [
 - `/blocks/{blockId}/extrinsics-raw`
 - `/blocks/{blockId}/para-inclusions`
 
-All other Polkadot methods and Sidecar endpoints — including requests that target the chain head or omit a block parameter — are billed as full (1 RU).
+All other Polkadot methods and Sidecar endpoints are billed as full (1 RU) — including requests that target the chain head, omit a block parameter, or select a historical block through the `?at=` query parameter (for example `/accounts/{address}/balance-info?at=<block>`). On Sidecar, only the path-based `/blocks/...` endpoints above trigger archive billing.
 
 ## HTTP requests vs WebSocket subscriptions
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -229,7 +229,7 @@ Polkadot is served over two transports — the Substrate node JSON-RPC and the [
 - `/blocks/{blockId}/extrinsics-raw`
 - `/blocks/{blockId}/para-inclusions`
 
-All other Polkadot methods and Sidecar endpoints are billed as full (1 RU) — including requests that target the chain head, omit a block parameter, or select a historical block through the `?at=` query parameter (for example `/accounts/{address}/balance-info?at=<block>`). On Sidecar, only the path-based `/blocks/...` endpoints above trigger archive billing.
+All other Polkadot methods and Sidecar endpoints — including requests that target the chain head or omit a block parameter — are billed as full (1 RU).
 
 ## HTTP requests vs WebSocket subscriptions
 

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -27,7 +27,8 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |
 | Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
-| Bitcoin, Sui, Polkadot, TRON, opBNB, Harmony | No archive split — every request is billed as full |
+| Polkadot | Most requests are **full**. Sidecar trace endpoints are always **2 RUs**; `chain_getBlockHash` and block-scoped Sidecar endpoints are **archive** when the requested block is more than 128 behind the tip. See [Polkadot method scope](#polkadot-method-scope) below. |
+| Bitcoin, Sui, TRON, opBNB, Harmony | No archive split — every request is billed as full |
 
 ## Always 2 RUs
 
@@ -204,6 +205,31 @@ Starknet requests are billed as full (1 RU) by default. Three cases are billed a
 **Archive when the event range is historical** — `starknet_getEvents` is billed as archive (2 RUs) when its `from_block` or `to_block` is more than 128 behind the tip, and full (1 RU) otherwise. This parallels the `eth_getLogs` rule in the EVM section.
 
 All other Starknet methods are billed as full (1 RU) regardless of the block they target.
+
+## Polkadot method scope
+
+Polkadot is served over two transports — the Substrate node JSON-RPC and the [Sidecar](https://github.com/paritytech/substrate-api-sidecar) REST API. Both are billed as full (1 RU) by default. Three cases are billed at 2 RUs.
+
+**Always 2 RUs** — these Sidecar trace endpoints are billed at the trace rate (2 RUs) regardless of block age, the same as the EVM `debug_*`/`trace_*` rule:
+
+- `/experimental/blocks/head/traces`
+- `/experimental/blocks/{number}/traces`
+- `/experimental/blocks/{number}/traces/operations`
+- `/experimental/blocks/head/traces/operations`
+
+**Archive when targeting a historical block (JSON-RPC)** — billed as archive (2 RUs) when the requested block is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or no block parameter):
+
+- `chain_getBlockHash`
+
+**Archive when targeting a historical block (Sidecar REST)** — these endpoints take a block number in the path and are billed as archive (2 RUs) when that block is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or a `head` path):
+
+- `/blocks/{number}`
+- `/blocks/{number}/header`
+- `/blocks/{blockId}/extrinsics/{extrinsicIndex}`
+- `/blocks/{blockId}/extrinsics-raw`
+- `/blocks/{blockId}/para-inclusions`
+
+All other Polkadot methods and Sidecar endpoints — including requests that target the chain head or omit a block parameter — are billed as full (1 RU).
 
 ## HTTP requests vs WebSocket subscriptions
 


### PR DESCRIPTION
## What

Documents full vs archive RU billing for **Polkadot**, mirroring the TON/Aptos/Starknet classifiers. Polkadot was previously listed as "no archive split — every request full"; the smart-proxy `polkadot` classifier (`forwardFromBlock` default 128) now classifies it across both transports.

### JSON-RPC (Substrate node RPC)
- `chain_getBlockHash` — **archive** when the requested block is more than 128 behind the tip.

### Sidecar REST API — block-scoped (archive when the block in the path is more than 128 behind)
- `/blocks/{number}`
- `/blocks/{number}/header`
- `/blocks/{blockId}/extrinsics/{extrinsicIndex}`
- `/blocks/{blockId}/extrinsics-raw`
- `/blocks/{blockId}/para-inclusions`

### Sidecar REST API — trace (always 2 RUs, regardless of block age)
- `/experimental/blocks/head/traces`
- `/experimental/blocks/{number}/traces`
- `/experimental/blocks/{number}/traces/operations`
- `/experimental/blocks/head/traces/operations`

Everything else — including head-targeted or block-less requests — is **full**.

## Changes
- `docs/request-units.mdx` — moved Polkadot out of the flat "no archive split" row, added a Polkadot row and a "Polkadot method scope" section.

## Verification
Checked against the smart-proxy `type_polkadot.go` classifier and `type_polkadot_test.go` (passing): `forwardFromBlock` default **128**, boundary is strictly greater-than (`latest - block > 128`, so a block exactly at `tip − 128` is full), and `head`/`latest`/block-less requests resolve to full. `docs.json` valid; `mint broken-links` passes.