### PR TITLE
docs: reconcile eth_getLogs range limits, fix stale BSC eth_getProof note

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -21,7 +21,7 @@ description: View Chainstack platform limits for node deployments, API requests,
 ### BNB Smart Chain-specific
 
 <Warning>
-  **BSC limitation**: On Binance Smart Chain, `eth_getProof` currently only works with the `"latest"`, `"earliest",` `"safe"`, `"finalized"`, `"pending"` block tags. Using specific block numbers will result in an error. This limitation will be addressed in a future update.
+  **BSC limitation**: On BNB Smart Chain, `eth_getProof` only works against named block tags such as `"latest"`. A specific block number returns the error `proofs are available only for the 'latest' block`. This is a constraint of the BSC node client, not Chainstack.
 </Warning>
 
 ### Cronos-specific
@@ -48,9 +48,7 @@ For the `eth_getLogs`, the caps are:
   Learn more about `eth_getLogs` limits by reading [Understanding eth_getLogs limitations](/docs/understanding-eth-getlogs-limitations).
 </Info>
 
-For users on the Developer subscription plan, Chainstack applies a specific range limit for certain requests.
-
-This limit is designed to optimize the performance and resource allocation for our users on this plan.
+Need a larger range? [Dedicated nodes](/docs/dedicated-node) support custom block-range limits on request.
 
 ## EVM disabled debug methods
 

--- a/docs/understanding-eth-getlogs-limitations.mdx
+++ b/docs/understanding-eth-getlogs-limitations.mdx
@@ -26,39 +26,11 @@ The `eth_getLogs` method is an Ethereum JSON-RPC endpoint used to query logs bas
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node’s performance.
+`eth_getLogs` is a resource-intensive method, so the block range you can query in a single request (the difference between `fromBlock` and `toBlock`) is capped by your subscription plan: Developer plans are capped at 100 blocks and paid plans at 10,000 blocks. For the authoritative per-plan figures, see [Throughput guidelines](/docs/limits#evm-range-limits). If you need a larger range, [dedicated nodes](/docs/dedicated-node) support custom range limits on request.
 
-Below you can find the block range limitations for the `eth_getLogs` that we recommend in order to maintain a good balance between node and application performance.
+Some chains also enforce their own hard limits at the client level, regardless of plan, and return an error past that range. These ceilings vary by client, so it's worth checking the node client's docs or source for the chain you're targeting.
 
-<Info>
-  ### Range limits based on subscription plan
-  
-  These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-
-  The ranges allowed change based on the plan you are on:
-
-  * **Developer** plan — 100 blocks
-  * **Growth** plan — 10,000 blocks
-  * **Business** plan — 10,000 blocks
-  * **Enterprise** — 10,000 blocks. Customization available on request.
-</Info>
-
-Cronos and Harmony have hard limits set by their respective blockchain clients. You will receive an error if you try to query a bigger range than the following:
-
-* Cronos — 10,000 blocks.
-* Harmony — 1,024 blocks.
-
-Even if your subscription plan allows for an **unlimited** range, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses. Here are some recommended block ranges per request for various networks:
-
-* Ethereum — 5,000 blocks.
-* Polygon — 3,000 blocks.
-* BNB Smart Chain — 5,000 blocks.
-* Avalanche — 100,000 blocks.
-* Fantom — 5,000 blocks.
-* Arbitrum — 10,000 blocks.
-* Gnosis — 10,000 blocks.
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+Even within your plan's cap, a busy chain or a high-traffic contract can return an oversized response or time out. On high-activity ranges, query fewer blocks and paginate (see below).
 
 ## Best practices when using `eth_getLogs`
 

--- a/reference/arbitrum-getlogs.mdx
+++ b/reference/arbitrum-getlogs.mdx
@@ -126,18 +126,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **10,000** blocks for `eth_getLogs` on Arbitrum to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Polygon network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitation are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/aurora-getlogs.mdx
+++ b/reference/aurora-getlogs.mdx
@@ -128,16 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks from which to get events and is important for exercising proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method, and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **10,000** blocks for `eth_getLogs` on Aurora to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data, read [Understanding eth\_getLogs limitations](/docs/understanding-eth-getlogs-limitations) to learn more about `eth_getLogs` limits.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/avalanche-getlogs.mdx
+++ b/reference/avalanche-getlogs.mdx
@@ -126,18 +126,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **100,000** blocks for `eth_getLogs` on Avalanche to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Avalanche network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitation are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/bnb-getlogs.mdx
+++ b/reference/bnb-getlogs.mdx
@@ -128,18 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks from which to get events and is important for exercising proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **5,000** blocks for `eth_getLogs` on Ethereum to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Ethereum network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/cronos-getlogs.mdx
+++ b/reference/cronos-getlogs.mdx
@@ -128,18 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks from which to get events and is important for exercising proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **5,000** blocks for `eth_getLogs` on Cronos to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-On Cronos, the hard limit is a range of 10,000 blocks.
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/ethereum-getlogs.mdx
+++ b/reference/ethereum-getlogs.mdx
@@ -136,18 +136,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **5,000** blocks for `eth_getLogs` on Ethereum to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Ethereum network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitation are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/fantom-getlogs.mdx
+++ b/reference/fantom-getlogs.mdx
@@ -128,18 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks from which to get events and is important for exercising proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **5,000** blocks for `eth_getLogs` on Ethereum to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Ethereum network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/getlogs.mdx
+++ b/reference/getlogs.mdx
@@ -126,18 +126,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **3,000** blocks for `eth_getLogs` on Polygon to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Polygon network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitation are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/gnosis-getlogs.mdx
+++ b/reference/gnosis-getlogs.mdx
@@ -128,18 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks to get events from and is important to exercise proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend to keep the block range limit of **10,000** blocks for `eth_getLogs` on Gnosis to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Gnosis network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitation are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 

--- a/reference/zkevm-getlogs.mdx
+++ b/reference/zkevm-getlogs.mdx
@@ -128,18 +128,7 @@ Read [Tracking some Bored Apes: The Ethereum event logs tutorial](/docs/tracking
 
 While `eth_getLogs` is a powerful tool, it's crucial to understand its limitations, particularly when working with different EVM-compatible chains, as these networks often have different constraints. The `eth_getLogs` method allows you to select a range of blocks from which to get events and is important for exercising proper management.
 
-In general, `eth_getLogs` is a very resource-intensive method, and although Chainstack does not pose any arbitrary limitation, some blockchain clients do, and a very large block range can impact your node's performance.
-
-We recommend keeping the block range limit of **5,000** blocks for `eth_getLogs` to maintain a good balance between node and application performance.
-
-<Note>
-These figures mean that the difference between the `fromBlock` and `toBlock` parameters should not exceed the given block range when querying logs.
-</Note>
-
-
-While there are no hard limits for the Ethereum network, it's best practice to limit the range of blocks you are querying in a single request to prevent issues such as timeout errors or overly large responses.
-
-These limitations are particularly important when working with popular smart contracts on busy blockchains, as they can return a large amount of data.
+`eth_getLogs` block range is capped by your [subscription plan](/docs/limits#evm-range-limits). On high-activity chains or contracts, query smaller ranges and paginate to avoid oversized responses or timeouts.
 
 ## Use case
 


### PR DESCRIPTION
Reconciles the `eth_getLogs` block-range docs (which contradicted themselves and `limits.mdx`) and fixes the now-stale BSC `eth_getProof` note. Facts verified against pricing + Notion/Slack/YouTrack.

- **Guide (`understanding-eth-getlogs-limitations`)**: dropped the self-contradictory "no arbitrary limitation" / "unlimited range" claims and the per-network list (incl. Avalanche 100,000, impossible under the 10k cap). Plan caps now single-sourced to `limits.mdx#evm-range-limits`; client hard limits softened to "check the client's docs/source".
- **`limits.mdx`**: added dedicated-node custom-range note; dropped a vague Developer-plan note; fixed the BSC `eth_getProof` note — INFRA-4453 was closed won't-fix (priority moved to Reth BSC), so removed the false "will be addressed in a future update", added the real error string + client attribution.
- **10 × `reference/*-getlogs.mdx`**: collapsed the duplicated/contradictory block-range blurb to one cap-pointer line. Fixes the bnb/fantom "on Ethereum" copy-paste and removes Avalanche 100,000.

Verified: local broken-link audit clean, pages render in `mintlify dev`, CRLF preserved on reference pages.

Drafted with Claude Code — please let CI (Vale/build/link) go green and review before merge.
