### PR TITLE
docs(solana): strip x-readme cruft from specs

### DIFF
--- a/openapi/solana_node_api/getAccountInfo.json
+++ b/openapi/solana_node_api/getAccountInfo.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBalance.json
+++ b/openapi/solana_node_api/getBalance.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlock.json
+++ b/openapi/solana_node_api/getBlock.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlockCommitment.json
+++ b/openapi/solana_node_api/getBlockCommitment.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlockHeight.json
+++ b/openapi/solana_node_api/getBlockHeight.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlockProduction.json
+++ b/openapi/solana_node_api/getBlockProduction.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlockTime.json
+++ b/openapi/solana_node_api/getBlockTime.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlocks.json
+++ b/openapi/solana_node_api/getBlocks.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getBlocksWithLimit.json
+++ b/openapi/solana_node_api/getBlocksWithLimit.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getClusterNodes.json
+++ b/openapi/solana_node_api/getClusterNodes.json
@@ -87,9 +87,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getEpochInfo.json
+++ b/openapi/solana_node_api/getEpochInfo.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getEpochSchedule.json
+++ b/openapi/solana_node_api/getEpochSchedule.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getFeeForMessage.json
+++ b/openapi/solana_node_api/getFeeForMessage.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getFirstAvailableBlock.json
+++ b/openapi/solana_node_api/getFirstAvailableBlock.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getGenesisHash.json
+++ b/openapi/solana_node_api/getGenesisHash.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getHealth.json
+++ b/openapi/solana_node_api/getHealth.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getHighestSnapshotSlot.json
+++ b/openapi/solana_node_api/getHighestSnapshotSlot.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getIdentity.json
+++ b/openapi/solana_node_api/getIdentity.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getInflationGovernor.json
+++ b/openapi/solana_node_api/getInflationGovernor.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getInflationRate.json
+++ b/openapi/solana_node_api/getInflationRate.json
@@ -85,9 +85,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getInflationReward.json
+++ b/openapi/solana_node_api/getInflationReward.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getLargestAccounts.json
+++ b/openapi/solana_node_api/getLargestAccounts.json
@@ -90,9 +90,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getLatestBlockhash.json
+++ b/openapi/solana_node_api/getLatestBlockhash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getLeaderSchedule.json
+++ b/openapi/solana_node_api/getLeaderSchedule.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getMaxRetransmitSlot.json
+++ b/openapi/solana_node_api/getMaxRetransmitSlot.json
@@ -70,9 +70,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getMaxShredInsertSlot.json
+++ b/openapi/solana_node_api/getMaxShredInsertSlot.json
@@ -70,9 +70,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getMinimumBalanceForRentExemption.json
+++ b/openapi/solana_node_api/getMinimumBalanceForRentExemption.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getMultipleAccounts.json
+++ b/openapi/solana_node_api/getMultipleAccounts.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getProgramAccounts.json
+++ b/openapi/solana_node_api/getProgramAccounts.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getRecentBlockhash.json
+++ b/openapi/solana_node_api/getRecentBlockhash.json
@@ -93,9 +93,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getRecentPerformanceSamples.json
+++ b/openapi/solana_node_api/getRecentPerformanceSamples.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getRecentPrioritizationFees.json
+++ b/openapi/solana_node_api/getRecentPrioritizationFees.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSignatureStatuses.json
+++ b/openapi/solana_node_api/getSignatureStatuses.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSignaturesForAddress.json
+++ b/openapi/solana_node_api/getSignaturesForAddress.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSlot.json
+++ b/openapi/solana_node_api/getSlot.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSlotLeader.json
+++ b/openapi/solana_node_api/getSlotLeader.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSlotLeaders.json
+++ b/openapi/solana_node_api/getSlotLeaders.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": { "explorer-enabled": true, "proxy-enabled": true }
+  }
 }

--- a/openapi/solana_node_api/getStakeMinimumDelegation.json
+++ b/openapi/solana_node_api/getStakeMinimumDelegation.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getSupply.json
+++ b/openapi/solana_node_api/getSupply.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTokenAccountBalance.json
+++ b/openapi/solana_node_api/getTokenAccountBalance.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTokenAccountsByDelegate.json
+++ b/openapi/solana_node_api/getTokenAccountsByDelegate.json
@@ -105,9 +105,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTokenAccountsByOwner.json
+++ b/openapi/solana_node_api/getTokenAccountsByOwner.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTokenLargestAccounts.json
+++ b/openapi/solana_node_api/getTokenLargestAccounts.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTokenSupply.json
+++ b/openapi/solana_node_api/getTokenSupply.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTransaction.json
+++ b/openapi/solana_node_api/getTransaction.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/getTransactionCount.json
+++ b/openapi/solana_node_api/getTransactionCount.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": { "explorer-enabled": true, "proxy-enabled": true }
+  }
 }

--- a/openapi/solana_node_api/getVersion.json
+++ b/openapi/solana_node_api/getVersion.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": { "explorer-enabled": true, "proxy-enabled": true }
+  }
 }

--- a/openapi/solana_node_api/getVoteAccounts.json
+++ b/openapi/solana_node_api/getVoteAccounts.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": { "explorer-enabled": true, "proxy-enabled": true }
+  }
 }

--- a/openapi/solana_node_api/isBlockhashValid.json
+++ b/openapi/solana_node_api/isBlockhashValid.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/minimumLedgerSlot.json
+++ b/openapi/solana_node_api/minimumLedgerSlot.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": { "explorer-enabled": true, "proxy-enabled": true }
+  }
 }

--- a/openapi/solana_node_api/sendTransaction.json
+++ b/openapi/solana_node_api/sendTransaction.json
@@ -110,9 +110,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/solana_node_api/simulateTransaction.json
+++ b/openapi/solana_node_api/simulateTransaction.json
@@ -93,9 +93,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }


### PR DESCRIPTION
## What

Strip the readme.com `x-readme` block (`explorer-enabled` / `proxy-enabled`) from all 52 Solana specs.

## Why

Spec-first migration for **Solana** — next by traffic after Ethereum (7.1K reference views/30d, 81% AI). Nav is already collapsed under **Node APIs** (#450). Per the flat-protocol policy, this is **strip-only** (specs stay flat; category reorg is source-only cosmetics with no rendered/score benefit).

## Safety — content-preserving, zero rendered change

- `x-readme` is a readme.com OpenAPI extension Mintlify does **not** render — nothing changes on the page or in the agent `.md`.
- Surgical raw-text removal: 198 deletions / 5 insertions (the 5 are `},`→`}` comma removals where `x-readme` was a single-line last key).
- Validated: each spec parses and equals **(prod minus x-readme)**; all 49 page bodies **byte-identical**; frontmatter resolves; `mintlify broken-links` clean.
