### PR TITLE
docs(ethereum): strip x-readme cruft from specs

### DIFF
--- a/openapi/ethereum_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/ethereum_node_api/accounts_info/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/accounts_info/eth_getCode.json
+++ b/openapi/ethereum_node_api/accounts_info/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/accounts_info/eth_getProof.json
+++ b/openapi/ethereum_node_api/accounts_info/eth_getProof.json
@@ -85,9 +85,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/ethereum_node_api/accounts_info/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/ethereum_node_api/accounts_info/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/ethereum_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/ethereum_node_api/blocks_info/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/ethereum_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/ethereum_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/ethereum_node_api/blocks_info/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/chain_info/eth_chainId.json
+++ b/openapi/ethereum_node_api/chain_info/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/chain_info/eth_syncing.json
+++ b/openapi/ethereum_node_api/chain_info/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/client_info/net_listening.json
+++ b/openapi/ethereum_node_api/client_info/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/client_info/net_peerCount.json
+++ b/openapi/ethereum_node_api/client_info/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/client_info/web3_clientVersion.json
+++ b/openapi/ethereum_node_api/client_info/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/custom_js_tracer.json
+++ b/openapi/ethereum_node_api/debug_and_trace/custom_js_tracer.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceCall.json
@@ -125,9 +125,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceCallMany.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceCallMany.json
@@ -108,9 +108,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/ethereum_node_api/debug_and_trace/debug_traceTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/trace_block.json
+++ b/openapi/ethereum_node_api/debug_and_trace/trace_block.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/debug_and_trace/trace_transaction.json
+++ b/openapi/ethereum_node_api/debug_and_trace/trace_transaction.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/execute_transactions/eth_call.json
+++ b/openapi/ethereum_node_api/execute_transactions/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/ethereum_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/execute_transactions/eth_sendRawTransactionSync.json
+++ b/openapi/ethereum_node_api/execute_transactions/eth_sendRawTransactionSync.json
@@ -125,9 +125,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/execute_transactions/eth_simulateV1.json
+++ b/openapi/ethereum_node_api/execute_transactions/eth_simulateV1.json
@@ -171,9 +171,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/ethereum_node_api/filter_handling/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/ethereum_node_api/filter_handling/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/ethereum_node_api/gas_data/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/ethereum_node_api/gas_data/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/gas_data/eth_maxPriorityFeePerGas.json
+++ b/openapi/ethereum_node_api/gas_data/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/ethereum_node_api/logs_and_events/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/ethereum_node_api/logs_and_events/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_getBlockReceipts.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_getBlockReceipts.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_node_api/transaction_info/eth_newPendingTransactionFilter.json
+++ b/openapi/ethereum_node_api/transaction_info/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }


### PR DESCRIPTION
## What

Strip the readme.com `x-readme` block (`explorer-enabled` / `proxy-enabled` toggles) from the 40 Ethereum specs that carry it.

## Why

Spec-first migration for **Ethereum** — the highest-traffic protocol after the Hyperliquid PoC (9.8K reference views / 30d, 76% AI). Its reorg (category subfolders) and collapsible nav (nested under **Node APIs** in #450) are already done, so cleaning `x-readme` is the only remaining structural step.

## Safety — content-preserving, zero rendered change

- `x-readme` is a readme.com OpenAPI extension Mintlify does **not** render, so this changes nothing on the page or in the agent `.md`.
- Surgical raw-text removal (no re-serialization): diff is **160 pure deletions across 40 files**, nothing else.
- Validated: each spec still parses and equals **(prod minus x-readme)**; all 63 Ethereum page bodies **byte-identical**; all 40 `openapi:` frontmatter tokens resolve; `mintlify broken-links` clean.

## Verify on preview

- [ ] Ethereum pages serve 200 + clean `.md`
- [ ] `.md` byte-identical to prod (proves zero agent-surface change)
- [ ] served specs no longer contain `x-readme`
- [ ] afdocs holds 100 (no regression)
