### PR TITLE
docs: collapse all node APIs under one Node APIs wrapper (page-size-html lever)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1461,909 +1461,917 @@
             ]
           },
           {
-            "group": "Ethereum node API",
-            "pages": [
-              "reference/ethereum-getting-started",
-              "reference/enable-debug-trace-apis-for-your-ethereum-node",
-              "reference/ethereum-rpc-methods-postman-collection",
-              {
-                "group": "Blocks info | Ethereum",
-                "pages": [
-                  "reference/ethereum-blocks-rpc-methods",
-                  "reference/ethereum-getblockbynumber",
-                  "reference/ethereum-getblockbyhash",
-                  "reference/ethereum-getblocknumber",
-                  "reference/ethereum-getblocktransactioncountbyhash",
-                  "reference/ethereum-getblocktransactioncountbynumber",
-                  "reference/ethereum-newblockfilter"
-                ]
-              },
-              {
-                "group": "Transactions info | Ethereum",
-                "pages": [
-                  "reference/ethereum-transactions-rpc-methods",
-                  "reference/ethereum-gettransactionbyhash",
-                  "reference/ethereum-gettransactionreceipt",
-                  "reference/ethereum-gettransactionbyblockhashandindex",
-                  "reference/ethereum-gettransactionbyblocknumberandindex",
-                  "reference/ethereum-getblockreceipts",
-                  "reference/ethereum-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Executing transactions | Ethereum",
-                "pages": [
-                  "reference/ethereum-execution-rpc-methods",
-                  "reference/ethereum-ethcall",
-                  "reference/ethereum-simulatev1",
-                  "reference/ethereum-sendrawtransaction",
-                  "reference/ethereum-sendrawtransactionsync"
-                ]
-              },
-              {
-                "group": "Debug and Trace | Ethereum",
-                "pages": [
-                  "reference/ethereum-debug-trace-rpc-methods",
-                  "reference/custom-js-tracing-ethereum",
-                  "reference/ethereum-traceblockbyhash",
-                  "reference/ethereum-tracetransaction",
-                  "reference/ethereum-tracecall",
-                  "reference/ethereum-tracecallmany",
-                  "reference/ethereum-trace_transaction",
-                  "reference/ethereum-trace_block",
-                  "reference/ethereum-traceblockbynumber"
-                ]
-              },
-              {
-                "group": "Chain info | Ethereum",
-                "pages": [
-                  "reference/ethereum-chain-data-rpc-methods",
-                  "reference/ethereum-syncing",
-                  "reference/ethereum-getchainid"
-                ]
-              },
-              {
-                "group": "Gas data | Ethereum",
-                "pages": [
-                  "reference/ethereum-gas-data-rpc-methods",
-                  "reference/ethereum-getgasprice",
-                  "reference/ethereum-estimategas",
-                  "reference/ethereum-maxpriorityfeepergas"
-                ]
-              },
-              {
-                "group": "Accounts info | Ethereum",
-                "pages": [
-                  "reference/ethereum-accounts-info-rpc-methods",
-                  "reference/ethereum-getstorageat",
-                  "reference/ethereum-getbalance",
-                  "reference/ethereum-gettransactioncount",
-                  "reference/ethereum-getcode",
-                  "reference/getproof"
-                ]
-              },
-              {
-                "group": "Logs & events | Ethereum",
-                "pages": [
-                  "reference/ethereum-logs-rpc-methods",
-                  "reference/ethereum-newfilter",
-                  "reference/ethereum-getlogs"
-                ]
-              },
-              {
-                "group": "Client information | Ethereum",
-                "pages": [
-                  "reference/ethereum-client-data-rpc-methods",
-                  "reference/ethereum-peercount",
-                  "reference/ethereum-listening",
-                  "reference/ethereum-clientversion"
-                ]
-              },
-              {
-                "group": "Filter handling | Ethereum",
-                "pages": [
-                  "reference/ethereum-filters-rpc-methods",
-                  "reference/ethereum-getfilterchanges",
-                  "reference/ethereum-uninstallfilter"
-                ]
-              },
-              {
-                "group": "Subscriptions | Ethereum",
-                "pages": [
-                  "reference/ethereum-web3js-subscriptions-methods",
-                  "reference/ethereum-native-subscribe-newheads",
-                  "reference/ethereum-native-subscribe-newpendingtransactions",
-                  "reference/ethereum-native-subscribe-logs",
-                  "reference/ethereum-native-unsubscribe",
-                  "reference/ethereum-subscribenewblockheaders",
-                  "reference/ethereum-subscribependingtransactions",
-                  "reference/ethereum-subscribelogs",
-                  "reference/ethereum-subscribesyncing",
-                  "reference/ethereum-clearsubscriptions"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Plasma node API",
-            "pages": [
-              "reference/plasma-getting-started",
-              {
-                "group": "Accounts info | Plasma",
-                "pages": [
-                  "reference/plasma-accounts-info-rpc-methods",
-                  "reference/plasma-eth-getbalance",
-                  "reference/plasma-eth-getcode",
-                  "reference/plasma-eth-getstorageat",
-                  "reference/plasma-eth-gettransactioncount",
-                  "reference/plasma-eth-getproof",
-                  "reference/plasma-eth-getaccount"
-                ]
-              },
-              {
-                "group": "Blocks info | Plasma",
-                "pages": [
-                  "reference/plasma-blocks-info-rpc-methods",
-                  "reference/plasma-eth-blocknumber",
-                  "reference/plasma-eth-getblockbynumber",
-                  "reference/plasma-eth-getblockbyhash",
-                  "reference/plasma-eth-getblocktransactioncountbynumber",
-                  "reference/plasma-eth-getblocktransactioncountbyhash",
-                  "reference/plasma-eth-getblockreceipts",
-                  "reference/plasma-eth-getunclecountbyblocknumber",
-                  "reference/plasma-eth-getunclecountbyblockhash",
-                  "reference/plasma-eth-getunclebyblocknumberandindex",
-                  "reference/plasma-eth-getunclebyblockhashandindex",
-                  "reference/plasma-eth-getheaderbynumber",
-                  "reference/plasma-eth-getheaderbyhash"
-                ]
-              },
-              {
-                "group": "Transaction info | Plasma",
-                "pages": [
-                  "reference/plasma-transaction-info-rpc-methods",
-                  "reference/plasma-eth-gettransactionbyhash",
-                  "reference/plasma-eth-gettransactionreceipt",
-                  "reference/plasma-eth-gettransactionbyblocknumberandindex",
-                  "reference/plasma-eth-gettransactionbyblockhashandindex",
-                  "reference/plasma-eth-getrawtransactionbyhash",
-                  "reference/plasma-eth-getrawtransactionbyblocknumberandindex",
-                  "reference/plasma-eth-getrawtransactionbyblockhashandindex",
-                  "reference/plasma-eth-gettransactionbysenderandnonce"
-                ]
-              },
-              {
-                "group": "Execute transactions | Plasma",
-                "pages": [
-                  "reference/plasma-execute-transactions-rpc-methods",
-                  "reference/plasma-eth-call",
-                  "reference/plasma-eth-estimategas",
-                  "reference/plasma-eth-createaccesslist",
-                  "reference/plasma-eth-simulatev1"
-                ]
-              },
-              {
-                "group": "Gas data | Plasma",
-                "pages": [
-                  "reference/plasma-gas-data-rpc-methods",
-                  "reference/plasma-eth-gasprice",
-                  "reference/plasma-eth-maxpriorityfeepergas",
-                  "reference/plasma-eth-feehistory",
-                  "reference/plasma-eth-blobbasefee"
-                ]
-              },
-              {
-                "group": "Chain info | Plasma",
-                "pages": [
-                  "reference/plasma-chain-info-rpc-methods",
-                  "reference/plasma-eth-chainid",
-                  "reference/plasma-eth-syncing",
-                  "reference/plasma-eth-protocolversion",
-                  "reference/plasma-eth-accounts",
-                  "reference/plasma-eth-hashrate"
-                ]
-              },
-              {
-                "group": "Filter handling | Plasma",
-                "pages": [
-                  "reference/plasma-filter-handling-rpc-methods",
-                  "reference/plasma-eth-newfilter",
-                  "reference/plasma-eth-newblockfilter",
-                  "reference/plasma-eth-newpendingtransactionfilter",
-                  "reference/plasma-eth-uninstallfilter"
-                ]
-              },
-              {
-                "group": "Logs and events | Plasma",
-                "pages": [
-                  "reference/plasma-logs-and-events-rpc-methods",
-                  "reference/plasma-eth-getlogs"
-                ]
-              },
-              {
-                "group": "Client info | Plasma",
-                "pages": [
-                  "reference/plasma-client-info-rpc-methods",
-                  "reference/plasma-web3-clientversion",
-                  "reference/plasma-web3-sha3",
-                  "reference/plasma-net-version",
-                  "reference/plasma-net-listening",
-                  "reference/plasma-net-peercount"
-                ]
-              },
-              {
-                "group": "Debug and trace | Plasma",
-                "pages": [
-                  "reference/plasma-debug-and-trace-rpc-methods",
-                  "reference/plasma-debug-getrawheader",
-                  "reference/plasma-debug-getrawblock",
-                  "reference/plasma-debug-getrawtransaction",
-                  "reference/plasma-debug-getrawreceipts",
-                  "reference/plasma-debug-tracecall",
-                  "reference/plasma-trace-call",
-                  "reference/plasma-trace-callmany",
-                  "reference/plasma-trace-replayblocktransactions",
-                  "reference/plasma-trace-block",
-                  "reference/plasma-trace-get"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Ethereum Beacon Chain API",
-            "pages": [
-              "reference/beacon-chain",
-              {
-                "group": "Beacon Chain configuration info",
-                "pages": [
-                  "reference/beacon-chain-configuration",
-                  "reference/getforkinformation",
-                  "reference/ethereum-beacon-genesis",
-                  "reference/getconfigforkschedule",
-                  "reference/getconfigspec",
-                  "reference/getconfigdepositcontract"
-                ]
-              },
-              {
-                "group": "Beacon Chain events",
-                "pages": [
-                  "reference/beacon-chain-events",
-                  "reference/subscribetobeaconevents"
-                ]
-              },
-              {
-                "group": "Beacon Chain validators info",
-                "pages": [
-                  "reference/beacon-chain-node",
-                  "reference/getbeaconpoolvoluntaryexits",
-                  "reference/getbeaconpoolproposerslashings",
-                  "reference/getbeaconpoolattesterslashings",
-                  "reference/getbeaconpoolattestationsbyslotandcommitteeindex",
-                  "reference/getvalidatorbalancesbystateidandvalidatorid",
-                  "reference/getvalidatorbystateidandindex",
-                  "reference/getvalidatorinformation",
-                  "reference/getproposerduties",
-                  "reference/produceblock",
-                  "reference/produceblindedblock",
-                  "reference/getattestationdata",
-                  "reference/getbeaconblockattestationsbyblockid"
-                ]
-              },
-              {
-                "group": "Beacon Chain state",
-                "pages": [
-                  "reference/beacon-chain-state",
-                  "reference/getbeaconblockrootbyblockid",
-                  "reference/getbeaconblocksbyblockid",
-                  "reference/getbeaconheadersbyblockid",
-                  "reference/getbeaconheadersbyslotandparentroot",
-                  "reference/getsynccommitteecontribution",
-                  "reference/getsynccommitteesbystateidandepoch",
-                  "reference/getcommitteesbystateidepochindexandslot",
-                  "reference/getfinalitycheckpoints",
-                  "reference/getstateroot",
-                  "reference/getblobsbyblockid",
-                  "reference/getdebugbeaconstatev2",
-                  "reference/getdebugbeaconheadsv2",
-                  "reference/getdebugforkchoice"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Polygon node API",
-            "pages": [
-              "reference/polygon-getting-started",
-              {
-                "group": "Blocks Info | Polygon",
-                "pages": [
-                  "reference/polygon-blocks-rpc-methods",
-                  "reference/polygon-getblocknumber",
-                  "reference/getblockbyhash",
-                  "reference/polygon-getblocktransactioncountbyhash",
-                  "reference/polygon-getblocktransactioncountbynumber",
-                  "reference/polygon-getblockbynumber",
-                  "reference/polygon-newblockfilter"
-                ]
-              },
-              {
-                "group": "Transactions info | Polygon",
-                "pages": [
-                  "reference/polygon-transactions-rpc-methods",
-                  "reference/polygon-gettransactionbyhash",
-                  "reference/polygon-gettransactionreceipt",
-                  "reference/polygon-gettransactionbyblockhashandindex",
-                  "reference/polygon-gettransactionbyblocknumberandindex",
-                  "reference/polygon-getblockreceipts",
-                  "reference/polygon-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Executing transactions | Polygon",
-                "pages": [
-                  "reference/polygon-evm-excecution-rpc-methods",
-                  "reference/ethcall",
-                  "reference/sendrawtransaction",
-                  "reference/polygon-sendrawtransactionsync"
-                ]
-              },
-              {
-                "group": "Debug & Trace | Polygon",
-                "pages": [
-                  "reference/polygon-debug-trace-rpc-methods",
-                  "reference/polygon-traceblockbyhash",
-                  "reference/polygon-traceblockbynumber",
-                  "reference/polygon-tracetransaction",
-                  "reference/polygon-tracecall",
-                  "reference/polygon-trace_transaction",
-                  "reference/polygon-trace_block"
-                ]
-              },
-              {
-                "group": "Chain info | Polygon",
-                "pages": [
-                  "reference/polygon-chain-data-rpc-methods",
-                  "reference/chainid",
-                  "reference/syncing"
-                ]
-              },
-              {
-                "group": "Gas data | Polygon",
-                "pages": [
-                  "reference/polygon-gas-data-rpc-methods",
-                  "reference/estimategas",
-                  "reference/gasprice"
-                ]
-              },
-              {
-                "group": "Accounts info | Polygon",
-                "pages": [
-                  "reference/polygon-accounts-info-rpc-methods",
-                  "reference/gettransactioncount",
-                  "reference/getbalance",
-                  "reference/getcode",
-                  "reference/getstorageat"
-                ]
-              },
-              {
-                "group": "Logs & events | Polygon",
-                "pages": [
-                  "reference/polygon-logs-rpc-methods",
-                  "reference/getlogs",
-                  "reference/newfilter"
-                ]
-              },
-              {
-                "group": "Filter handling | Polygon",
-                "pages": [
-                  "reference/polygon-filters-rpc-methods",
-                  "reference/getfilterchanges",
-                  "reference/uninstallfilter"
-                ]
-              },
-              {
-                "group": "Client information | Polygon",
-                "pages": [
-                  "reference/polygon-client-data-rpc-methods",
-                  "reference/clientversion",
-                  "reference/netlistening",
-                  "reference/peercount"
-                ]
-              },
-              {
-                "group": "Subscriptions | Polygon",
-                "pages": [
-                  "reference/polygon-web3js-subscriptions-methods",
-                  "reference/polygon-native-subscribe-newheads",
-                  "reference/polygon-native-subscribe-newpendingtransactions",
-                  "reference/polygon-native-subscribe-logs",
-                  "reference/polygon-native-unsubscribe",
-                  "reference/polygon-subscribenewblockheaders",
-                  "reference/polygon-subscribependingtransactions",
-                  "reference/polygon-subscribelogs",
-                  "reference/polygon-subscribesyncing",
-                  "reference/polygon-clearsubscriptions"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "BNB node API",
-            "pages": [
-              "reference/getting-started-bnb-chain",
-              {
-                "group": "Endpoints",
-                "pages": [
-                  "reference/bnb-blocknumber",
-                  "reference/bnb-getblockbynumber",
-                  "reference/bnb-getblockbyhash",
-                  "reference/bnb-getblocktransactioncountbynumber",
-                  "reference/bnb-getblocktransactioncountbyhash",
-                  "reference/bnb-newblockfilter",
-                  "reference/bnb-gettransactionbyhash",
-                  "reference/bnb-gettransactionreceipt",
-                  "reference/bnb-gettransactionbyblocknumberandindex",
-                  "reference/bnb-gettransactionbyblockhashandindex",
-                  "reference/bnb-getblockreceipts",
-                  "reference/bnb-newpendingtransactionfilter",
-                  "reference/bnb-ethcall",
-                  "reference/bnb-sendrawtransaction",
-                  "reference/bnb-getbalance",
-                  "reference/bnb-getcode",
-                  "reference/bnb-getstorageat",
-                  "reference/bnb-gettransactioncount",
-                  "reference/bnb-getproof",
-                  "reference/bnb-getchainid",
-                  "reference/bnb-syncing",
-                  "reference/bnb-netlistening",
-                  "reference/bnb-peercount",
-                  "reference/bnb-clientversion",
-                  "reference/bnb-estimategas",
-                  "reference/bnb-getgasprice",
-                  "reference/bnb-maxpriorityfeepergas",
-                  "reference/bnb-getlogs",
-                  "reference/bnb-newfilter",
-                  "reference/bnb-getfilterchanges",
-                  "reference/bnb-uninstallfilter",
-                  "reference/bnb-customtracer",
-                  "reference/bnb-traceblockbyhash",
-                  "reference/bnb-traceblockbynumber",
-                  "reference/bnb-tracecall",
-                  "reference/bnb-tracetransaction",
-                  "reference/bnb-traceblock",
-                  "reference/trace_transaction",
-                  "reference/bnb-trace-call",
-                  "reference/bnb-tracecallmany",
-                  "reference/bnb-replayblocktransactions",
-                  "reference/bnb-replaytransaction",
-                  "reference/bnb-gettrace"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Base node API",
-            "pages": [
-              "reference/base-api-reference",
-              {
-                "group": "Endpoints",
-                "pages": [
-                  "reference/base-blocknumber",
-                  "reference/base-getblockbyhash",
-                  "reference/base-getblockbynumber",
-                  "reference/base-getblocktransactioncountbyhash",
-                  "reference/base-getblocktransactioncountbynumber",
-                  "reference/base-getunclecountbyblockhash",
-                  "reference/base-getunclecountbyblocknumber",
-                  "reference/base-getunclebyblocknumberandindex",
-                  "reference/base-getunclebyblockhashandindex",
-                  "reference/base-getblockreceipts",
-                  "reference/base-chainid",
-                  "reference/base-syncing",
-                  "reference/base-call",
-                  "reference/base-callmany",
-                  "reference/base-estimategas",
-                  "reference/debug-createaccesslist",
-                  "reference/debug-gasprice",
-                  "reference/debug-feehistory",
-                  "reference/base-newfilter",
-                  "reference/base-newblockfilter",
-                  "reference/base-uninstallfilter",
-                  "reference/base-getfilterchanges",
-                  "reference/base-getfilterlogs",
-                  "reference/base-getlogs",
-                  "reference/base-accounts",
-                  "reference/base-getbalance",
-                  "reference/base-getstorageat",
-                  "reference/base-gettransactioncount",
-                  "reference/base-getcode",
-                  "reference/base-getproof",
-                  "reference/base-gettransactionbyhash",
-                  "reference/base-getrawtransactionbyhash",
-                  "reference/base-gettransactionbyblockhashandindex",
-                  "reference/base-getrawtransactionbyblockhashandindex",
-                  "reference/base-gettransactionbyblocknumberandindex",
-                  "reference/base-getrawtransactionbyblocknumberandindex",
-                  "reference/base-gettransactionreceipt",
-                  "reference/base-maxpriorityfeepergas",
-                  "reference/base-sendrawtransaction",
-                  "reference/base-sendrawtransactionsync",
-                  "reference/base-newpendingtransactionfilter",
-                  "reference/base-clientversion",
-                  "reference/protocolversion",
-                  "reference/base-sha3",
-                  "reference/base-listening",
-                  "reference/base-getmodifiedaccountsbynumber",
-                  "reference/base-getmodifiedaccountsbyhash",
-                  "reference/base-getstoragerangeat",
-                  "reference/base-traceblockbyhash",
-                  "reference/base-traceblockbynumber",
-                  "reference/base-tracetransaction",
-                  "reference/base-tracecall",
-                  "reference/base-tracecallmany",
-                  "reference/base-trace-call",
-                  "reference/base-trace-callmany",
-                  "reference/base-trace-replayblocktransactions",
-                  "reference/base-trace-replaytransaction",
-                  "reference/debug-tracetransaction",
-                  "reference/base-trace-get",
-                  "reference/base-trace-block"
-                ]
-              },
-              {
-                "group": "Subscriptions | Base",
-                "pages": [
-                  "reference/base-subscribe-newflashblocktransactions",
-                  "reference/base-subscribe-pendinglogs",
-                  "reference/base-subscribe-newflashblocks",
-                  "reference/base-unsubscribe"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "TRON node API",
-            "pages": [
-              "reference/tron-api-reference",
-              {
-                "group": "Wallet operations",
-                "pages": [
-                  "reference/tron-validateaddress",
-                  "reference/tron-broadcasttransaction",
-                  "reference/tron-broadcasthex",
-                  "reference/tron-createtransaction",
-                  "reference/tron-createaccount",
-                  "reference/tron-updateaccount",
-                  "reference/tron-accountpermissionupdate"
-                ]
-              },
-              {
-                "group": "Account management",
-                "pages": [
-                  "reference/tron-getaccount",
-                  "reference/tron-getaccountbalance",
-                  "reference/tron-getaccountnet",
-                  "reference/tron-getapprovedlist"
-                ]
-              },
-              {
-                "group": "Resource management",
-                "pages": [
-                  "reference/tron-getaccountresource",
-                  "reference/tron-freezebalance",
-                  "reference/tron-unfreezebalance",
-                  "reference/tron-freezebalancev2",
-                  "reference/tron-unfreezebalancev2",
-                  "reference/tron-cancelallunfreezev2",
-                  "reference/tron-delegateresource",
-                  "reference/tron-undelegateresource",
-                  "reference/tron-withdrawexpireunfreeze",
-                  "reference/tron-getdelegatedresource",
-                  "reference/tron-getdelegatedresourcev2",
-                  "reference/tron-getdelegatedresourceaccountindex",
-                  "reference/tron-getdelegatedresourceaccountindexv2",
-                  "reference/tron-getavailableunfreezecount",
-                  "reference/tron-getcanwithdrawunfreezeamount",
-                  "reference/tron-getcandelegatedmaxsize"
-                ]
-              },
-              {
-                "group": "Block operations",
-                "pages": [
-                  "reference/tron-getnowblock",
-                  "reference/tron-getblock",
-                  "reference/tron-getblockbynum",
-                  "reference/tron-getblockbyid",
-                  "reference/tron-getblockbylatestnum",
-                  "reference/tron-getblockbylimitnext",
-                  "reference/tron-getblockbalance"
-                ]
-              },
-              {
-                "group": "Transaction operations",
-                "pages": [
-                  "reference/tron-createtransaction",
-                  "reference/tron-broadcasttransaction",
-                  "reference/tron-broadcasthex",
-                  "reference/tron-gettransactionbyid",
-                  "reference/tron-gettransactioninfobyid",
-                  "reference/tron-gettransactioninfobyblocknum",
-                  "reference/tron-gettransactionlistfrompending",
-                  "reference/tron-gettransactionfrompending",
-                  "reference/tron-getpendingsize"
-                ]
-              },
-              {
-                "group": "Smart contracts",
-                "pages": [
-                  "reference/tron-getcontract",
-                  "reference/tron-getcontractinfo",
-                  "reference/tron-triggersmartcontract",
-                  "reference/tron-triggerconstantcontract",
-                  "reference/tron-deploycontract",
-                  "reference/tron-updatesetting",
-                  "reference/tron-updateenergylimit",
-                  "reference/tron-clearabi",
-                  "reference/tron-estimateenergy"
-                ]
-              },
-              {
-                "group": "Witness and governance",
-                "pages": [
-                  "reference/tron-listwitnesses",
-                  "reference/tron-createwitness",
-                  "reference/tron-updatewitness",
-                  "reference/tron-votewitnessaccount",
-                  "reference/tron-getbrokerage",
-                  "reference/tron-updatebrokerage",
-                  "reference/tron-getreward",
-                  "reference/tron-withdrawbalance",
-                  "reference/tron-getnextmaintenancetime",
-                  "reference/tron-listproposals",
-                  "reference/tron-getproposalbyid",
-                  "reference/tron-proposalcreate",
-                  "reference/tron-proposalapprove",
-                  "reference/tron-proposaldelete",
-                  "reference/tron-getpaginatedproposallist"
-                ]
-              },
-              {
-                "group": "Assets and tokens",
-                "pages": [
-                  "reference/tron-getassetissuebyid",
-                  "reference/tron-getassetissuebyname",
-                  "reference/tron-getassetissuelist",
-                  "reference/tron-getassetissuelistbyname",
-                  "reference/tron-getpaginatedassetissuelist",
-                  "reference/tron-transferasset",
-                  "reference/tron-createassetissue",
-                  "reference/tron-participateassetissue",
-                  "reference/tron-unfreezeasset",
-                  "reference/tron-updateasset"
-                ]
-              },
-              {
-                "group": "Network information",
-                "pages": [
-                  "reference/tron-getnodeinfo",
-                  "reference/tron-listnodes",
-                  "reference/tron-getchainparameters",
-                  "reference/tron-getenergyprices",
-                  "reference/tron-getbandwidthprices",
-                  "reference/tron-getburntrx"
-                ]
-              },
-              {
-                "group": "Exchange and market methods",
-                "pages": [
-                  "reference/tron-listexchanges",
-                  "reference/tron-getexchangebyid",
-                  "reference/tron-exchangecreate",
-                  "reference/tron-exchangeinject",
-                  "reference/tron-exchangewithdraw",
-                  "reference/tron-exchangetransaction",
-                  "reference/tron-getmarketorderbyaccount",
-                  "reference/tron-getmarketorderbyid",
-                  "reference/tron-getmarketpricebypair",
-                  "reference/tron-getmarketorderlistbypair",
-                  "reference/tron-getmarketpairlist",
-                  "reference/tron-marketcancelorder",
-                  "reference/tron-marketsellasset",
-                  "reference/tron-marketbuyasset"
-                ]
-              },
-              {
-                "group": "Shielded contract methods",
-                "pages": [
-                  "reference/tron-shielded-getspendingkey",
-                  "reference/tron-shielded-getexpandedspendingkey",
-                  "reference/tron-shielded-getakfromask",
-                  "reference/tron-shielded-getnkfromnsk",
-                  "reference/tron-shielded-getincomingviewingkey",
-                  "reference/tron-shielded-getdiversifier",
-                  "reference/tron-shielded-getshieldedpaymentaddress",
-                  "reference/tron-shielded-getzenpaymentaddress",
-                  "reference/tron-shielded-getnewshieldedaddress",
-                  "reference/tron-getmerkletreevoucherinfo",
-                  "reference/tron-shielded-createshieldedtransaction",
-                  "reference/tron-shielded-createshieldedtransactionwithoutspendauthsig",
-                  "reference/tron-shielded-createshieldedcontractparameters",
-                  "reference/tron-shielded-createshieldedcontractparameterswithoutask",
-                  "reference/tron-shielded-createspendauthsig",
-                  "reference/tron-shielded-gettriggerinputforshieldedtrc20contract",
-                  "reference/tron-shielded-scanshieldedtrc20notesbyivk",
-                  "reference/tron-shielded-scanshieldedtrc20notesbyovk",
-                  "reference/tron-shielded-isshieldedtrc20contractnotespent"
-                ]
-              },
-              {
-                "group": "Walletsolidity methods",
-                "pages": [
-                  "reference/tron-solidity-getaccount",
-                  "reference/tron-solidity-getblockbynum",
-                  "reference/tron-solidity-getblockbyid",
-                  "reference/tron-solidity-getblockbylimitnext",
-                  "reference/tron-solidity-getblockbylatestnum",
-                  "reference/tron-solidity-getnowblock",
-                  "reference/tron-solidity-gettransactionbyid",
-                  "reference/tron-solidity-gettransactioninfobyid",
-                  "reference/tron-solidity-gettransactioncountbyblocknum"
-                ]
-              },
-              {
-                "group": "JSON-RPC methods",
-                "pages": [
-                  "reference/tron-jsonrpc-blocknumber",
-                  "reference/tron-jsonrpc-getblockbynumber",
-                  "reference/tron-jsonrpc-getblockbyhash",
-                  "reference/tron-jsonrpc-getblocktransactioncountbyhash",
-                  "reference/tron-jsonrpc-getblocktransactioncountbynumber",
-                  "reference/tron-jsonrpc-gettransactionbyhash",
-                  "reference/tron-jsonrpc-gettransactionbyblockhashandindex",
-                  "reference/tron-jsonrpc-gettransactionbyblocknumberandindex",
-                  "reference/tron-jsonrpc-gettransactionreceipt",
-                  "reference/tron-jsonrpc-sendrawtransaction",
-                  "reference/tron-jsonrpc-getbalance",
-                  "reference/tron-jsonrpc-getcode",
-                  "reference/tron-jsonrpc-getstorageat",
-                  "reference/tron-jsonrpc-call",
-                  "reference/tron-jsonrpc-estimategas",
-                  "reference/tron-jsonrpc-gasprice",
-                  "reference/tron-jsonrpc-getlogs",
-                  "reference/tron-jsonrpc-newfilter",
-                  "reference/tron-jsonrpc-newblockfilter",
-                  "reference/tron-jsonrpc-getfilterchanges",
-                  "reference/tron-jsonrpc-getfilterlogs",
-                  "reference/tron-jsonrpc-uninstallfilter",
-                  "reference/tron-jsonrpc-getwork",
-                  "reference/tron-jsonrpc-protocolversion",
-                  "reference/tron-jsonrpc-syncing",
-                  "reference/tron-jsonrpc-listening",
-                  "reference/tron-jsonrpc-peercount",
-                  "reference/tron-jsonrpc-version",
-                  "reference/tron-jsonrpc-clientversion",
-                  "reference/tron-jsonrpc-sha3",
-                  "reference/tron-jsonrpc-web3-clientversion",
-                  "reference/tron-jsonrpc-net-version"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Avalanche node API",
-            "pages": [
-              "reference/avalanche-getting-started",
-              {
-                "group": "Blocks Info | Avalanche",
-                "pages": [
-                  "reference/avalanche-blocks-rpc-methods",
-                  "reference/avalanche-getblocknumber",
-                  "reference/avalanche-getblockbyhash",
-                  "reference/avalanche-getblockbynumber",
-                  "reference/avalanche-getblocktransactioncountbyhash",
-                  "reference/avalanche-getblocktransactioncountbynumber",
-                  "reference/avalanche-newblockfilter"
-                ]
-              },
-              {
-                "group": "Transactions info | Avalanche",
-                "pages": [
-                  "reference/avalanche-transactions-rpc-methods",
-                  "reference/avalanche-gettransactionbyhash",
-                  "reference/avalanche-gettransactionreceipt",
-                  "reference/avalanche-gettransactionbyblockhashandindex",
-                  "reference/avalanche-gettransactionbyblocknumberandindex",
-                  "reference/avalanche-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Executing transactions | Avalanche",
-                "pages": [
-                  "reference/avalanche-execution-rpc-methods",
-                  "reference/avalanche-ethcall",
-                  "reference/avalanche-sendrawtransaction"
-                ]
-              },
-              {
-                "group": "Debug & Trace | Avalanche",
-                "pages": [
-                  "reference/avalanche-debug-trace-rpc-methods",
-                  "reference/avalanche-traceblockbyhash",
-                  "reference/avalanche-traceblockbynumber",
-                  "reference/avalanche-tracecall",
-                  "reference/avalanche-tracetransaction"
-                ]
-              },
-              {
-                "group": "Chain info | Avalanche",
-                "pages": [
-                  "reference/avalanche-chain-data-rpc-methods",
-                  "reference/avalanche-getchainid",
-                  "reference/avalanche-syncing"
-                ]
-              },
-              {
-                "group": "Gas data | Avalanche",
-                "pages": [
-                  "reference/avalanche-gas-data-rpc-methods",
-                  "reference/avalanche-estimategas",
-                  "reference/avalanche-getgasprice"
-                ]
-              },
-              {
-                "group": "Accounts info | Avalanche",
-                "pages": [
-                  "reference/avalanche-accounts-info-rpc-methods",
-                  "reference/avalanche-gettransactioncount",
-                  "reference/avalanche-getbalance",
-                  "reference/avalanche-getcode",
-                  "reference/avalanche-getstorageat"
-                ]
-              },
-              {
-                "group": "Logs & events | Avalanche",
-                "pages": [
-                  "reference/avalanche-logs-rpc-methods",
-                  "reference/avalanche-getlogs",
-                  "reference/avalanche-newfilter"
-                ]
-              },
-              {
-                "group": "Filter handling | Avalanche",
-                "pages": [
-                  "reference/avalanche-filters-rpc-methods",
-                  "reference/avalanche-getfilterchanges",
-                  "reference/avalanche-uninstallfilter"
-                ]
-              },
-              {
-                "group": "Client information | Avalanche",
-                "pages": [
-                  "reference/avalanche-client-data-rpc-methods",
-                  "reference/avalanche-clientversion",
-                  "reference/avalanche-listening"
-                ]
-              },
-              {
-                "group": "Subscriptions | Avalanche",
-                "pages": [
-                  "reference/avalanche-web3js-subscriptions-methods",
-                  "reference/avalanche-native-subscribe-newheads",
-                  "reference/avalanche-native-subscribe-newpendingtransactions",
-                  "reference/avalanche-native-subscribe-logs",
-                  "reference/avalanche-native-unsubscribe",
-                  "reference/avalanche-subscribenewblockheaders",
-                  "reference/avalanche-subscribependingtransactions",
-                  "reference/avalanche-subscribelogs",
-                  "reference/avalanche-subscribesyncing",
-                  "reference/avalanche-clearsubscriptions"
-                ]
-              }
-            ]
-          },
-          {
             "group": "Node APIs",
             "pages": [
+              {
+                "group": "Ethereum node API",
+                "expanded": false,
+                "pages": [
+                  "reference/ethereum-getting-started",
+                  "reference/enable-debug-trace-apis-for-your-ethereum-node",
+                  "reference/ethereum-rpc-methods-postman-collection",
+                  {
+                    "group": "Blocks info | Ethereum",
+                    "pages": [
+                      "reference/ethereum-blocks-rpc-methods",
+                      "reference/ethereum-getblockbynumber",
+                      "reference/ethereum-getblockbyhash",
+                      "reference/ethereum-getblocknumber",
+                      "reference/ethereum-getblocktransactioncountbyhash",
+                      "reference/ethereum-getblocktransactioncountbynumber",
+                      "reference/ethereum-newblockfilter"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Ethereum",
+                    "pages": [
+                      "reference/ethereum-transactions-rpc-methods",
+                      "reference/ethereum-gettransactionbyhash",
+                      "reference/ethereum-gettransactionreceipt",
+                      "reference/ethereum-gettransactionbyblockhashandindex",
+                      "reference/ethereum-gettransactionbyblocknumberandindex",
+                      "reference/ethereum-getblockreceipts",
+                      "reference/ethereum-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Ethereum",
+                    "pages": [
+                      "reference/ethereum-execution-rpc-methods",
+                      "reference/ethereum-ethcall",
+                      "reference/ethereum-simulatev1",
+                      "reference/ethereum-sendrawtransaction",
+                      "reference/ethereum-sendrawtransactionsync"
+                    ]
+                  },
+                  {
+                    "group": "Debug and Trace | Ethereum",
+                    "pages": [
+                      "reference/ethereum-debug-trace-rpc-methods",
+                      "reference/custom-js-tracing-ethereum",
+                      "reference/ethereum-traceblockbyhash",
+                      "reference/ethereum-tracetransaction",
+                      "reference/ethereum-tracecall",
+                      "reference/ethereum-tracecallmany",
+                      "reference/ethereum-trace_transaction",
+                      "reference/ethereum-trace_block",
+                      "reference/ethereum-traceblockbynumber"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Ethereum",
+                    "pages": [
+                      "reference/ethereum-chain-data-rpc-methods",
+                      "reference/ethereum-syncing",
+                      "reference/ethereum-getchainid"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Ethereum",
+                    "pages": [
+                      "reference/ethereum-gas-data-rpc-methods",
+                      "reference/ethereum-getgasprice",
+                      "reference/ethereum-estimategas",
+                      "reference/ethereum-maxpriorityfeepergas"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Ethereum",
+                    "pages": [
+                      "reference/ethereum-accounts-info-rpc-methods",
+                      "reference/ethereum-getstorageat",
+                      "reference/ethereum-getbalance",
+                      "reference/ethereum-gettransactioncount",
+                      "reference/ethereum-getcode",
+                      "reference/getproof"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Ethereum",
+                    "pages": [
+                      "reference/ethereum-logs-rpc-methods",
+                      "reference/ethereum-newfilter",
+                      "reference/ethereum-getlogs"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Ethereum",
+                    "pages": [
+                      "reference/ethereum-client-data-rpc-methods",
+                      "reference/ethereum-peercount",
+                      "reference/ethereum-listening",
+                      "reference/ethereum-clientversion"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Ethereum",
+                    "pages": [
+                      "reference/ethereum-filters-rpc-methods",
+                      "reference/ethereum-getfilterchanges",
+                      "reference/ethereum-uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Ethereum",
+                    "pages": [
+                      "reference/ethereum-web3js-subscriptions-methods",
+                      "reference/ethereum-native-subscribe-newheads",
+                      "reference/ethereum-native-subscribe-newpendingtransactions",
+                      "reference/ethereum-native-subscribe-logs",
+                      "reference/ethereum-native-unsubscribe",
+                      "reference/ethereum-subscribenewblockheaders",
+                      "reference/ethereum-subscribependingtransactions",
+                      "reference/ethereum-subscribelogs",
+                      "reference/ethereum-subscribesyncing",
+                      "reference/ethereum-clearsubscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Plasma node API",
+                "expanded": false,
+                "pages": [
+                  "reference/plasma-getting-started",
+                  {
+                    "group": "Accounts info | Plasma",
+                    "pages": [
+                      "reference/plasma-accounts-info-rpc-methods",
+                      "reference/plasma-eth-getbalance",
+                      "reference/plasma-eth-getcode",
+                      "reference/plasma-eth-getstorageat",
+                      "reference/plasma-eth-gettransactioncount",
+                      "reference/plasma-eth-getproof",
+                      "reference/plasma-eth-getaccount"
+                    ]
+                  },
+                  {
+                    "group": "Blocks info | Plasma",
+                    "pages": [
+                      "reference/plasma-blocks-info-rpc-methods",
+                      "reference/plasma-eth-blocknumber",
+                      "reference/plasma-eth-getblockbynumber",
+                      "reference/plasma-eth-getblockbyhash",
+                      "reference/plasma-eth-getblocktransactioncountbynumber",
+                      "reference/plasma-eth-getblocktransactioncountbyhash",
+                      "reference/plasma-eth-getblockreceipts",
+                      "reference/plasma-eth-getunclecountbyblocknumber",
+                      "reference/plasma-eth-getunclecountbyblockhash",
+                      "reference/plasma-eth-getunclebyblocknumberandindex",
+                      "reference/plasma-eth-getunclebyblockhashandindex",
+                      "reference/plasma-eth-getheaderbynumber",
+                      "reference/plasma-eth-getheaderbyhash"
+                    ]
+                  },
+                  {
+                    "group": "Transaction info | Plasma",
+                    "pages": [
+                      "reference/plasma-transaction-info-rpc-methods",
+                      "reference/plasma-eth-gettransactionbyhash",
+                      "reference/plasma-eth-gettransactionreceipt",
+                      "reference/plasma-eth-gettransactionbyblocknumberandindex",
+                      "reference/plasma-eth-gettransactionbyblockhashandindex",
+                      "reference/plasma-eth-getrawtransactionbyhash",
+                      "reference/plasma-eth-getrawtransactionbyblocknumberandindex",
+                      "reference/plasma-eth-getrawtransactionbyblockhashandindex",
+                      "reference/plasma-eth-gettransactionbysenderandnonce"
+                    ]
+                  },
+                  {
+                    "group": "Execute transactions | Plasma",
+                    "pages": [
+                      "reference/plasma-execute-transactions-rpc-methods",
+                      "reference/plasma-eth-call",
+                      "reference/plasma-eth-estimategas",
+                      "reference/plasma-eth-createaccesslist",
+                      "reference/plasma-eth-simulatev1"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Plasma",
+                    "pages": [
+                      "reference/plasma-gas-data-rpc-methods",
+                      "reference/plasma-eth-gasprice",
+                      "reference/plasma-eth-maxpriorityfeepergas",
+                      "reference/plasma-eth-feehistory",
+                      "reference/plasma-eth-blobbasefee"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Plasma",
+                    "pages": [
+                      "reference/plasma-chain-info-rpc-methods",
+                      "reference/plasma-eth-chainid",
+                      "reference/plasma-eth-syncing",
+                      "reference/plasma-eth-protocolversion",
+                      "reference/plasma-eth-accounts",
+                      "reference/plasma-eth-hashrate"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Plasma",
+                    "pages": [
+                      "reference/plasma-filter-handling-rpc-methods",
+                      "reference/plasma-eth-newfilter",
+                      "reference/plasma-eth-newblockfilter",
+                      "reference/plasma-eth-newpendingtransactionfilter",
+                      "reference/plasma-eth-uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Logs and events | Plasma",
+                    "pages": [
+                      "reference/plasma-logs-and-events-rpc-methods",
+                      "reference/plasma-eth-getlogs"
+                    ]
+                  },
+                  {
+                    "group": "Client info | Plasma",
+                    "pages": [
+                      "reference/plasma-client-info-rpc-methods",
+                      "reference/plasma-web3-clientversion",
+                      "reference/plasma-web3-sha3",
+                      "reference/plasma-net-version",
+                      "reference/plasma-net-listening",
+                      "reference/plasma-net-peercount"
+                    ]
+                  },
+                  {
+                    "group": "Debug and trace | Plasma",
+                    "pages": [
+                      "reference/plasma-debug-and-trace-rpc-methods",
+                      "reference/plasma-debug-getrawheader",
+                      "reference/plasma-debug-getrawblock",
+                      "reference/plasma-debug-getrawtransaction",
+                      "reference/plasma-debug-getrawreceipts",
+                      "reference/plasma-debug-tracecall",
+                      "reference/plasma-trace-call",
+                      "reference/plasma-trace-callmany",
+                      "reference/plasma-trace-replayblocktransactions",
+                      "reference/plasma-trace-block",
+                      "reference/plasma-trace-get"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Ethereum Beacon Chain API",
+                "expanded": false,
+                "pages": [
+                  "reference/beacon-chain",
+                  {
+                    "group": "Beacon Chain configuration info",
+                    "pages": [
+                      "reference/beacon-chain-configuration",
+                      "reference/getforkinformation",
+                      "reference/ethereum-beacon-genesis",
+                      "reference/getconfigforkschedule",
+                      "reference/getconfigspec",
+                      "reference/getconfigdepositcontract"
+                    ]
+                  },
+                  {
+                    "group": "Beacon Chain events",
+                    "pages": [
+                      "reference/beacon-chain-events",
+                      "reference/subscribetobeaconevents"
+                    ]
+                  },
+                  {
+                    "group": "Beacon Chain validators info",
+                    "pages": [
+                      "reference/beacon-chain-node",
+                      "reference/getbeaconpoolvoluntaryexits",
+                      "reference/getbeaconpoolproposerslashings",
+                      "reference/getbeaconpoolattesterslashings",
+                      "reference/getbeaconpoolattestationsbyslotandcommitteeindex",
+                      "reference/getvalidatorbalancesbystateidandvalidatorid",
+                      "reference/getvalidatorbystateidandindex",
+                      "reference/getvalidatorinformation",
+                      "reference/getproposerduties",
+                      "reference/produceblock",
+                      "reference/produceblindedblock",
+                      "reference/getattestationdata",
+                      "reference/getbeaconblockattestationsbyblockid"
+                    ]
+                  },
+                  {
+                    "group": "Beacon Chain state",
+                    "pages": [
+                      "reference/beacon-chain-state",
+                      "reference/getbeaconblockrootbyblockid",
+                      "reference/getbeaconblocksbyblockid",
+                      "reference/getbeaconheadersbyblockid",
+                      "reference/getbeaconheadersbyslotandparentroot",
+                      "reference/getsynccommitteecontribution",
+                      "reference/getsynccommitteesbystateidandepoch",
+                      "reference/getcommitteesbystateidepochindexandslot",
+                      "reference/getfinalitycheckpoints",
+                      "reference/getstateroot",
+                      "reference/getblobsbyblockid",
+                      "reference/getdebugbeaconstatev2",
+                      "reference/getdebugbeaconheadsv2",
+                      "reference/getdebugforkchoice"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Polygon node API",
+                "expanded": false,
+                "pages": [
+                  "reference/polygon-getting-started",
+                  {
+                    "group": "Blocks Info | Polygon",
+                    "pages": [
+                      "reference/polygon-blocks-rpc-methods",
+                      "reference/polygon-getblocknumber",
+                      "reference/getblockbyhash",
+                      "reference/polygon-getblocktransactioncountbyhash",
+                      "reference/polygon-getblocktransactioncountbynumber",
+                      "reference/polygon-getblockbynumber",
+                      "reference/polygon-newblockfilter"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Polygon",
+                    "pages": [
+                      "reference/polygon-transactions-rpc-methods",
+                      "reference/polygon-gettransactionbyhash",
+                      "reference/polygon-gettransactionreceipt",
+                      "reference/polygon-gettransactionbyblockhashandindex",
+                      "reference/polygon-gettransactionbyblocknumberandindex",
+                      "reference/polygon-getblockreceipts",
+                      "reference/polygon-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Polygon",
+                    "pages": [
+                      "reference/polygon-evm-excecution-rpc-methods",
+                      "reference/ethcall",
+                      "reference/sendrawtransaction",
+                      "reference/polygon-sendrawtransactionsync"
+                    ]
+                  },
+                  {
+                    "group": "Debug & Trace | Polygon",
+                    "pages": [
+                      "reference/polygon-debug-trace-rpc-methods",
+                      "reference/polygon-traceblockbyhash",
+                      "reference/polygon-traceblockbynumber",
+                      "reference/polygon-tracetransaction",
+                      "reference/polygon-tracecall",
+                      "reference/polygon-trace_transaction",
+                      "reference/polygon-trace_block"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Polygon",
+                    "pages": [
+                      "reference/polygon-chain-data-rpc-methods",
+                      "reference/chainid",
+                      "reference/syncing"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Polygon",
+                    "pages": [
+                      "reference/polygon-gas-data-rpc-methods",
+                      "reference/estimategas",
+                      "reference/gasprice"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Polygon",
+                    "pages": [
+                      "reference/polygon-accounts-info-rpc-methods",
+                      "reference/gettransactioncount",
+                      "reference/getbalance",
+                      "reference/getcode",
+                      "reference/getstorageat"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Polygon",
+                    "pages": [
+                      "reference/polygon-logs-rpc-methods",
+                      "reference/getlogs",
+                      "reference/newfilter"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Polygon",
+                    "pages": [
+                      "reference/polygon-filters-rpc-methods",
+                      "reference/getfilterchanges",
+                      "reference/uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Polygon",
+                    "pages": [
+                      "reference/polygon-client-data-rpc-methods",
+                      "reference/clientversion",
+                      "reference/netlistening",
+                      "reference/peercount"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Polygon",
+                    "pages": [
+                      "reference/polygon-web3js-subscriptions-methods",
+                      "reference/polygon-native-subscribe-newheads",
+                      "reference/polygon-native-subscribe-newpendingtransactions",
+                      "reference/polygon-native-subscribe-logs",
+                      "reference/polygon-native-unsubscribe",
+                      "reference/polygon-subscribenewblockheaders",
+                      "reference/polygon-subscribependingtransactions",
+                      "reference/polygon-subscribelogs",
+                      "reference/polygon-subscribesyncing",
+                      "reference/polygon-clearsubscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "BNB node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-bnb-chain",
+                  {
+                    "group": "Endpoints",
+                    "pages": [
+                      "reference/bnb-blocknumber",
+                      "reference/bnb-getblockbynumber",
+                      "reference/bnb-getblockbyhash",
+                      "reference/bnb-getblocktransactioncountbynumber",
+                      "reference/bnb-getblocktransactioncountbyhash",
+                      "reference/bnb-newblockfilter",
+                      "reference/bnb-gettransactionbyhash",
+                      "reference/bnb-gettransactionreceipt",
+                      "reference/bnb-gettransactionbyblocknumberandindex",
+                      "reference/bnb-gettransactionbyblockhashandindex",
+                      "reference/bnb-getblockreceipts",
+                      "reference/bnb-newpendingtransactionfilter",
+                      "reference/bnb-ethcall",
+                      "reference/bnb-sendrawtransaction",
+                      "reference/bnb-getbalance",
+                      "reference/bnb-getcode",
+                      "reference/bnb-getstorageat",
+                      "reference/bnb-gettransactioncount",
+                      "reference/bnb-getproof",
+                      "reference/bnb-getchainid",
+                      "reference/bnb-syncing",
+                      "reference/bnb-netlistening",
+                      "reference/bnb-peercount",
+                      "reference/bnb-clientversion",
+                      "reference/bnb-estimategas",
+                      "reference/bnb-getgasprice",
+                      "reference/bnb-maxpriorityfeepergas",
+                      "reference/bnb-getlogs",
+                      "reference/bnb-newfilter",
+                      "reference/bnb-getfilterchanges",
+                      "reference/bnb-uninstallfilter",
+                      "reference/bnb-customtracer",
+                      "reference/bnb-traceblockbyhash",
+                      "reference/bnb-traceblockbynumber",
+                      "reference/bnb-tracecall",
+                      "reference/bnb-tracetransaction",
+                      "reference/bnb-traceblock",
+                      "reference/trace_transaction",
+                      "reference/bnb-trace-call",
+                      "reference/bnb-tracecallmany",
+                      "reference/bnb-replayblocktransactions",
+                      "reference/bnb-replaytransaction",
+                      "reference/bnb-gettrace"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Base node API",
+                "expanded": false,
+                "pages": [
+                  "reference/base-api-reference",
+                  {
+                    "group": "Endpoints",
+                    "pages": [
+                      "reference/base-blocknumber",
+                      "reference/base-getblockbyhash",
+                      "reference/base-getblockbynumber",
+                      "reference/base-getblocktransactioncountbyhash",
+                      "reference/base-getblocktransactioncountbynumber",
+                      "reference/base-getunclecountbyblockhash",
+                      "reference/base-getunclecountbyblocknumber",
+                      "reference/base-getunclebyblocknumberandindex",
+                      "reference/base-getunclebyblockhashandindex",
+                      "reference/base-getblockreceipts",
+                      "reference/base-chainid",
+                      "reference/base-syncing",
+                      "reference/base-call",
+                      "reference/base-callmany",
+                      "reference/base-estimategas",
+                      "reference/debug-createaccesslist",
+                      "reference/debug-gasprice",
+                      "reference/debug-feehistory",
+                      "reference/base-newfilter",
+                      "reference/base-newblockfilter",
+                      "reference/base-uninstallfilter",
+                      "reference/base-getfilterchanges",
+                      "reference/base-getfilterlogs",
+                      "reference/base-getlogs",
+                      "reference/base-accounts",
+                      "reference/base-getbalance",
+                      "reference/base-getstorageat",
+                      "reference/base-gettransactioncount",
+                      "reference/base-getcode",
+                      "reference/base-getproof",
+                      "reference/base-gettransactionbyhash",
+                      "reference/base-getrawtransactionbyhash",
+                      "reference/base-gettransactionbyblockhashandindex",
+                      "reference/base-getrawtransactionbyblockhashandindex",
+                      "reference/base-gettransactionbyblocknumberandindex",
+                      "reference/base-getrawtransactionbyblocknumberandindex",
+                      "reference/base-gettransactionreceipt",
+                      "reference/base-maxpriorityfeepergas",
+                      "reference/base-sendrawtransaction",
+                      "reference/base-sendrawtransactionsync",
+                      "reference/base-newpendingtransactionfilter",
+                      "reference/base-clientversion",
+                      "reference/protocolversion",
+                      "reference/base-sha3",
+                      "reference/base-listening",
+                      "reference/base-getmodifiedaccountsbynumber",
+                      "reference/base-getmodifiedaccountsbyhash",
+                      "reference/base-getstoragerangeat",
+                      "reference/base-traceblockbyhash",
+                      "reference/base-traceblockbynumber",
+                      "reference/base-tracetransaction",
+                      "reference/base-tracecall",
+                      "reference/base-tracecallmany",
+                      "reference/base-trace-call",
+                      "reference/base-trace-callmany",
+                      "reference/base-trace-replayblocktransactions",
+                      "reference/base-trace-replaytransaction",
+                      "reference/debug-tracetransaction",
+                      "reference/base-trace-get",
+                      "reference/base-trace-block"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Base",
+                    "pages": [
+                      "reference/base-subscribe-newflashblocktransactions",
+                      "reference/base-subscribe-pendinglogs",
+                      "reference/base-subscribe-newflashblocks",
+                      "reference/base-unsubscribe"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "TRON node API",
+                "expanded": false,
+                "pages": [
+                  "reference/tron-api-reference",
+                  {
+                    "group": "Wallet operations",
+                    "pages": [
+                      "reference/tron-validateaddress",
+                      "reference/tron-broadcasttransaction",
+                      "reference/tron-broadcasthex",
+                      "reference/tron-createtransaction",
+                      "reference/tron-createaccount",
+                      "reference/tron-updateaccount",
+                      "reference/tron-accountpermissionupdate"
+                    ]
+                  },
+                  {
+                    "group": "Account management",
+                    "pages": [
+                      "reference/tron-getaccount",
+                      "reference/tron-getaccountbalance",
+                      "reference/tron-getaccountnet",
+                      "reference/tron-getapprovedlist"
+                    ]
+                  },
+                  {
+                    "group": "Resource management",
+                    "pages": [
+                      "reference/tron-getaccountresource",
+                      "reference/tron-freezebalance",
+                      "reference/tron-unfreezebalance",
+                      "reference/tron-freezebalancev2",
+                      "reference/tron-unfreezebalancev2",
+                      "reference/tron-cancelallunfreezev2",
+                      "reference/tron-delegateresource",
+                      "reference/tron-undelegateresource",
+                      "reference/tron-withdrawexpireunfreeze",
+                      "reference/tron-getdelegatedresource",
+                      "reference/tron-getdelegatedresourcev2",
+                      "reference/tron-getdelegatedresourceaccountindex",
+                      "reference/tron-getdelegatedresourceaccountindexv2",
+                      "reference/tron-getavailableunfreezecount",
+                      "reference/tron-getcanwithdrawunfreezeamount",
+                      "reference/tron-getcandelegatedmaxsize"
+                    ]
+                  },
+                  {
+                    "group": "Block operations",
+                    "pages": [
+                      "reference/tron-getnowblock",
+                      "reference/tron-getblock",
+                      "reference/tron-getblockbynum",
+                      "reference/tron-getblockbyid",
+                      "reference/tron-getblockbylatestnum",
+                      "reference/tron-getblockbylimitnext",
+                      "reference/tron-getblockbalance"
+                    ]
+                  },
+                  {
+                    "group": "Transaction operations",
+                    "pages": [
+                      "reference/tron-createtransaction",
+                      "reference/tron-broadcasttransaction",
+                      "reference/tron-broadcasthex",
+                      "reference/tron-gettransactionbyid",
+                      "reference/tron-gettransactioninfobyid",
+                      "reference/tron-gettransactioninfobyblocknum",
+                      "reference/tron-gettransactionlistfrompending",
+                      "reference/tron-gettransactionfrompending",
+                      "reference/tron-getpendingsize"
+                    ]
+                  },
+                  {
+                    "group": "Smart contracts",
+                    "pages": [
+                      "reference/tron-getcontract",
+                      "reference/tron-getcontractinfo",
+                      "reference/tron-triggersmartcontract",
+                      "reference/tron-triggerconstantcontract",
+                      "reference/tron-deploycontract",
+                      "reference/tron-updatesetting",
+                      "reference/tron-updateenergylimit",
+                      "reference/tron-clearabi",
+                      "reference/tron-estimateenergy"
+                    ]
+                  },
+                  {
+                    "group": "Witness and governance",
+                    "pages": [
+                      "reference/tron-listwitnesses",
+                      "reference/tron-createwitness",
+                      "reference/tron-updatewitness",
+                      "reference/tron-votewitnessaccount",
+                      "reference/tron-getbrokerage",
+                      "reference/tron-updatebrokerage",
+                      "reference/tron-getreward",
+                      "reference/tron-withdrawbalance",
+                      "reference/tron-getnextmaintenancetime",
+                      "reference/tron-listproposals",
+                      "reference/tron-getproposalbyid",
+                      "reference/tron-proposalcreate",
+                      "reference/tron-proposalapprove",
+                      "reference/tron-proposaldelete",
+                      "reference/tron-getpaginatedproposallist"
+                    ]
+                  },
+                  {
+                    "group": "Assets and tokens",
+                    "pages": [
+                      "reference/tron-getassetissuebyid",
+                      "reference/tron-getassetissuebyname",
+                      "reference/tron-getassetissuelist",
+                      "reference/tron-getassetissuelistbyname",
+                      "reference/tron-getpaginatedassetissuelist",
+                      "reference/tron-transferasset",
+                      "reference/tron-createassetissue",
+                      "reference/tron-participateassetissue",
+                      "reference/tron-unfreezeasset",
+                      "reference/tron-updateasset"
+                    ]
+                  },
+                  {
+                    "group": "Network information",
+                    "pages": [
+                      "reference/tron-getnodeinfo",
+                      "reference/tron-listnodes",
+                      "reference/tron-getchainparameters",
+                      "reference/tron-getenergyprices",
+                      "reference/tron-getbandwidthprices",
+                      "reference/tron-getburntrx"
+                    ]
+                  },
+                  {
+                    "group": "Exchange and market methods",
+                    "pages": [
+                      "reference/tron-listexchanges",
+                      "reference/tron-getexchangebyid",
+                      "reference/tron-exchangecreate",
+                      "reference/tron-exchangeinject",
+                      "reference/tron-exchangewithdraw",
+                      "reference/tron-exchangetransaction",
+                      "reference/tron-getmarketorderbyaccount",
+                      "reference/tron-getmarketorderbyid",
+                      "reference/tron-getmarketpricebypair",
+                      "reference/tron-getmarketorderlistbypair",
+                      "reference/tron-getmarketpairlist",
+                      "reference/tron-marketcancelorder",
+                      "reference/tron-marketsellasset",
+                      "reference/tron-marketbuyasset"
+                    ]
+                  },
+                  {
+                    "group": "Shielded contract methods",
+                    "pages": [
+                      "reference/tron-shielded-getspendingkey",
+                      "reference/tron-shielded-getexpandedspendingkey",
+                      "reference/tron-shielded-getakfromask",
+                      "reference/tron-shielded-getnkfromnsk",
+                      "reference/tron-shielded-getincomingviewingkey",
+                      "reference/tron-shielded-getdiversifier",
+                      "reference/tron-shielded-getshieldedpaymentaddress",
+                      "reference/tron-shielded-getzenpaymentaddress",
+                      "reference/tron-shielded-getnewshieldedaddress",
+                      "reference/tron-getmerkletreevoucherinfo",
+                      "reference/tron-shielded-createshieldedtransaction",
+                      "reference/tron-shielded-createshieldedtransactionwithoutspendauthsig",
+                      "reference/tron-shielded-createshieldedcontractparameters",
+                      "reference/tron-shielded-createshieldedcontractparameterswithoutask",
+                      "reference/tron-shielded-createspendauthsig",
+                      "reference/tron-shielded-gettriggerinputforshieldedtrc20contract",
+                      "reference/tron-shielded-scanshieldedtrc20notesbyivk",
+                      "reference/tron-shielded-scanshieldedtrc20notesbyovk",
+                      "reference/tron-shielded-isshieldedtrc20contractnotespent"
+                    ]
+                  },
+                  {
+                    "group": "Walletsolidity methods",
+                    "pages": [
+                      "reference/tron-solidity-getaccount",
+                      "reference/tron-solidity-getblockbynum",
+                      "reference/tron-solidity-getblockbyid",
+                      "reference/tron-solidity-getblockbylimitnext",
+                      "reference/tron-solidity-getblockbylatestnum",
+                      "reference/tron-solidity-getnowblock",
+                      "reference/tron-solidity-gettransactionbyid",
+                      "reference/tron-solidity-gettransactioninfobyid",
+                      "reference/tron-solidity-gettransactioncountbyblocknum"
+                    ]
+                  },
+                  {
+                    "group": "JSON-RPC methods",
+                    "pages": [
+                      "reference/tron-jsonrpc-blocknumber",
+                      "reference/tron-jsonrpc-getblockbynumber",
+                      "reference/tron-jsonrpc-getblockbyhash",
+                      "reference/tron-jsonrpc-getblocktransactioncountbyhash",
+                      "reference/tron-jsonrpc-getblocktransactioncountbynumber",
+                      "reference/tron-jsonrpc-gettransactionbyhash",
+                      "reference/tron-jsonrpc-gettransactionbyblockhashandindex",
+                      "reference/tron-jsonrpc-gettransactionbyblocknumberandindex",
+                      "reference/tron-jsonrpc-gettransactionreceipt",
+                      "reference/tron-jsonrpc-sendrawtransaction",
+                      "reference/tron-jsonrpc-getbalance",
+                      "reference/tron-jsonrpc-getcode",
+                      "reference/tron-jsonrpc-getstorageat",
+                      "reference/tron-jsonrpc-call",
+                      "reference/tron-jsonrpc-estimategas",
+                      "reference/tron-jsonrpc-gasprice",
+                      "reference/tron-jsonrpc-getlogs",
+                      "reference/tron-jsonrpc-newfilter",
+                      "reference/tron-jsonrpc-newblockfilter",
+                      "reference/tron-jsonrpc-getfilterchanges",
+                      "reference/tron-jsonrpc-getfilterlogs",
+                      "reference/tron-jsonrpc-uninstallfilter",
+                      "reference/tron-jsonrpc-getwork",
+                      "reference/tron-jsonrpc-protocolversion",
+                      "reference/tron-jsonrpc-syncing",
+                      "reference/tron-jsonrpc-listening",
+                      "reference/tron-jsonrpc-peercount",
+                      "reference/tron-jsonrpc-version",
+                      "reference/tron-jsonrpc-clientversion",
+                      "reference/tron-jsonrpc-sha3",
+                      "reference/tron-jsonrpc-web3-clientversion",
+                      "reference/tron-jsonrpc-net-version"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Avalanche node API",
+                "expanded": false,
+                "pages": [
+                  "reference/avalanche-getting-started",
+                  {
+                    "group": "Blocks Info | Avalanche",
+                    "pages": [
+                      "reference/avalanche-blocks-rpc-methods",
+                      "reference/avalanche-getblocknumber",
+                      "reference/avalanche-getblockbyhash",
+                      "reference/avalanche-getblockbynumber",
+                      "reference/avalanche-getblocktransactioncountbyhash",
+                      "reference/avalanche-getblocktransactioncountbynumber",
+                      "reference/avalanche-newblockfilter"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Avalanche",
+                    "pages": [
+                      "reference/avalanche-transactions-rpc-methods",
+                      "reference/avalanche-gettransactionbyhash",
+                      "reference/avalanche-gettransactionreceipt",
+                      "reference/avalanche-gettransactionbyblockhashandindex",
+                      "reference/avalanche-gettransactionbyblocknumberandindex",
+                      "reference/avalanche-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Avalanche",
+                    "pages": [
+                      "reference/avalanche-execution-rpc-methods",
+                      "reference/avalanche-ethcall",
+                      "reference/avalanche-sendrawtransaction"
+                    ]
+                  },
+                  {
+                    "group": "Debug & Trace | Avalanche",
+                    "pages": [
+                      "reference/avalanche-debug-trace-rpc-methods",
+                      "reference/avalanche-traceblockbyhash",
+                      "reference/avalanche-traceblockbynumber",
+                      "reference/avalanche-tracecall",
+                      "reference/avalanche-tracetransaction"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Avalanche",
+                    "pages": [
+                      "reference/avalanche-chain-data-rpc-methods",
+                      "reference/avalanche-getchainid",
+                      "reference/avalanche-syncing"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Avalanche",
+                    "pages": [
+                      "reference/avalanche-gas-data-rpc-methods",
+                      "reference/avalanche-estimategas",
+                      "reference/avalanche-getgasprice"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Avalanche",
+                    "pages": [
+                      "reference/avalanche-accounts-info-rpc-methods",
+                      "reference/avalanche-gettransactioncount",
+                      "reference/avalanche-getbalance",
+                      "reference/avalanche-getcode",
+                      "reference/avalanche-getstorageat"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Avalanche",
+                    "pages": [
+                      "reference/avalanche-logs-rpc-methods",
+                      "reference/avalanche-getlogs",
+                      "reference/avalanche-newfilter"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Avalanche",
+                    "pages": [
+                      "reference/avalanche-filters-rpc-methods",
+                      "reference/avalanche-getfilterchanges",
+                      "reference/avalanche-uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Avalanche",
+                    "pages": [
+                      "reference/avalanche-client-data-rpc-methods",
+                      "reference/avalanche-clientversion",
+                      "reference/avalanche-listening"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Avalanche",
+                    "pages": [
+                      "reference/avalanche-web3js-subscriptions-methods",
+                      "reference/avalanche-native-subscribe-newheads",
+                      "reference/avalanche-native-subscribe-newpendingtransactions",
+                      "reference/avalanche-native-subscribe-logs",
+                      "reference/avalanche-native-unsubscribe",
+                      "reference/avalanche-subscribenewblockheaders",
+                      "reference/avalanche-subscribependingtransactions",
+                      "reference/avalanche-subscribelogs",
+                      "reference/avalanche-subscribesyncing",
+                      "reference/avalanche-clearsubscriptions"
+                    ]
+                  }
+                ]
+              },
               {
                 "group": "Hyperliquid node API",
                 "expanded": false,
@@ -2559,917 +2567,930 @@
                   "reference/hyperliquid-evm-eth-subscribe-syncing",
                   "reference/hyperliquid-evm-eth-unsubscribe"
                 ]
+              },
+              {
+                "group": "Monad node API",
+                "expanded": false,
+                "pages": [
+                  "reference/monad-getting-started",
+                  {
+                    "group": "Blocks info | Monad",
+                    "pages": [
+                      "reference/monad-blocks-rpc-methods",
+                      "reference/monad-getblocknumber",
+                      "reference/monad-getblockbynumber",
+                      "reference/monad-getblockbyhash",
+                      "reference/monad-getblocktransactioncountbyhash",
+                      "reference/monad-getblocktransactioncountbynumber",
+                      "reference/monad-newblockfilter",
+                      "reference/monad-subscribe-monadnewheads"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Monad",
+                    "pages": [
+                      "reference/monad-transactions-rpc-methods",
+                      "reference/monad-gettransactionbyhash",
+                      "reference/monad-gettransactionreceipt",
+                      "reference/monad-gettransactionbyblockhashandindex",
+                      "reference/monad-gettransactionbyblocknumberandindex",
+                      "reference/monad-getblockreceipts",
+                      "reference/monad-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Monad",
+                    "pages": [
+                      "reference/monad-execution-rpc-methods",
+                      "reference/monad-ethcall",
+                      "reference/monad-sendrawtransaction",
+                      "reference/monad-createaccesslist"
+                    ]
+                  },
+                  {
+                    "group": "Debug and Trace | Monad",
+                    "pages": [
+                      "reference/monad-debug-trace-rpc-methods",
+                      "reference/monad-tracetransaction",
+                      "reference/monad-traceblockbynumber",
+                      "reference/monad-traceblockbyhash",
+                      "reference/monad-tracecall"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Monad",
+                    "pages": [
+                      "reference/monad-chain-data-rpc-methods",
+                      "reference/monad-getchainid",
+                      "reference/monad-syncing"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Monad",
+                    "pages": [
+                      "reference/monad-gas-data-rpc-methods",
+                      "reference/monad-getgasprice",
+                      "reference/monad-estimategas",
+                      "reference/monad-maxpriorityfeepergas",
+                      "reference/monad-feehistory"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Monad",
+                    "pages": [
+                      "reference/monad-accounts-info-rpc-methods",
+                      "reference/monad-getbalance",
+                      "reference/monad-gettransactioncount",
+                      "reference/monad-getcode",
+                      "reference/monad-getstorageat"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Monad",
+                    "pages": [
+                      "reference/monad-logs-rpc-methods",
+                      "reference/monad-getlogs"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Monad",
+                    "pages": [
+                      "reference/monad-client-data-rpc-methods",
+                      "reference/monad-clientversion",
+                      "reference/monad-netversion",
+                      "reference/monad-listening"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "TON node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-ton",
+                  "reference/ton-getaddressinformation-v2",
+                  "reference/ton-getextendedaddressinformation-v2",
+                  "reference/ton-getwalletinformation-v2",
+                  "reference/ton-gettransactions-v2",
+                  "reference/ton-getaddressbalance-v2",
+                  "reference/ton-getaddressstate-v2",
+                  "reference/ton-packaddress-v2",
+                  "reference/ton-unpackaddress-v2",
+                  "reference/ton-gettokendata-v2",
+                  "reference/ton-detectaddress-v2",
+                  "reference/ton-getmasterchaininfo-v2",
+                  "reference/ton-getmasterchainblocksignatures-v2",
+                  "reference/ton-getshardblockproof-v2",
+                  "reference/ton-getconsensusblock-v2",
+                  "reference/ton-lookupblock-v2",
+                  "reference/ton-shards-v2",
+                  "reference/ton-getblocktransactions-v2",
+                  "reference/ton-getblocktransactionsext-v2",
+                  "reference/ton-getblockheader-v2",
+                  "reference/ton-trylocatetx-v2",
+                  "reference/ton-trylocateresulttx-v2",
+                  "reference/ton-trylocatesourcetx-v2",
+                  "reference/ton-getconfigparam-v2",
+                  "reference/ton-rungetmethod-v2",
+                  "reference/ton-sendboc-v2",
+                  "reference/ton-sendbocreturnhash-v2",
+                  "reference/ton-sendquery-v2",
+                  "reference/ton-estimatefee-v2",
+                  "reference/ton-masterchaininfo-v3",
+                  "reference/ton-blocks-v3",
+                  "reference/ton-masterchainblockshardstate-v3",
+                  "reference/ton-addressbook-v3",
+                  "reference/ton-masterchainblockshards-v3",
+                  "reference/ton-transactions-v3",
+                  "reference/ton-transactionsbymasterchainblock-v3",
+                  "reference/ton-transactionsbymessage-v3",
+                  "reference/ton-adjacenttransactions-v3",
+                  "reference/ton-messages-v3",
+                  "reference/ton-nft-collections-v3",
+                  "reference/ton-nft-items-v3",
+                  "reference/ton-nft-transfers-v3",
+                  "reference/ton-jetton-masters-v3",
+                  "reference/ton-jetton-wallets-v3",
+                  "reference/ton-jetton-transfers-v3",
+                  "reference/ton-jetton-burns-v3",
+                  "reference/ton-rungetmethod-v3",
+                  "reference/ton-estimatefee-v3",
+                  "reference/ton-account-v3",
+                  "reference/ton-wallet-v3",
+                  "reference/ton-addressinformation-v3",
+                  "reference/ton-walletstates-v3",
+                  "reference/ton-accountstates-v3",
+                  "reference/ton-metadata-v3",
+                  "reference/ton-traces-v3",
+                  "reference/ton-actions-v3",
+                  "reference/ton-events-v3",
+                  "reference/ton-pendingtransactions-v3",
+                  "reference/ton-pendingtraces-v3",
+                  "reference/ton-multisig-wallets-v3",
+                  "reference/ton-multisig-orders-v3",
+                  "reference/ton-message-v3",
+                  "reference/ton-topaccountsbybalance-v3"
+                ]
+              },
+              {
+                "group": "Arbitrum node API",
+                "expanded": false,
+                "pages": [
+                  "reference/arbitrum-getting-started",
+                  {
+                    "group": "Blocks info | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-blocks-rpc-methods",
+                      "reference/arbitrum-eth_blocknumber",
+                      "reference/arbitrum-getblockbyhash",
+                      "reference/arbitrum-getblockbynumber",
+                      "reference/arbitrum-getblocktransactioncountbyhash",
+                      "reference/arbitrum-getblocktransactioncountbynumber",
+                      "reference/arbitrum-newblockfilter"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-transactions-rpc-methods",
+                      "reference/arbitrum-gettransactionbyhash",
+                      "reference/arbitrum-gettransactionreceipt",
+                      "reference/arbitrum-gettransactionbyblockhashandindex",
+                      "reference/arbitrum-gettransactionbyblocknumberandindex",
+                      "reference/arbitrum-simulatev1"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-evm-excecution-rpc-methods",
+                      "reference/arbitrum-ethcall",
+                      "reference/arbitrum-sendrawtransaction",
+                      "reference/arbitrum-sendrawtransactionsync"
+                    ]
+                  },
+                  {
+                    "group": "Debug & Trace | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-debug-and-trace-rpc-methods",
+                      "reference/arbitrum-debug-accountrange",
+                      "reference/arbitrum-debug-dumpblock",
+                      "reference/arbitrum-debug-getaccessiblestate",
+                      "reference/arbitrum-debug-getmodifiedaccountsbyhash",
+                      "reference/arbitrum-debug-getmodifiedaccountsbynumber",
+                      "reference/arbitrum-debug-getrawblock",
+                      "reference/arbitrum-debug-getrawheader",
+                      "reference/arbitrum-debug-getrawreceipts",
+                      "reference/arbitrum-debug-getrawtransaction",
+                      "reference/arbitrum-debug-intermediateroots",
+                      "reference/arbitrum-debug-preimage",
+                      "reference/arbitrum-debug-printblock",
+                      "reference/arbitrum-debug-tracebadblock",
+                      "reference/arbitrum-debug-traceblockbyhash",
+                      "reference/arbitrum-debug-traceblockbynumber",
+                      "reference/arbitrum-debug-tracecall",
+                      "reference/arbitrum-debug-tracetransaction",
+                      "reference/arbitrum-arbtrace-block",
+                      "reference/arbitrum-arbtrace-call",
+                      "reference/arbitrum-arbtrace-callmany",
+                      "reference/arbitrum-arbtrace-filter",
+                      "reference/arbitrum-arbtrace-get",
+                      "reference/arbitrum-arbtrace-replayblocktransactions",
+                      "reference/arbitrum-arbtrace-replaytransaction",
+                      "reference/arbitrum-arbtrace-transaction",
+                      "reference/arbitrum-tracetransaction"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-chain-data-rpc-methods",
+                      "reference/arbitrum-getchainid",
+                      "reference/arbitrum-syncing"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-gas-data-rpc-methods",
+                      "reference/arbitrum-estimategas",
+                      "reference/arbitrum-getgasprice"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-accounts-info-rpc-methods",
+                      "reference/arbitrum-gettransactioncount",
+                      "reference/arbitrum-getbalance",
+                      "reference/arbitrum-getcode",
+                      "reference/arbitrum-getstorageat"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-logs-rpc-methods",
+                      "reference/arbitrum-getlogs",
+                      "reference/arbitrum-newfilter"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-filters-rpc-methods",
+                      "reference/arbitrum-getfilterchanges",
+                      "reference/arbitrum-uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-client-data-rpc-methods",
+                      "reference/arbitrum-clientversion"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Arbitrum",
+                    "pages": [
+                      "reference/arbitrum-web3js-subscriptions-methods",
+                      "reference/arbitrum-native-subscribe-newheads",
+                      "reference/arbitrum-native-subscribe-logs",
+                      "reference/arbitrum-native-unsubscribe",
+                      "reference/arbitrum-subscribenewblockheaders",
+                      "reference/arbitrum-subscribelogs",
+                      "reference/arbitrum-subscribesyncing",
+                      "reference/arbitrum-clearsubscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Tempo node API",
+                "expanded": false,
+                "pages": [
+                  "reference/tempo-getting-started",
+                  {
+                    "group": "Tempo specific | Tempo",
+                    "pages": [
+                      "reference/tempo-tempo-fundaddress",
+                      "reference/tempo-eth-sendrawtransactionsync"
+                    ]
+                  },
+                  {
+                    "group": "Blocks info | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-blocknumber",
+                      "reference/tempo-eth-getblockbyhash",
+                      "reference/tempo-eth-getblockbynumber",
+                      "reference/tempo-eth-newblockfilter",
+                      "reference/tempo-eth-getblockreceipts",
+                      "reference/tempo-eth-getblocktransactioncountbyhash",
+                      "reference/tempo-eth-getblocktransactioncountbynumber",
+                      "reference/tempo-eth-getunclecountbyblocknumber"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-gettransactionbyhash",
+                      "reference/tempo-eth-gettransactionreceipt",
+                      "reference/tempo-eth-sendrawtransaction",
+                      "reference/tempo-eth-call",
+                      "reference/tempo-eth-gettransactionbyblockhashandindex",
+                      "reference/tempo-eth-gettransactionbyblocknumberandindex",
+                      "reference/tempo-eth-createaccesslist"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-chainid",
+                      "reference/tempo-eth-syncing",
+                      "reference/tempo-eth-protocolversion",
+                      "reference/tempo-eth-accounts"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-gasprice",
+                      "reference/tempo-eth-estimategas",
+                      "reference/tempo-eth-maxpriorityfeepergas",
+                      "reference/tempo-eth-feehistory",
+                      "reference/tempo-eth-blobbasefee"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-getbalance",
+                      "reference/tempo-eth-gettransactioncount",
+                      "reference/tempo-eth-getcode",
+                      "reference/tempo-eth-getstorageat",
+                      "reference/tempo-eth-getproof"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-getlogs",
+                      "reference/tempo-eth-newfilter",
+                      "reference/tempo-eth-getfilterlogs"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Tempo",
+                    "pages": [
+                      "reference/tempo-eth-getfilterchanges",
+                      "reference/tempo-eth-uninstallfilter",
+                      "reference/tempo-eth-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Debug & trace | Tempo",
+                    "pages": [
+                      "reference/tempo-debug-tracetransaction",
+                      "reference/tempo-debug-tracecall",
+                      "reference/tempo-debug-traceblockbynumber",
+                      "reference/tempo-debug-traceblockbyhash",
+                      "reference/tempo-debug-tracecallmany",
+                      "reference/tempo-debug-getbadblocks",
+                      "reference/tempo-debug-getrawblock",
+                      "reference/tempo-debug-getrawheader",
+                      "reference/tempo-debug-getrawreceipts",
+                      "reference/tempo-debug-getrawtransaction",
+                      "reference/tempo-trace-block",
+                      "reference/tempo-trace-transaction",
+                      "reference/tempo-trace-call",
+                      "reference/tempo-trace-callmany",
+                      "reference/tempo-trace-get",
+                      "reference/tempo-trace-rawtransaction",
+                      "reference/tempo-trace-filter",
+                      "reference/tempo-trace-replayblocktransactions",
+                      "reference/tempo-trace-replaytransaction"
+                    ]
+                  },
+                  {
+                    "group": "Transaction pool | Tempo",
+                    "pages": [
+                      "reference/tempo-txpool-status",
+                      "reference/tempo-txpool-content"
+                    ]
+                  },
+                  {
+                    "group": "Client info | Tempo",
+                    "pages": [
+                      "reference/tempo-web3-clientversion",
+                      "reference/tempo-net-version",
+                      "reference/tempo-net-listening",
+                      "reference/tempo-net-peercount",
+                      "reference/tempo-web3-sha3"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Zksync node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-zksync",
+                  "reference/zks_l1chainid",
+                  "reference/zks_estimatefee",
+                  "reference/zks_estimategasl1tol2",
+                  "reference/zks_getallaccountbalances",
+                  "reference/zks_getblockdetails",
+                  "reference/zks_getbridgecontracts",
+                  "reference/zks_getbytecodebyhash",
+                  "reference/zks_getl1batchblockrange",
+                  "reference/zks_getl1batchdetails",
+                  "reference/zks_getl2tol1logproof",
+                  "reference/zks_getmaincontract",
+                  "reference/zks_getrawblocktransactions",
+                  "reference/zks_gettestnetpaymaster",
+                  "reference/zks_gettransactiondetails",
+                  "reference/zks_l1batchnumber"
+                ]
+              },
+              {
+                "group": "Polygon zkEVM node API",
+                "expanded": false,
+                "pages": [
+                  "reference/zkevm-getting-started",
+                  {
+                    "group": "zkEVM methods | Polygon zkEVM",
+                    "pages": [
+                      "reference/zkevm-rpc-methods",
+                      "reference/zkevm-consolidatedblocknumber",
+                      "reference/zkevm-isblockvirtualized",
+                      "reference/zkevm-isblockconsolidated",
+                      "reference/zkevm-batchnumberbyblocknumber",
+                      "reference/zkevm-batchnumber",
+                      "reference/zkevm-virtualbatchnumber",
+                      "reference/zkevm-verifiedbatchnumber",
+                      "reference/zkevm-getbatchbynumber"
+                    ]
+                  },
+                  "reference/zkevm-eth_blocknumber",
+                  "reference/zkevm-getblockbynumber",
+                  "reference/zkevm-getblockbyhash",
+                  "reference/getblocktransactioncountbynumber",
+                  "reference/zkevm-getblocktransactioncountbyhash",
+                  "reference/zkevm-newblockfilter",
+                  "reference/zkevm-gettransactionbyhash",
+                  "reference/zkevm-gettransactionreceipt",
+                  "reference/zkevm-gettransactionbyblocknumberandindex",
+                  "reference/zkevm-gettransactionbyblockhashandindex",
+                  "reference/zkevm-newpendingtransactionfilter",
+                  "reference/zkevm-ethcall",
+                  "reference/zkevm-endrawtransaction",
+                  "reference/zkevm-getbalance",
+                  "reference/zkevm-getcode",
+                  "reference/zkevm-getstorageat",
+                  "reference/gettransactioncount-1",
+                  "reference/getchainid",
+                  "reference/zkevm-syncing",
+                  "reference/zkevm-clientversion",
+                  "reference/zkevm-estimategas",
+                  "reference/zkevm-getgasprice",
+                  "reference/zkevm-getlogs",
+                  "reference/zkevm-newfilter",
+                  "reference/zkevm-getfilterchanges",
+                  "reference/zkevm-uninstallfilter"
+                ]
+              },
+              {
+                "group": "Optimism node API",
+                "expanded": false,
+                "pages": [
+                  "reference/optimism-api-reference",
+                  "reference/optimism-blocknumber",
+                  "reference/optimism-getblockbyhash",
+                  "reference/optimism-getblockbynumber",
+                  "reference/optimism-getblocktransactioncountbyhash",
+                  "reference/optimism-getblocktransactioncountbynumber",
+                  "reference/optimism-getunclecountbyblockhash",
+                  "reference/optimism-getunclecountbyblocknumber",
+                  "reference/optimism-getblockreceipts",
+                  "reference/optimism-chainid",
+                  "reference/optimism-syncing",
+                  "reference/optimism-call",
+                  "reference/optimism-estimategas",
+                  "reference/optimism-createaccesslist",
+                  "reference/optimism-gasprice",
+                  "reference/optimism-feehistory",
+                  "reference/optimism-newfilter",
+                  "reference/optimism-newblockfilter",
+                  "reference/optimism-uninstallfilter",
+                  "reference/optimism-getfilterchanges",
+                  "reference/optimism-getfilterlogs",
+                  "reference/optimism-getlogs",
+                  "reference/optimism-getbalance",
+                  "reference/optimism-getstorageat",
+                  "reference/optimism-gettransactioncount",
+                  "reference/optimism-getcode",
+                  "reference/optimism-getproof",
+                  "reference/optimism-gettransactionbyhash",
+                  "reference/optimism-getrawtransactionbyhash",
+                  "reference/optimism-gettransactionbyblockhashandindex",
+                  "reference/optimism-getrawtransactionbyblockhashandindex",
+                  "reference/optimism-gettransactionbyblocknumberandindex",
+                  "reference/optimism-getrawtransactionbyblocknumberandindex",
+                  "reference/optimism-gettransactionreceipt",
+                  "reference/optimism-subscribenewheads",
+                  "reference/optimism-subscribelogs",
+                  "reference/optimism-unsubscribe",
+                  "reference/optimism-maxpriorityfeepergas",
+                  "reference/optimism-sendrawtransaction",
+                  "reference/optimism-sendrawtransactionsync",
+                  "reference/optimism-clientversion",
+                  "reference/optimism-sha3",
+                  "reference/optimism-listening",
+                  "reference/optimism-callmany",
+                  "reference/optimism-getmodifiedaccountsbynumber",
+                  "reference/optimism-getmodifiedaccountsbyhash",
+                  "reference/optimism-getstoragerangeat",
+                  "reference/traceblockbyhash",
+                  "reference/optimism-traceblockbynumber",
+                  "reference/optimism-tracetransaction",
+                  "reference/optimism-tracecall",
+                  "reference/optimism-tracecallmany"
+                ]
+              },
+              {
+                "group": "Solana node API",
+                "expanded": false,
+                "pages": [
+                  "reference/solana-getting-started",
+                  "reference/solana-getaccountinfo",
+                  "reference/solana-getbalance",
+                  "reference/solana-getblockheight",
+                  "reference/solana-getblock",
+                  "reference/solana-getblockproduction",
+                  "reference/solana-getblockcommitment",
+                  "reference/solana-getblocks",
+                  "reference/getblockswithlimit",
+                  "reference/solana-getblocktime",
+                  "reference/solana-getclusternodes",
+                  "reference/solana-getepochinfo",
+                  "reference/solana-getepochschedule",
+                  "reference/solana-getfeeformessage",
+                  "reference/solana-getfirstavailableblock",
+                  "reference/solana-getgenesishash",
+                  "reference/solana-gethighestsnapshotslot",
+                  "reference/solana-getidentity",
+                  "reference/solana-getinflationgovernor",
+                  "reference/solana-getinflationrate",
+                  "reference/solana-getinflationreward",
+                  "reference/solana-getlatestblockhash",
+                  "reference/getleaderschedule",
+                  "reference/solana-getmaxretransmitslot",
+                  "reference/solana-getmaxshredinsertslot",
+                  "reference/solana-getminimumbalanceforrentexemption",
+                  "reference/solana-getmultipleaccounts",
+                  "reference/solana-getprogramaccounts",
+                  "reference/solana-getrecentblockhash",
+                  "reference/solana-getrecentperformancesamples",
+                  "reference/solana-getrecentprioritizationfees",
+                  "reference/solana-getsignaturesforaddress",
+                  "reference/solana-getsignaturestatuses",
+                  "reference/solana-getslot",
+                  "reference/solana-getslotleader",
+                  "reference/solana-getstakeminimumdelegation",
+                  "reference/solana-getsupply",
+                  "reference/solana-gettokenaccountbalance",
+                  "reference/solana-gettokenaccountsbydelegate",
+                  "reference/solana-gettokensupply",
+                  "reference/solana-gethealth",
+                  "reference/solana-gettokenaccountsbyowner",
+                  "reference/solana-gettokenlargestaccounts",
+                  "reference/solana-getlargestaccounts",
+                  "reference/gettransaction",
+                  "reference/isblockhashvalid",
+                  "reference/solana-sendtransaction",
+                  "reference/solana-simulatetransaction",
+                  "reference/solana-gettransactioncount",
+                  "reference/solana-getversion",
+                  "reference/solana-getvoteaccounts",
+                  "reference/solana-getslotleaders",
+                  "reference/solana-minimumledgerslot",
+                  "reference/logssubscribe-solana",
+                  "reference/logsunsubscribe-solana",
+                  "reference/blocksubscribe-solana",
+                  "reference/blockunsubscribe-solana",
+                  "reference/accountsubscribe-solana",
+                  "reference/accountunsubscribe-solana",
+                  "reference/programsubscribe-solana",
+                  "reference/programunsubscribe-solana",
+                  "reference/rootsubscribe-solana",
+                  "reference/rootunsubscribe-solana",
+                  "reference/signaturesubscribe-solana",
+                  "reference/signatureunsubscribe-solana",
+                  "reference/slotsubscribe-solana",
+                  "reference/slotunsubscribe-solana",
+                  "reference/slotsupdatessubscribe-solana",
+                  "reference/slotsupdatesunsubscribe-solana"
+                ]
+              },
+              {
+                "group": "Ronin node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-ronin",
+                  "reference/ronin-blocknumber",
+                  "reference/ronin-getblockbyhash",
+                  "reference/ronin-getblockbynumber",
+                  "reference/ronin-getblocktransactioncountbyhash",
+                  "reference/ronin-getblocktransactioncountbynumber",
+                  "reference/ronin-newblockfilter",
+                  "reference/ronin-gettransactionbyhash",
+                  "reference/ronin-gettransactionreceipt",
+                  "reference/ronin-gettransactionbyblockhashandindex",
+                  "reference/ronin-gettransactionbyblocknumberandindex",
+                  "reference/ronin-newpendingtransactionfilter",
+                  "reference/ronin-call",
+                  "reference/ronin-sendrawtransaction",
+                  "reference/ronin-traceblockbyhash",
+                  "reference/ronin-traceblockbynumber",
+                  "reference/ronin-tracetransaction",
+                  "reference/ronin-tracecall",
+                  "reference/ronin-getchainid",
+                  "reference/ronin-syncing",
+                  "reference/ronin-estimategas",
+                  "reference/ronin-getgasprice",
+                  "reference/ronin-getmaxpriorityfeepergas",
+                  "reference/ronin-gettransactioncount",
+                  "reference/ronin-getbalance",
+                  "reference/ronin-getcode",
+                  "reference/ronin-getstorageat",
+                  "reference/ronin-getlogs",
+                  "reference/ronin-newfilter",
+                  "reference/ronin-clientversion",
+                  "reference/ronin-netlistening",
+                  "reference/ronin-netpeercount",
+                  "reference/ronin-getfilterchanges",
+                  "reference/ronin-uninstallfilter",
+                  "reference/ronin-subscribenewheads",
+                  "reference/ronin-subscribenewpendingtransactions",
+                  "reference/ronin-subscribelogs",
+                  "reference/ronin-unsubscribe"
+                ]
+              },
+              {
+                "group": "Gnosis Chain node API",
+                "expanded": false,
+                "pages": [
+                  "reference/gnosis-getting-started",
+                  "reference/gnosis-beacon-chain",
+                  {
+                    "group": "Blocks info | Gnosis",
+                    "pages": [
+                      "reference/gnosis-blocks-rpc-methods",
+                      "reference/gnosis-blocknumber",
+                      "reference/gnosis-getblockbyhash",
+                      "reference/gnosis-getblockbynumber",
+                      "reference/gnosis-getblocktransactioncountbyhash",
+                      "reference/gnosis-getblocktransactioncountbynumber",
+                      "reference/gnosis-newblockfilter"
+                    ]
+                  },
+                  {
+                    "group": "Transactions info | Gnosis",
+                    "pages": [
+                      "reference/gnosis-transactions-rpc-methods",
+                      "reference/gnosis-gettransactionbyhash",
+                      "reference/gnosis-gettransactionreceipt",
+                      "reference/gnosis-gettransactionbyblockhashandindex",
+                      "reference/gnosis-gettransactionbyblocknumberandindex",
+                      "reference/gnosis-newpendingtransactionfilter"
+                    ]
+                  },
+                  {
+                    "group": "Executing transactions | Gnosis",
+                    "pages": [
+                      "reference/gnosis-excecution-rpc-methods",
+                      "reference/gnosis-ethcall",
+                      "reference/gnosis-sendrawtransaction"
+                    ]
+                  },
+                  {
+                    "group": "Chain info | Gnosis",
+                    "pages": [
+                      "reference/gnosis-chain-data-rpc-methods",
+                      "reference/gnosis-getchainid",
+                      "reference/gnosis-syncing"
+                    ]
+                  },
+                  {
+                    "group": "Gas data | Gnosis",
+                    "pages": [
+                      "reference/gnosis-gas-data-rpc-methods",
+                      "reference/gnosis-estimategas",
+                      "reference/gnosis-getgasprice"
+                    ]
+                  },
+                  {
+                    "group": "Accounts info | Gnosis",
+                    "pages": [
+                      "reference/gnosis-accounts-info-rpc-methods",
+                      "reference/gnosis-gettransactioncount",
+                      "reference/gnosis-getbalance",
+                      "reference/gnosis-getcode",
+                      "reference/gnosis-getstorageat"
+                    ]
+                  },
+                  {
+                    "group": "Logs & events | Gnosis",
+                    "pages": [
+                      "reference/gnosis-logs-rpc-methods",
+                      "reference/gnosis-getlogs",
+                      "reference/gnosis-newfilter"
+                    ]
+                  },
+                  {
+                    "group": "Filter handling | Gnosis",
+                    "pages": [
+                      "reference/gnosis-filters-rpc-methods",
+                      "reference/gnosis-getfilterchanges",
+                      "reference/gnosis-uninstallfilter"
+                    ]
+                  },
+                  {
+                    "group": "Client information | Gnosis",
+                    "pages": [
+                      "reference/gnosis-client-data-rpc-methods",
+                      "reference/gnosis-clientversion",
+                      "reference/gnosis-listening",
+                      "reference/gnosis-peercount"
+                    ]
+                  },
+                  {
+                    "group": "Subscriptions | Gnosis",
+                    "pages": [
+                      "reference/gnosis-web3js-subscriptions-methods",
+                      "reference/gnosis-native-subscribe-newheads",
+                      "reference/gnosis-native-subscribe-newpendingtransactions",
+                      "reference/gnosis-native-subscribe-logs",
+                      "reference/gnosis-native-unsubscribe",
+                      "reference/gnosis-subscribenewblockheaders",
+                      "reference/gnosis-subscribependingtransactions",
+                      "reference/gnosis-subscribelogs",
+                      "reference/gnosis-subscribesyncing",
+                      "reference/gnosis-clearsubscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Cronos node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-cronos",
+                  "reference/cronos-eth-blocknumber",
+                  "reference/cronos-getblockbynumber",
+                  "reference/cronos-getblockbyhash",
+                  "reference/cronos-getblocktransactioncountbynumber",
+                  "reference/cronos-getblocktransactioncountbyhash",
+                  "reference/cronos-newblockfilter",
+                  "reference/cronos-gettransactionbyhash",
+                  "reference/gettransactionreceipt",
+                  "reference/gettransactionbyblocknumberandindex",
+                  "reference/gettransactionbyblockhashandindex",
+                  "reference/cronos-newpendingtransactionfilter",
+                  "reference/cronos-ethcall",
+                  "reference/cronos-sendrawtransaction",
+                  "reference/cronos-getbalance",
+                  "reference/cronos-getcode",
+                  "reference/cronos-getstorageat",
+                  "reference/cronos-getproof",
+                  "reference/cronos-gettransactioncount",
+                  "reference/getchainid-1",
+                  "reference/cronos-syncing",
+                  "reference/cronos-clientversion",
+                  "reference/cronos-listening",
+                  "reference/cronos-peercount",
+                  "reference/cronos-estimategas",
+                  "reference/cronos-getgasprice",
+                  "reference/cronos-maxpriorityfeepergas",
+                  "reference/cronos-getlogs",
+                  "reference/cronos-newfilter",
+                  "reference/getfilterchanges-1",
+                  "reference/cronos-uninstallfilter"
+                ]
+              },
+              {
+                "group": "Fantom node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-fantom",
+                  "reference/fantom-eth-blocknumber",
+                  "reference/fantom-getblockbynumber",
+                  "reference/fantom-getblockbyhash",
+                  "reference/fantom-getblocktransactioncountbynumber",
+                  "reference/fantom-getblocktransactioncountbyhash",
+                  "reference/fantom-newblockfilter",
+                  "reference/fantom-gettransactionbyhash",
+                  "reference/fantom-gettransactionreceipt",
+                  "reference/fantom-gettransactionbyblocknumberandindex",
+                  "reference/fantom-gettransactionbyblockhashandindex",
+                  "reference/fantom-newpendingtransactionfilter",
+                  "reference/fantom-ethcall",
+                  "reference/fantom-sendrawtransaction",
+                  "reference/fantom-getbalance",
+                  "reference/getcode-1",
+                  "reference/fantom-getstorageat",
+                  "reference/fantom-getproof",
+                  "reference/fantom-gettransactioncount",
+                  "reference/fantom-getchainid",
+                  "reference/fantom-syncing",
+                  "reference/fantom-clientversion",
+                  "reference/fantom-listening",
+                  "reference/fantom-peercount",
+                  "reference/fantom-estimategas",
+                  "reference/fantom-getgasprice",
+                  "reference/fantom-maxpriorityfeepergas",
+                  "reference/fantom-getlogs",
+                  "reference/fantom-newfilter",
+                  "reference/fantom-getfilterchanges",
+                  "reference/fantom-uninstallfilter",
+                  "reference/custom-js-tracer-fantom",
+                  "reference/debug_traceblockbyhash-fantom-chain",
+                  "reference/debug_traceblockbynumber-fantom",
+                  "reference/debug_tracetransaction-fantom",
+                  "reference/trace_block-fantom",
+                  "reference/trace-transaction-fantom",
+                  "reference/trace-filter-fantom",
+                  "reference/trace-get-fantom"
+                ]
+              },
+              {
+                "group": "Bitcoin node API",
+                "expanded": false,
+                "pages": [
+                  "reference/bitcoin-api-reference",
+                  "reference/bitcoin-rpc-methods-postman-collection",
+                  "reference/bitcoin-getbestblockhash",
+                  "reference/bitcoin-getblock",
+                  "reference/bitcoin-getblockchaininfo",
+                  "reference/bitcoin-getblockfilter",
+                  "reference/bitcoin-getblockhash",
+                  "reference/bitcoin-getblockheader",
+                  "reference/bitcoin-getblockstats",
+                  "reference/bitcoin-getchaintips",
+                  "reference/bitcoin-getchaintxstats",
+                  "reference/bitcoin-getdifficulty",
+                  "reference/bitcoin-getmempoolancestors",
+                  "reference/bitcoin-getmempooldescendants",
+                  "reference/bitcoin-getmempoolentry",
+                  "reference/bitcoin-getmempoolinfo",
+                  "reference/bitcoin-getrawmempool",
+                  "reference/bitcoin-gettxoutsetinfo",
+                  "reference/bitcoin-gettxout",
+                  "reference/bitcoin-verifychain",
+                  "reference/bitcoin-gettxoutproof",
+                  "reference/bitcoin-preciousblock",
+                  "reference/bitcoin-verifytxoutproof",
+                  "reference/bitcoin-uptime",
+                  "reference/bitcoin-getmemoryinfo",
+                  "reference/bitcoin-getrpcinfo",
+                  "reference/bitcoin-getblocktemplate",
+                  "reference/bitcoin-getmininginfo",
+                  "reference/bitcoin-getnetworkhashps",
+                  "reference/bitcoin-prioritisetransaction",
+                  "reference/bitcoin-getpeerinfo",
+                  "reference/bitcoin-getnetworkinfo",
+                  "reference/bitcoin-getconnectioncount",
+                  "reference/bitcoin-getnettotals",
+                  "reference/bitcoin-listbanned",
+                  "reference/bitcoin-ping",
+                  "reference/bitcoin-getnodeaddresses",
+                  "reference/bitcoin-decodescript",
+                  "reference/bitcoin-decoderawtransaction",
+                  "reference/bitcoin-getrawtransaction",
+                  "reference/bitcoin-estimatesmartfee",
+                  "reference/bitcoin-validateaddress"
+                ]
+              },
+              {
+                "group": "Starknet node API",
+                "expanded": false,
+                "pages": [
+                  "reference/getting-started-starknet",
+                  "reference/starknet-pathfinder-default-api-version-change",
+                  "reference/starknet-pathfinder-methods-deprecation",
+                  "reference/starknet-starknetcall",
+                  "reference/starknet-starknetestimatefee",
+                  "reference/starknet-starknetestimatemessagefee",
+                  "reference/starknet-starknetsimulatetransactions",
+                  "reference/starknet-starknettraceblocktransactions",
+                  "reference/starknet-starknetgetclasshashat",
+                  "reference/starknet-starknetgetnonce",
+                  "reference/starknet-starknetgetstorageat",
+                  "reference/starknet-starknetgettransactionbyblockidandindex",
+                  "reference/starknet-starknetgettransactionbyhash",
+                  "reference/starknet-starknetgetclassat"
+                ]
               }
-            ]
-          },
-          {
-            "group": "Monad node API",
-            "pages": [
-              "reference/monad-getting-started",
-              {
-                "group": "Blocks info | Monad",
-                "pages": [
-                  "reference/monad-blocks-rpc-methods",
-                  "reference/monad-getblocknumber",
-                  "reference/monad-getblockbynumber",
-                  "reference/monad-getblockbyhash",
-                  "reference/monad-getblocktransactioncountbyhash",
-                  "reference/monad-getblocktransactioncountbynumber",
-                  "reference/monad-newblockfilter",
-                  "reference/monad-subscribe-monadnewheads"
-                ]
-              },
-              {
-                "group": "Transactions info | Monad",
-                "pages": [
-                  "reference/monad-transactions-rpc-methods",
-                  "reference/monad-gettransactionbyhash",
-                  "reference/monad-gettransactionreceipt",
-                  "reference/monad-gettransactionbyblockhashandindex",
-                  "reference/monad-gettransactionbyblocknumberandindex",
-                  "reference/monad-getblockreceipts",
-                  "reference/monad-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Executing transactions | Monad",
-                "pages": [
-                  "reference/monad-execution-rpc-methods",
-                  "reference/monad-ethcall",
-                  "reference/monad-sendrawtransaction",
-                  "reference/monad-createaccesslist"
-                ]
-              },
-              {
-                "group": "Debug and Trace | Monad",
-                "pages": [
-                  "reference/monad-debug-trace-rpc-methods",
-                  "reference/monad-tracetransaction",
-                  "reference/monad-traceblockbynumber",
-                  "reference/monad-traceblockbyhash",
-                  "reference/monad-tracecall"
-                ]
-              },
-              {
-                "group": "Chain info | Monad",
-                "pages": [
-                  "reference/monad-chain-data-rpc-methods",
-                  "reference/monad-getchainid",
-                  "reference/monad-syncing"
-                ]
-              },
-              {
-                "group": "Gas data | Monad",
-                "pages": [
-                  "reference/monad-gas-data-rpc-methods",
-                  "reference/monad-getgasprice",
-                  "reference/monad-estimategas",
-                  "reference/monad-maxpriorityfeepergas",
-                  "reference/monad-feehistory"
-                ]
-              },
-              {
-                "group": "Accounts info | Monad",
-                "pages": [
-                  "reference/monad-accounts-info-rpc-methods",
-                  "reference/monad-getbalance",
-                  "reference/monad-gettransactioncount",
-                  "reference/monad-getcode",
-                  "reference/monad-getstorageat"
-                ]
-              },
-              {
-                "group": "Logs & events | Monad",
-                "pages": [
-                  "reference/monad-logs-rpc-methods",
-                  "reference/monad-getlogs"
-                ]
-              },
-              {
-                "group": "Client information | Monad",
-                "pages": [
-                  "reference/monad-client-data-rpc-methods",
-                  "reference/monad-clientversion",
-                  "reference/monad-netversion",
-                  "reference/monad-listening"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "TON node API",
-            "pages": [
-              "reference/getting-started-ton",
-              "reference/ton-getaddressinformation-v2",
-              "reference/ton-getextendedaddressinformation-v2",
-              "reference/ton-getwalletinformation-v2",
-              "reference/ton-gettransactions-v2",
-              "reference/ton-getaddressbalance-v2",
-              "reference/ton-getaddressstate-v2",
-              "reference/ton-packaddress-v2",
-              "reference/ton-unpackaddress-v2",
-              "reference/ton-gettokendata-v2",
-              "reference/ton-detectaddress-v2",
-              "reference/ton-getmasterchaininfo-v2",
-              "reference/ton-getmasterchainblocksignatures-v2",
-              "reference/ton-getshardblockproof-v2",
-              "reference/ton-getconsensusblock-v2",
-              "reference/ton-lookupblock-v2",
-              "reference/ton-shards-v2",
-              "reference/ton-getblocktransactions-v2",
-              "reference/ton-getblocktransactionsext-v2",
-              "reference/ton-getblockheader-v2",
-              "reference/ton-trylocatetx-v2",
-              "reference/ton-trylocateresulttx-v2",
-              "reference/ton-trylocatesourcetx-v2",
-              "reference/ton-getconfigparam-v2",
-              "reference/ton-rungetmethod-v2",
-              "reference/ton-sendboc-v2",
-              "reference/ton-sendbocreturnhash-v2",
-              "reference/ton-sendquery-v2",
-              "reference/ton-estimatefee-v2",
-              "reference/ton-masterchaininfo-v3",
-              "reference/ton-blocks-v3",
-              "reference/ton-masterchainblockshardstate-v3",
-              "reference/ton-addressbook-v3",
-              "reference/ton-masterchainblockshards-v3",
-              "reference/ton-transactions-v3",
-              "reference/ton-transactionsbymasterchainblock-v3",
-              "reference/ton-transactionsbymessage-v3",
-              "reference/ton-adjacenttransactions-v3",
-              "reference/ton-messages-v3",
-              "reference/ton-nft-collections-v3",
-              "reference/ton-nft-items-v3",
-              "reference/ton-nft-transfers-v3",
-              "reference/ton-jetton-masters-v3",
-              "reference/ton-jetton-wallets-v3",
-              "reference/ton-jetton-transfers-v3",
-              "reference/ton-jetton-burns-v3",
-              "reference/ton-rungetmethod-v3",
-              "reference/ton-estimatefee-v3",
-              "reference/ton-account-v3",
-              "reference/ton-wallet-v3",
-              "reference/ton-addressinformation-v3",
-              "reference/ton-walletstates-v3",
-              "reference/ton-accountstates-v3",
-              "reference/ton-metadata-v3",
-              "reference/ton-traces-v3",
-              "reference/ton-actions-v3",
-              "reference/ton-events-v3",
-              "reference/ton-pendingtransactions-v3",
-              "reference/ton-pendingtraces-v3",
-              "reference/ton-multisig-wallets-v3",
-              "reference/ton-multisig-orders-v3",
-              "reference/ton-message-v3",
-              "reference/ton-topaccountsbybalance-v3"
-            ]
-          },
-          {
-            "group": "Arbitrum node API",
-            "pages": [
-              "reference/arbitrum-getting-started",
-              {
-                "group": "Blocks info | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-blocks-rpc-methods",
-                  "reference/arbitrum-eth_blocknumber",
-                  "reference/arbitrum-getblockbyhash",
-                  "reference/arbitrum-getblockbynumber",
-                  "reference/arbitrum-getblocktransactioncountbyhash",
-                  "reference/arbitrum-getblocktransactioncountbynumber",
-                  "reference/arbitrum-newblockfilter"
-                ]
-              },
-              {
-                "group": "Transactions info | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-transactions-rpc-methods",
-                  "reference/arbitrum-gettransactionbyhash",
-                  "reference/arbitrum-gettransactionreceipt",
-                  "reference/arbitrum-gettransactionbyblockhashandindex",
-                  "reference/arbitrum-gettransactionbyblocknumberandindex",
-                  "reference/arbitrum-simulatev1"
-                ]
-              },
-              {
-                "group": "Executing transactions | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-evm-excecution-rpc-methods",
-                  "reference/arbitrum-ethcall",
-                  "reference/arbitrum-sendrawtransaction",
-                  "reference/arbitrum-sendrawtransactionsync"
-                ]
-              },
-              {
-                "group": "Debug & Trace | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-debug-and-trace-rpc-methods",
-                  "reference/arbitrum-debug-accountrange",
-                  "reference/arbitrum-debug-dumpblock",
-                  "reference/arbitrum-debug-getaccessiblestate",
-                  "reference/arbitrum-debug-getmodifiedaccountsbyhash",
-                  "reference/arbitrum-debug-getmodifiedaccountsbynumber",
-                  "reference/arbitrum-debug-getrawblock",
-                  "reference/arbitrum-debug-getrawheader",
-                  "reference/arbitrum-debug-getrawreceipts",
-                  "reference/arbitrum-debug-getrawtransaction",
-                  "reference/arbitrum-debug-intermediateroots",
-                  "reference/arbitrum-debug-preimage",
-                  "reference/arbitrum-debug-printblock",
-                  "reference/arbitrum-debug-tracebadblock",
-                  "reference/arbitrum-debug-traceblockbyhash",
-                  "reference/arbitrum-debug-traceblockbynumber",
-                  "reference/arbitrum-debug-tracecall",
-                  "reference/arbitrum-debug-tracetransaction",
-                  "reference/arbitrum-arbtrace-block",
-                  "reference/arbitrum-arbtrace-call",
-                  "reference/arbitrum-arbtrace-callmany",
-                  "reference/arbitrum-arbtrace-filter",
-                  "reference/arbitrum-arbtrace-get",
-                  "reference/arbitrum-arbtrace-replayblocktransactions",
-                  "reference/arbitrum-arbtrace-replaytransaction",
-                  "reference/arbitrum-arbtrace-transaction",
-                  "reference/arbitrum-tracetransaction"
-                ]
-              },
-              {
-                "group": "Chain info | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-chain-data-rpc-methods",
-                  "reference/arbitrum-getchainid",
-                  "reference/arbitrum-syncing"
-                ]
-              },
-              {
-                "group": "Gas data | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-gas-data-rpc-methods",
-                  "reference/arbitrum-estimategas",
-                  "reference/arbitrum-getgasprice"
-                ]
-              },
-              {
-                "group": "Accounts info | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-accounts-info-rpc-methods",
-                  "reference/arbitrum-gettransactioncount",
-                  "reference/arbitrum-getbalance",
-                  "reference/arbitrum-getcode",
-                  "reference/arbitrum-getstorageat"
-                ]
-              },
-              {
-                "group": "Logs & events | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-logs-rpc-methods",
-                  "reference/arbitrum-getlogs",
-                  "reference/arbitrum-newfilter"
-                ]
-              },
-              {
-                "group": "Filter handling | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-filters-rpc-methods",
-                  "reference/arbitrum-getfilterchanges",
-                  "reference/arbitrum-uninstallfilter"
-                ]
-              },
-              {
-                "group": "Client information | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-client-data-rpc-methods",
-                  "reference/arbitrum-clientversion"
-                ]
-              },
-              {
-                "group": "Subscriptions | Arbitrum",
-                "pages": [
-                  "reference/arbitrum-web3js-subscriptions-methods",
-                  "reference/arbitrum-native-subscribe-newheads",
-                  "reference/arbitrum-native-subscribe-logs",
-                  "reference/arbitrum-native-unsubscribe",
-                  "reference/arbitrum-subscribenewblockheaders",
-                  "reference/arbitrum-subscribelogs",
-                  "reference/arbitrum-subscribesyncing",
-                  "reference/arbitrum-clearsubscriptions"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Tempo node API",
-            "pages": [
-              "reference/tempo-getting-started",
-              {
-                "group": "Tempo specific | Tempo",
-                "pages": [
-                  "reference/tempo-tempo-fundaddress",
-                  "reference/tempo-eth-sendrawtransactionsync"
-                ]
-              },
-              {
-                "group": "Blocks info | Tempo",
-                "pages": [
-                  "reference/tempo-eth-blocknumber",
-                  "reference/tempo-eth-getblockbyhash",
-                  "reference/tempo-eth-getblockbynumber",
-                  "reference/tempo-eth-newblockfilter",
-                  "reference/tempo-eth-getblockreceipts",
-                  "reference/tempo-eth-getblocktransactioncountbyhash",
-                  "reference/tempo-eth-getblocktransactioncountbynumber",
-                  "reference/tempo-eth-getunclecountbyblocknumber"
-                ]
-              },
-              {
-                "group": "Transactions info | Tempo",
-                "pages": [
-                  "reference/tempo-eth-gettransactionbyhash",
-                  "reference/tempo-eth-gettransactionreceipt",
-                  "reference/tempo-eth-sendrawtransaction",
-                  "reference/tempo-eth-call",
-                  "reference/tempo-eth-gettransactionbyblockhashandindex",
-                  "reference/tempo-eth-gettransactionbyblocknumberandindex",
-                  "reference/tempo-eth-createaccesslist"
-                ]
-              },
-              {
-                "group": "Chain info | Tempo",
-                "pages": [
-                  "reference/tempo-eth-chainid",
-                  "reference/tempo-eth-syncing",
-                  "reference/tempo-eth-protocolversion",
-                  "reference/tempo-eth-accounts"
-                ]
-              },
-              {
-                "group": "Gas data | Tempo",
-                "pages": [
-                  "reference/tempo-eth-gasprice",
-                  "reference/tempo-eth-estimategas",
-                  "reference/tempo-eth-maxpriorityfeepergas",
-                  "reference/tempo-eth-feehistory",
-                  "reference/tempo-eth-blobbasefee"
-                ]
-              },
-              {
-                "group": "Accounts info | Tempo",
-                "pages": [
-                  "reference/tempo-eth-getbalance",
-                  "reference/tempo-eth-gettransactioncount",
-                  "reference/tempo-eth-getcode",
-                  "reference/tempo-eth-getstorageat",
-                  "reference/tempo-eth-getproof"
-                ]
-              },
-              {
-                "group": "Logs & events | Tempo",
-                "pages": [
-                  "reference/tempo-eth-getlogs",
-                  "reference/tempo-eth-newfilter",
-                  "reference/tempo-eth-getfilterlogs"
-                ]
-              },
-              {
-                "group": "Filter handling | Tempo",
-                "pages": [
-                  "reference/tempo-eth-getfilterchanges",
-                  "reference/tempo-eth-uninstallfilter",
-                  "reference/tempo-eth-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Debug & trace | Tempo",
-                "pages": [
-                  "reference/tempo-debug-tracetransaction",
-                  "reference/tempo-debug-tracecall",
-                  "reference/tempo-debug-traceblockbynumber",
-                  "reference/tempo-debug-traceblockbyhash",
-                  "reference/tempo-debug-tracecallmany",
-                  "reference/tempo-debug-getbadblocks",
-                  "reference/tempo-debug-getrawblock",
-                  "reference/tempo-debug-getrawheader",
-                  "reference/tempo-debug-getrawreceipts",
-                  "reference/tempo-debug-getrawtransaction",
-                  "reference/tempo-trace-block",
-                  "reference/tempo-trace-transaction",
-                  "reference/tempo-trace-call",
-                  "reference/tempo-trace-callmany",
-                  "reference/tempo-trace-get",
-                  "reference/tempo-trace-rawtransaction",
-                  "reference/tempo-trace-filter",
-                  "reference/tempo-trace-replayblocktransactions",
-                  "reference/tempo-trace-replaytransaction"
-                ]
-              },
-              {
-                "group": "Transaction pool | Tempo",
-                "pages": [
-                  "reference/tempo-txpool-status",
-                  "reference/tempo-txpool-content"
-                ]
-              },
-              {
-                "group": "Client info | Tempo",
-                "pages": [
-                  "reference/tempo-web3-clientversion",
-                  "reference/tempo-net-version",
-                  "reference/tempo-net-listening",
-                  "reference/tempo-net-peercount",
-                  "reference/tempo-web3-sha3"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Zksync node API",
-            "pages": [
-              "reference/getting-started-zksync",
-              "reference/zks_l1chainid",
-              "reference/zks_estimatefee",
-              "reference/zks_estimategasl1tol2",
-              "reference/zks_getallaccountbalances",
-              "reference/zks_getblockdetails",
-              "reference/zks_getbridgecontracts",
-              "reference/zks_getbytecodebyhash",
-              "reference/zks_getl1batchblockrange",
-              "reference/zks_getl1batchdetails",
-              "reference/zks_getl2tol1logproof",
-              "reference/zks_getmaincontract",
-              "reference/zks_getrawblocktransactions",
-              "reference/zks_gettestnetpaymaster",
-              "reference/zks_gettransactiondetails",
-              "reference/zks_l1batchnumber"
-            ]
-          },
-          {
-            "group": "Polygon zkEVM node API",
-            "pages": [
-              "reference/zkevm-getting-started",
-              {
-                "group": "zkEVM methods | Polygon zkEVM",
-                "pages": [
-                  "reference/zkevm-rpc-methods",
-                  "reference/zkevm-consolidatedblocknumber",
-                  "reference/zkevm-isblockvirtualized",
-                  "reference/zkevm-isblockconsolidated",
-                  "reference/zkevm-batchnumberbyblocknumber",
-                  "reference/zkevm-batchnumber",
-                  "reference/zkevm-virtualbatchnumber",
-                  "reference/zkevm-verifiedbatchnumber",
-                  "reference/zkevm-getbatchbynumber"
-                ]
-              },
-              "reference/zkevm-eth_blocknumber",
-              "reference/zkevm-getblockbynumber",
-              "reference/zkevm-getblockbyhash",
-              "reference/getblocktransactioncountbynumber",
-              "reference/zkevm-getblocktransactioncountbyhash",
-              "reference/zkevm-newblockfilter",
-              "reference/zkevm-gettransactionbyhash",
-              "reference/zkevm-gettransactionreceipt",
-              "reference/zkevm-gettransactionbyblocknumberandindex",
-              "reference/zkevm-gettransactionbyblockhashandindex",
-              "reference/zkevm-newpendingtransactionfilter",
-              "reference/zkevm-ethcall",
-              "reference/zkevm-endrawtransaction",
-              "reference/zkevm-getbalance",
-              "reference/zkevm-getcode",
-              "reference/zkevm-getstorageat",
-              "reference/gettransactioncount-1",
-              "reference/getchainid",
-              "reference/zkevm-syncing",
-              "reference/zkevm-clientversion",
-              "reference/zkevm-estimategas",
-              "reference/zkevm-getgasprice",
-              "reference/zkevm-getlogs",
-              "reference/zkevm-newfilter",
-              "reference/zkevm-getfilterchanges",
-              "reference/zkevm-uninstallfilter"
-            ]
-          },
-          {
-            "group": "Optimism node API",
-            "pages": [
-              "reference/optimism-api-reference",
-              "reference/optimism-blocknumber",
-              "reference/optimism-getblockbyhash",
-              "reference/optimism-getblockbynumber",
-              "reference/optimism-getblocktransactioncountbyhash",
-              "reference/optimism-getblocktransactioncountbynumber",
-              "reference/optimism-getunclecountbyblockhash",
-              "reference/optimism-getunclecountbyblocknumber",
-              "reference/optimism-getblockreceipts",
-              "reference/optimism-chainid",
-              "reference/optimism-syncing",
-              "reference/optimism-call",
-              "reference/optimism-estimategas",
-              "reference/optimism-createaccesslist",
-              "reference/optimism-gasprice",
-              "reference/optimism-feehistory",
-              "reference/optimism-newfilter",
-              "reference/optimism-newblockfilter",
-              "reference/optimism-uninstallfilter",
-              "reference/optimism-getfilterchanges",
-              "reference/optimism-getfilterlogs",
-              "reference/optimism-getlogs",
-              "reference/optimism-getbalance",
-              "reference/optimism-getstorageat",
-              "reference/optimism-gettransactioncount",
-              "reference/optimism-getcode",
-              "reference/optimism-getproof",
-              "reference/optimism-gettransactionbyhash",
-              "reference/optimism-getrawtransactionbyhash",
-              "reference/optimism-gettransactionbyblockhashandindex",
-              "reference/optimism-getrawtransactionbyblockhashandindex",
-              "reference/optimism-gettransactionbyblocknumberandindex",
-              "reference/optimism-getrawtransactionbyblocknumberandindex",
-              "reference/optimism-gettransactionreceipt",
-              "reference/optimism-subscribenewheads",
-              "reference/optimism-subscribelogs",
-              "reference/optimism-unsubscribe",
-              "reference/optimism-maxpriorityfeepergas",
-              "reference/optimism-sendrawtransaction",
-              "reference/optimism-sendrawtransactionsync",
-              "reference/optimism-clientversion",
-              "reference/optimism-sha3",
-              "reference/optimism-listening",
-              "reference/optimism-callmany",
-              "reference/optimism-getmodifiedaccountsbynumber",
-              "reference/optimism-getmodifiedaccountsbyhash",
-              "reference/optimism-getstoragerangeat",
-              "reference/traceblockbyhash",
-              "reference/optimism-traceblockbynumber",
-              "reference/optimism-tracetransaction",
-              "reference/optimism-tracecall",
-              "reference/optimism-tracecallmany"
-            ]
-          },
-          {
-            "group": "Solana node API",
-            "pages": [
-              "reference/solana-getting-started",
-              "reference/solana-getaccountinfo",
-              "reference/solana-getbalance",
-              "reference/solana-getblockheight",
-              "reference/solana-getblock",
-              "reference/solana-getblockproduction",
-              "reference/solana-getblockcommitment",
-              "reference/solana-getblocks",
-              "reference/getblockswithlimit",
-              "reference/solana-getblocktime",
-              "reference/solana-getclusternodes",
-              "reference/solana-getepochinfo",
-              "reference/solana-getepochschedule",
-              "reference/solana-getfeeformessage",
-              "reference/solana-getfirstavailableblock",
-              "reference/solana-getgenesishash",
-              "reference/solana-gethighestsnapshotslot",
-              "reference/solana-getidentity",
-              "reference/solana-getinflationgovernor",
-              "reference/solana-getinflationrate",
-              "reference/solana-getinflationreward",
-              "reference/solana-getlatestblockhash",
-              "reference/getleaderschedule",
-              "reference/solana-getmaxretransmitslot",
-              "reference/solana-getmaxshredinsertslot",
-              "reference/solana-getminimumbalanceforrentexemption",
-              "reference/solana-getmultipleaccounts",
-              "reference/solana-getprogramaccounts",
-              "reference/solana-getrecentblockhash",
-              "reference/solana-getrecentperformancesamples",
-              "reference/solana-getrecentprioritizationfees",
-              "reference/solana-getsignaturesforaddress",
-              "reference/solana-getsignaturestatuses",
-              "reference/solana-getslot",
-              "reference/solana-getslotleader",
-
-              "reference/solana-getstakeminimumdelegation",
-              "reference/solana-getsupply",
-              "reference/solana-gettokenaccountbalance",
-              "reference/solana-gettokenaccountsbydelegate",
-              "reference/solana-gettokensupply",
-              "reference/solana-gethealth",
-              "reference/solana-gettokenaccountsbyowner",
-              "reference/solana-gettokenlargestaccounts",
-              "reference/solana-getlargestaccounts",
-              "reference/gettransaction",
-              "reference/isblockhashvalid",
-              "reference/solana-sendtransaction",
-              "reference/solana-simulatetransaction",
-              "reference/solana-gettransactioncount",
-              "reference/solana-getversion",
-              "reference/solana-getvoteaccounts",
-              "reference/solana-getslotleaders",
-              "reference/solana-minimumledgerslot",
-              "reference/logssubscribe-solana",
-              "reference/logsunsubscribe-solana",
-              "reference/blocksubscribe-solana",
-              "reference/blockunsubscribe-solana",
-              "reference/accountsubscribe-solana",
-              "reference/accountunsubscribe-solana",
-              "reference/programsubscribe-solana",
-              "reference/programunsubscribe-solana",
-              "reference/rootsubscribe-solana",
-              "reference/rootunsubscribe-solana",
-              "reference/signaturesubscribe-solana",
-              "reference/signatureunsubscribe-solana",
-              "reference/slotsubscribe-solana",
-              "reference/slotunsubscribe-solana",
-              "reference/slotsupdatessubscribe-solana",
-              "reference/slotsupdatesunsubscribe-solana"
-            ]
-          },
-          {
-            "group": "Ronin node API",
-            "pages": [
-              "reference/getting-started-ronin",
-              "reference/ronin-blocknumber",
-              "reference/ronin-getblockbyhash",
-              "reference/ronin-getblockbynumber",
-              "reference/ronin-getblocktransactioncountbyhash",
-              "reference/ronin-getblocktransactioncountbynumber",
-              "reference/ronin-newblockfilter",
-              "reference/ronin-gettransactionbyhash",
-              "reference/ronin-gettransactionreceipt",
-              "reference/ronin-gettransactionbyblockhashandindex",
-              "reference/ronin-gettransactionbyblocknumberandindex",
-              "reference/ronin-newpendingtransactionfilter",
-              "reference/ronin-call",
-              "reference/ronin-sendrawtransaction",
-              "reference/ronin-traceblockbyhash",
-              "reference/ronin-traceblockbynumber",
-              "reference/ronin-tracetransaction",
-              "reference/ronin-tracecall",
-              "reference/ronin-getchainid",
-              "reference/ronin-syncing",
-              "reference/ronin-estimategas",
-              "reference/ronin-getgasprice",
-              "reference/ronin-getmaxpriorityfeepergas",
-              "reference/ronin-gettransactioncount",
-              "reference/ronin-getbalance",
-              "reference/ronin-getcode",
-              "reference/ronin-getstorageat",
-              "reference/ronin-getlogs",
-              "reference/ronin-newfilter",
-              "reference/ronin-clientversion",
-              "reference/ronin-netlistening",
-              "reference/ronin-netpeercount",
-              "reference/ronin-getfilterchanges",
-              "reference/ronin-uninstallfilter",
-              "reference/ronin-subscribenewheads",
-              "reference/ronin-subscribenewpendingtransactions",
-              "reference/ronin-subscribelogs",
-              "reference/ronin-unsubscribe"
-            ]
-          },
-          {
-            "group": "Gnosis Chain node API",
-            "pages": [
-              "reference/gnosis-getting-started",
-              "reference/gnosis-beacon-chain",
-              {
-                "group": "Blocks info | Gnosis",
-                "pages": [
-                  "reference/gnosis-blocks-rpc-methods",
-                  "reference/gnosis-blocknumber",
-                  "reference/gnosis-getblockbyhash",
-                  "reference/gnosis-getblockbynumber",
-                  "reference/gnosis-getblocktransactioncountbyhash",
-                  "reference/gnosis-getblocktransactioncountbynumber",
-                  "reference/gnosis-newblockfilter"
-                ]
-              },
-              {
-                "group": "Transactions info | Gnosis",
-                "pages": [
-                  "reference/gnosis-transactions-rpc-methods",
-                  "reference/gnosis-gettransactionbyhash",
-                  "reference/gnosis-gettransactionreceipt",
-                  "reference/gnosis-gettransactionbyblockhashandindex",
-                  "reference/gnosis-gettransactionbyblocknumberandindex",
-                  "reference/gnosis-newpendingtransactionfilter"
-                ]
-              },
-              {
-                "group": "Executing transactions | Gnosis",
-                "pages": [
-                  "reference/gnosis-excecution-rpc-methods",
-                  "reference/gnosis-ethcall",
-                  "reference/gnosis-sendrawtransaction"
-                ]
-              },
-              {
-                "group": "Chain info | Gnosis",
-                "pages": [
-                  "reference/gnosis-chain-data-rpc-methods",
-                  "reference/gnosis-getchainid",
-                  "reference/gnosis-syncing"
-                ]
-              },
-              {
-                "group": "Gas data | Gnosis",
-                "pages": [
-                  "reference/gnosis-gas-data-rpc-methods",
-                  "reference/gnosis-estimategas",
-                  "reference/gnosis-getgasprice"
-                ]
-              },
-              {
-                "group": "Accounts info | Gnosis",
-                "pages": [
-                  "reference/gnosis-accounts-info-rpc-methods",
-                  "reference/gnosis-gettransactioncount",
-                  "reference/gnosis-getbalance",
-                  "reference/gnosis-getcode",
-                  "reference/gnosis-getstorageat"
-                ]
-              },
-              {
-                "group": "Logs & events | Gnosis",
-                "pages": [
-                  "reference/gnosis-logs-rpc-methods",
-                  "reference/gnosis-getlogs",
-                  "reference/gnosis-newfilter"
-                ]
-              },
-              {
-                "group": "Filter handling | Gnosis",
-                "pages": [
-                  "reference/gnosis-filters-rpc-methods",
-                  "reference/gnosis-getfilterchanges",
-                  "reference/gnosis-uninstallfilter"
-                ]
-              },
-              {
-                "group": "Client information | Gnosis",
-                "pages": [
-                  "reference/gnosis-client-data-rpc-methods",
-                  "reference/gnosis-clientversion",
-                  "reference/gnosis-listening",
-                  "reference/gnosis-peercount"
-                ]
-              },
-              {
-                "group": "Subscriptions | Gnosis",
-                "pages": [
-                  "reference/gnosis-web3js-subscriptions-methods",
-                  "reference/gnosis-native-subscribe-newheads",
-                  "reference/gnosis-native-subscribe-newpendingtransactions",
-                  "reference/gnosis-native-subscribe-logs",
-                  "reference/gnosis-native-unsubscribe",
-                  "reference/gnosis-subscribenewblockheaders",
-                  "reference/gnosis-subscribependingtransactions",
-                  "reference/gnosis-subscribelogs",
-                  "reference/gnosis-subscribesyncing",
-                  "reference/gnosis-clearsubscriptions"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Cronos node API",
-            "pages": [
-              "reference/getting-started-cronos",
-              "reference/cronos-eth-blocknumber",
-              "reference/cronos-getblockbynumber",
-              "reference/cronos-getblockbyhash",
-              "reference/cronos-getblocktransactioncountbynumber",
-              "reference/cronos-getblocktransactioncountbyhash",
-              "reference/cronos-newblockfilter",
-              "reference/cronos-gettransactionbyhash",
-              "reference/gettransactionreceipt",
-              "reference/gettransactionbyblocknumberandindex",
-              "reference/gettransactionbyblockhashandindex",
-              "reference/cronos-newpendingtransactionfilter",
-              "reference/cronos-ethcall",
-              "reference/cronos-sendrawtransaction",
-              "reference/cronos-getbalance",
-              "reference/cronos-getcode",
-              "reference/cronos-getstorageat",
-              "reference/cronos-getproof",
-              "reference/cronos-gettransactioncount",
-              "reference/getchainid-1",
-              "reference/cronos-syncing",
-              "reference/cronos-clientversion",
-              "reference/cronos-listening",
-              "reference/cronos-peercount",
-              "reference/cronos-estimategas",
-              "reference/cronos-getgasprice",
-              "reference/cronos-maxpriorityfeepergas",
-              "reference/cronos-getlogs",
-              "reference/cronos-newfilter",
-              "reference/getfilterchanges-1",
-              "reference/cronos-uninstallfilter"
-            ]
-          },
-          {
-            "group": "Fantom node API",
-            "pages": [
-              "reference/getting-started-fantom",
-              "reference/fantom-eth-blocknumber",
-              "reference/fantom-getblockbynumber",
-              "reference/fantom-getblockbyhash",
-              "reference/fantom-getblocktransactioncountbynumber",
-              "reference/fantom-getblocktransactioncountbyhash",
-              "reference/fantom-newblockfilter",
-              "reference/fantom-gettransactionbyhash",
-              "reference/fantom-gettransactionreceipt",
-              "reference/fantom-gettransactionbyblocknumberandindex",
-              "reference/fantom-gettransactionbyblockhashandindex",
-              "reference/fantom-newpendingtransactionfilter",
-              "reference/fantom-ethcall",
-              "reference/fantom-sendrawtransaction",
-              "reference/fantom-getbalance",
-              "reference/getcode-1",
-              "reference/fantom-getstorageat",
-              "reference/fantom-getproof",
-              "reference/fantom-gettransactioncount",
-              "reference/fantom-getchainid",
-              "reference/fantom-syncing",
-              "reference/fantom-clientversion",
-              "reference/fantom-listening",
-              "reference/fantom-peercount",
-              "reference/fantom-estimategas",
-              "reference/fantom-getgasprice",
-              "reference/fantom-maxpriorityfeepergas",
-              "reference/fantom-getlogs",
-              "reference/fantom-newfilter",
-              "reference/fantom-getfilterchanges",
-              "reference/fantom-uninstallfilter",
-              "reference/custom-js-tracer-fantom",
-              "reference/debug_traceblockbyhash-fantom-chain",
-              "reference/debug_traceblockbynumber-fantom",
-              "reference/debug_tracetransaction-fantom",
-              "reference/trace_block-fantom",
-              "reference/trace-transaction-fantom",
-              "reference/trace-filter-fantom",
-              "reference/trace-get-fantom"
-            ]
-          },
-          {
-            "group": "Bitcoin node API",
-            "pages": [
-              "reference/bitcoin-api-reference",
-              "reference/bitcoin-rpc-methods-postman-collection",
-              "reference/bitcoin-getbestblockhash",
-              "reference/bitcoin-getblock",
-              "reference/bitcoin-getblockchaininfo",
-              "reference/bitcoin-getblockfilter",
-              "reference/bitcoin-getblockhash",
-              "reference/bitcoin-getblockheader",
-              "reference/bitcoin-getblockstats",
-              "reference/bitcoin-getchaintips",
-              "reference/bitcoin-getchaintxstats",
-              "reference/bitcoin-getdifficulty",
-              "reference/bitcoin-getmempoolancestors",
-              "reference/bitcoin-getmempooldescendants",
-              "reference/bitcoin-getmempoolentry",
-              "reference/bitcoin-getmempoolinfo",
-              "reference/bitcoin-getrawmempool",
-              "reference/bitcoin-gettxoutsetinfo",
-              "reference/bitcoin-gettxout",
-              "reference/bitcoin-verifychain",
-              "reference/bitcoin-gettxoutproof",
-              "reference/bitcoin-preciousblock",
-              "reference/bitcoin-verifytxoutproof",
-              "reference/bitcoin-uptime",
-              "reference/bitcoin-getmemoryinfo",
-              "reference/bitcoin-getrpcinfo",
-              "reference/bitcoin-getblocktemplate",
-              "reference/bitcoin-getmininginfo",
-              "reference/bitcoin-getnetworkhashps",
-              "reference/bitcoin-prioritisetransaction",
-              "reference/bitcoin-getpeerinfo",
-              "reference/bitcoin-getnetworkinfo",
-              "reference/bitcoin-getconnectioncount",
-              "reference/bitcoin-getnettotals",
-              "reference/bitcoin-listbanned",
-              "reference/bitcoin-ping",
-              "reference/bitcoin-getnodeaddresses",
-              "reference/bitcoin-decodescript",
-              "reference/bitcoin-decoderawtransaction",
-              "reference/bitcoin-getrawtransaction",
-              "reference/bitcoin-estimatesmartfee",
-              "reference/bitcoin-validateaddress"
-            ]
-          },
-          {
-            "group": "Starknet node API",
-            "pages": [
-              "reference/getting-started-starknet",
-              "reference/starknet-pathfinder-default-api-version-change",
-              "reference/starknet-pathfinder-methods-deprecation",
-              "reference/starknet-starknetcall",
-              "reference/starknet-starknetestimatefee",
-              "reference/starknet-starknetestimatemessagefee",
-              "reference/starknet-starknetsimulatetransactions",
-              "reference/starknet-starknettraceblocktransactions",
-              "reference/starknet-starknetgetclasshashat",
-              "reference/starknet-starknetgetnonce",
-              "reference/starknet-starknetgetstorageat",
-              "reference/starknet-starknetgettransactionbyblockidandindex",
-              "reference/starknet-starknetgettransactionbyhash",
-              "reference/starknet-starknetgetclassat"
             ]
           },
           {


### PR DESCRIPTION
## What

Nest all 23 protocol node APIs under the existing collapsible **Node APIs** group (each `expanded: false`). Leaves **APIs introduction**, **Faucet API**, and **Chainstack platform API** top-level.

## Why

The last drag on our AFDocs score (prod **97/100**) is `page-size-html`: flat top-level protocols render *all* their method links into *every* page's HTML (~370 of ~399 nav links on an Ethereum page come from other protocols). Collapsed **nested** groups render **zero** children into other pages — so once every protocol is nested+collapsed, each page renders only the current protocol's methods. Targets `page-size-html` up → **AFDocs 97 → ~99** (QuickNode 98 / Alchemy 99 parity).

## Safety — nav-only, zero URL/content change

- **No `.mdx` files move, no page bodies change, no spec files change.** URLs come from file paths, not nav, so every `/reference/<slug>` is byte-identical.
- Page-path set verified **identical** before/after (1,544 pages).
- `mintlify broken-links` → clean.
- The only substantive additions are 22 `expanded: false` lines; the rest of the diff is re-indentation of the now-nested blocks.

## Validate on preview before merge

- [ ] 3-level nesting renders for already-grouped protocols (`Node APIs > Ethereum > Blocks info > pages`)
- [ ] `page-size-html` rises / overall AFDocs ~99 via `npx afdocs check <preview>`
- [ ] grouped + flat protocol pages still serve 200 and read clean

Draft until the preview confirms the score move.
