### PR TITLE
docs: strip x-readme cruft from all remaining protocol specs (765 specs)

### DIFF
--- a/openapi/arbitrum_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/arbitrum_node_api/accounts_info/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/accounts_info/eth_getCode.json
+++ b/openapi/arbitrum_node_api/accounts_info/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/arbitrum_node_api/accounts_info/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/arbitrum_node_api/accounts_info/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/arbitrum_node_api/blocks_info/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/chain_info/eth_chainId.json
+++ b/openapi/arbitrum_node_api/chain_info/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/chain_info/eth_syncing.json
+++ b/openapi/arbitrum_node_api/chain_info/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/client_info/web3_clientVersion.json
+++ b/openapi/arbitrum_node_api/client_info/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_block.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_block.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_call.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_call.json
@@ -102,9 +102,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_callMany.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_callMany.json
@@ -124,9 +124,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_filter.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_filter.json
@@ -93,9 +93,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_get.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_get.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_replayBlockTransactions.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_replayBlockTransactions.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_replayTransaction.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_replayTransaction.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/arbtrace_transaction.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/arbtrace_transaction.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_accountRange.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_accountRange.json
@@ -112,9 +112,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_dumpBlock.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_dumpBlock.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getAccessibleState.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getAccessibleState.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getModifiedAccountsByHash.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getModifiedAccountsByHash.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getModifiedAccountsByNumber.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getModifiedAccountsByNumber.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getRawBlock.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getRawBlock.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getRawHeader.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getRawHeader.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getRawReceipts.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getRawReceipts.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_getRawTransaction.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_getRawTransaction.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_intermediateRoots.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_intermediateRoots.json
@@ -90,9 +90,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_preimage.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_preimage.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_printBlock.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_printBlock.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_traceBadBlock.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_traceBadBlock.json
@@ -92,9 +92,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_traceCall.json
@@ -110,9 +110,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/arbitrum_node_api/debug_and_trace/debug_traceTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/execute_transactions/eth_call.json
+++ b/openapi/arbitrum_node_api/execute_transactions/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/arbitrum_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/arbitrum_node_api/filter_handling/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/arbitrum_node_api/filter_handling/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/arbitrum_node_api/gas_data/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/arbitrum_node_api/gas_data/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/arbitrum_node_api/logs_and_events/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/arbitrum_node_api/logs_and_events/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/arbitrum_node_api/transaction_info/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/arbitrum_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/arbitrum_node_api/transaction_info/eth_simulateV1.json
+++ b/openapi/arbitrum_node_api/transaction_info/eth_simulateV1.json
@@ -157,9 +157,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 } 

--- a/openapi/aurora_node_api/eth_blockNumber.json
+++ b/openapi/aurora_node_api/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_call.json
+++ b/openapi/aurora_node_api/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_chainId.json
+++ b/openapi/aurora_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_estimateGas.json
+++ b/openapi/aurora_node_api/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_gasPrice.json
+++ b/openapi/aurora_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getBalance.json
+++ b/openapi/aurora_node_api/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getBlockByHash.json
+++ b/openapi/aurora_node_api/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getBlockByNumber.json
+++ b/openapi/aurora_node_api/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/aurora_node_api/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/aurora_node_api/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getCode.json
+++ b/openapi/aurora_node_api/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getFilterChanges.json
+++ b/openapi/aurora_node_api/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getLogs.json
+++ b/openapi/aurora_node_api/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getStorageAt.json
+++ b/openapi/aurora_node_api/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/aurora_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/aurora_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getTransactionByHash.json
+++ b/openapi/aurora_node_api/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getTransactionCount.json
+++ b/openapi/aurora_node_api/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_getTransactionReceipt.json
+++ b/openapi/aurora_node_api/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_newBlockFilter.json
+++ b/openapi/aurora_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_newFilter.json
+++ b/openapi/aurora_node_api/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/aurora_node_api/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_sendRawTransaction.json
+++ b/openapi/aurora_node_api/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_syncing.json
+++ b/openapi/aurora_node_api/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/eth_uninstallFilter.json
+++ b/openapi/aurora_node_api/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/net_listening.json
+++ b/openapi/aurora_node_api/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/net_peerCount.json
+++ b/openapi/aurora_node_api/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/aurora_node_api/web3_clientVersion.json
+++ b/openapi/aurora_node_api/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/avalanche_node_api/accounts_info/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/accounts_info/eth_getCode.json
+++ b/openapi/avalanche_node_api/accounts_info/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/avalanche_node_api/accounts_info/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/avalanche_node_api/accounts_info/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/avalanche_node_api/blocks_info/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/chain_info/eth_chainId.json
+++ b/openapi/avalanche_node_api/chain_info/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/chain_info/eth_syncing.json
+++ b/openapi/avalanche_node_api/chain_info/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/client_info/net_listening.json
+++ b/openapi/avalanche_node_api/client_info/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/client_info/web3_clientVersion.json
+++ b/openapi/avalanche_node_api/client_info/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/avalanche_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/avalanche_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/avalanche_node_api/debug_and_trace/debug_traceCall.json
@@ -96,9 +96,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/avalanche_node_api/debug_and_trace/debug_traceTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/execute_transactions/eth_call.json
+++ b/openapi/avalanche_node_api/execute_transactions/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/avalanche_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/avalanche_node_api/filter_handling/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/avalanche_node_api/filter_handling/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/avalanche_node_api/gas_data/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/avalanche_node_api/gas_data/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/avalanche_node_api/logs_and_events/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/avalanche_node_api/logs_and_events/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/transactions_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/avalanche_node_api/transactions_info/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/transactions_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/avalanche_node_api/transactions_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/transactions_info/eth_getTransactionByHash.json
+++ b/openapi/avalanche_node_api/transactions_info/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/transactions_info/eth_getTransactionReceipt.json
+++ b/openapi/avalanche_node_api/transactions_info/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/avalanche_node_api/transactions_info/eth_newPendingTransactionFilter.json
+++ b/openapi/avalanche_node_api/transactions_info/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_getModifiedAccountsByHash.json
+++ b/openapi/base_node_api/debug_getModifiedAccountsByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_getModifiedAccountsByNumber.json
+++ b/openapi/base_node_api/debug_getModifiedAccountsByNumber.json
@@ -87,9 +87,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_storageRangeAt.json
+++ b/openapi/base_node_api/debug_storageRangeAt.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_traceBlockByHash.json
+++ b/openapi/base_node_api/debug_traceBlockByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_traceBlockByNumber.json
+++ b/openapi/base_node_api/debug_traceBlockByNumber.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_traceCall.json
+++ b/openapi/base_node_api/debug_traceCall.json
@@ -104,9 +104,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_traceCallMany.json
+++ b/openapi/base_node_api/debug_traceCallMany.json
@@ -145,9 +145,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/debug_traceTransaction.json
+++ b/openapi/base_node_api/debug_traceTransaction.json
@@ -108,9 +108,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_accounts.json
+++ b/openapi/base_node_api/eth_accounts.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_blockNumber.json
+++ b/openapi/base_node_api/eth_blockNumber.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_call.json
+++ b/openapi/base_node_api/eth_call.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_callMany.json
+++ b/openapi/base_node_api/eth_callMany.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_chainId.json
+++ b/openapi/base_node_api/eth_chainId.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_createAccessList.json
+++ b/openapi/base_node_api/eth_createAccessList.json
@@ -120,9 +120,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_estimateGas.json
+++ b/openapi/base_node_api/eth_estimateGas.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_feeHistory.json
+++ b/openapi/base_node_api/eth_feeHistory.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_gasPrice.json
+++ b/openapi/base_node_api/eth_gasPrice.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBalance.json
+++ b/openapi/base_node_api/eth_getBalance.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBlockByHash.json
+++ b/openapi/base_node_api/eth_getBlockByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBlockByNumber.json
+++ b/openapi/base_node_api/eth_getBlockByNumber.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBlockReceipts.json
+++ b/openapi/base_node_api/eth_getBlockReceipts.json
@@ -154,9 +154,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/base_node_api/eth_getBlockTransactionCountByHash.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/base_node_api/eth_getBlockTransactionCountByNumber.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getCode.json
+++ b/openapi/base_node_api/eth_getCode.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getFilterChanges.json
+++ b/openapi/base_node_api/eth_getFilterChanges.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getFilterLogs.json
+++ b/openapi/base_node_api/eth_getFilterLogs.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getLogs.json
+++ b/openapi/base_node_api/eth_getLogs.json
@@ -137,9 +137,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getProof.json
+++ b/openapi/base_node_api/eth_getProof.json
@@ -136,9 +136,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getRawTransactionByBlockHashAndIndex.json
+++ b/openapi/base_node_api/eth_getRawTransactionByBlockHashAndIndex.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getRawTransactionByBlockNumberAndIndex.json
+++ b/openapi/base_node_api/eth_getRawTransactionByBlockNumberAndIndex.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getRawTransactionByHash.json
+++ b/openapi/base_node_api/eth_getRawTransactionByHash.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getStorageAt.json
+++ b/openapi/base_node_api/eth_getStorageAt.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/base_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/base_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getTransactionByHash.json
+++ b/openapi/base_node_api/eth_getTransactionByHash.json
@@ -126,9 +126,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getTransactionCount.json
+++ b/openapi/base_node_api/eth_getTransactionCount.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getTransactionReceipt.json
+++ b/openapi/base_node_api/eth_getTransactionReceipt.json
@@ -155,9 +155,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getUncleByBlockHashAndIndex.json
+++ b/openapi/base_node_api/eth_getUncleByBlockHashAndIndex.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getUncleByBlockNumberAndIndex.json
+++ b/openapi/base_node_api/eth_getUncleByBlockNumberAndIndex.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getUncleCountByBlockHash.json
+++ b/openapi/base_node_api/eth_getUncleCountByBlockHash.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_getUncleCountByBlockNumber.json
+++ b/openapi/base_node_api/eth_getUncleCountByBlockNumber.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/base_node_api/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_newBlockFilter.json
+++ b/openapi/base_node_api/eth_newBlockFilter.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_newFilter.json
+++ b/openapi/base_node_api/eth_newFilter.json
@@ -101,9 +101,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/base_node_api/eth_newPendingTransactionFilter.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_protocolVersion.json
+++ b/openapi/base_node_api/eth_protocolVersion.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_sendRawTransaction.json
+++ b/openapi/base_node_api/eth_sendRawTransaction.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_syncing.json
+++ b/openapi/base_node_api/eth_syncing.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/eth_uninstallFilter.json
+++ b/openapi/base_node_api/eth_uninstallFilter.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/net_listening.json
+++ b/openapi/base_node_api/net_listening.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_block.json
+++ b/openapi/base_node_api/trace_block.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_call.json
+++ b/openapi/base_node_api/trace_call.json
@@ -118,9 +118,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_callMany_method.json
+++ b/openapi/base_node_api/trace_callMany_method.json
@@ -105,9 +105,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_get.json
+++ b/openapi/base_node_api/trace_get.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_replayBlockTransactions.json
+++ b/openapi/base_node_api/trace_replayBlockTransactions.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_replayTransaction.json
+++ b/openapi/base_node_api/trace_replayTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/trace_transaction.json
+++ b/openapi/base_node_api/trace_transaction.json
@@ -108,9 +108,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/web3_clientVersion.json
+++ b/openapi/base_node_api/web3_clientVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/base_node_api/web3_sha3.json
+++ b/openapi/base_node_api/web3_sha3.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/decoderawtransaction.json
+++ b/openapi/bitcoin_node_api/decoderawtransaction.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/decodescript.json
+++ b/openapi/bitcoin_node_api/decodescript.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/estimatesmartfee.json
+++ b/openapi/bitcoin_node_api/estimatesmartfee.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getbestblockhash.json
+++ b/openapi/bitcoin_node_api/getbestblockhash.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblock.json
+++ b/openapi/bitcoin_node_api/getblock.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblockchaininfo.json
+++ b/openapi/bitcoin_node_api/getblockchaininfo.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblockfilter.json
+++ b/openapi/bitcoin_node_api/getblockfilter.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblockhash.json
+++ b/openapi/bitcoin_node_api/getblockhash.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblockheader.json
+++ b/openapi/bitcoin_node_api/getblockheader.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblockstats.json
+++ b/openapi/bitcoin_node_api/getblockstats.json
@@ -183,9 +183,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getblocktemplate.json
+++ b/openapi/bitcoin_node_api/getblocktemplate.json
@@ -135,9 +135,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getchaintips.json
+++ b/openapi/bitcoin_node_api/getchaintips.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getchaintxstats.json
+++ b/openapi/bitcoin_node_api/getchaintxstats.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getconnectioncount.json
+++ b/openapi/bitcoin_node_api/getconnectioncount.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getdifficulty.json
+++ b/openapi/bitcoin_node_api/getdifficulty.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmemoryinfo.json
+++ b/openapi/bitcoin_node_api/getmemoryinfo.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmempoolancestors.json
+++ b/openapi/bitcoin_node_api/getmempoolancestors.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmempooldescendants.json
+++ b/openapi/bitcoin_node_api/getmempooldescendants.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmempoolentry.json
+++ b/openapi/bitcoin_node_api/getmempoolentry.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmempoolinfo.json
+++ b/openapi/bitcoin_node_api/getmempoolinfo.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getmininginfo.json
+++ b/openapi/bitcoin_node_api/getmininginfo.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getnettotals.json
+++ b/openapi/bitcoin_node_api/getnettotals.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getnetworkhashps.json
+++ b/openapi/bitcoin_node_api/getnetworkhashps.json
@@ -87,9 +87,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getnetworkinfo.json
+++ b/openapi/bitcoin_node_api/getnetworkinfo.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getnodeaddresses.json
+++ b/openapi/bitcoin_node_api/getnodeaddresses.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getpeerinfo.json
+++ b/openapi/bitcoin_node_api/getpeerinfo.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getrawmempool.json
+++ b/openapi/bitcoin_node_api/getrawmempool.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getrawtransaction.json
+++ b/openapi/bitcoin_node_api/getrawtransaction.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/getrpcinfo.json
+++ b/openapi/bitcoin_node_api/getrpcinfo.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/gettxout.json
+++ b/openapi/bitcoin_node_api/gettxout.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/gettxoutproof.json
+++ b/openapi/bitcoin_node_api/gettxoutproof.json
@@ -85,9 +85,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/gettxoutsetinfo.json
+++ b/openapi/bitcoin_node_api/gettxoutsetinfo.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/listbanned.json
+++ b/openapi/bitcoin_node_api/listbanned.json
@@ -90,9 +90,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/ping.json
+++ b/openapi/bitcoin_node_api/ping.json
@@ -68,9 +68,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/preciousblock.json
+++ b/openapi/bitcoin_node_api/preciousblock.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/prioritisetransaction.json
+++ b/openapi/bitcoin_node_api/prioritisetransaction.json
@@ -97,9 +97,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/uptime.json
+++ b/openapi/bitcoin_node_api/uptime.json
@@ -69,9 +69,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/validateaddress.json
+++ b/openapi/bitcoin_node_api/validateaddress.json
@@ -157,9 +157,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/verifychain.json
+++ b/openapi/bitcoin_node_api/verifychain.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bitcoin_node_api/verifytxoutproof.json
+++ b/openapi/bitcoin_node_api/verifytxoutproof.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/custom_js_tracer.json
+++ b/openapi/bnb_node_api/custom_js_tracer.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/debug_traceBlockByHash.json
+++ b/openapi/bnb_node_api/debug_traceBlockByHash.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/debug_traceBlockByNumber.json
+++ b/openapi/bnb_node_api/debug_traceBlockByNumber.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/debug_traceCall.json
+++ b/openapi/bnb_node_api/debug_traceCall.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/debug_traceTransaction.json
+++ b/openapi/bnb_node_api/debug_traceTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_blockNumber.json
+++ b/openapi/bnb_node_api/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_call.json
+++ b/openapi/bnb_node_api/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_chainId.json
+++ b/openapi/bnb_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_estimateGas.json
+++ b/openapi/bnb_node_api/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_gasPrice.json
+++ b/openapi/bnb_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBalance.json
+++ b/openapi/bnb_node_api/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBlockByHash.json
+++ b/openapi/bnb_node_api/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBlockByNumber.json
+++ b/openapi/bnb_node_api/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBlockReceipts.json
+++ b/openapi/bnb_node_api/eth_getBlockReceipts.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/bnb_node_api/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/bnb_node_api/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getCode.json
+++ b/openapi/bnb_node_api/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getFilterChanges.json
+++ b/openapi/bnb_node_api/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getLogs.json
+++ b/openapi/bnb_node_api/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getProof.json
+++ b/openapi/bnb_node_api/eth_getProof.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getStorageAt.json
+++ b/openapi/bnb_node_api/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/bnb_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/bnb_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getTransactionByHash.json
+++ b/openapi/bnb_node_api/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getTransactionCount.json
+++ b/openapi/bnb_node_api/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_getTransactionReceipt.json
+++ b/openapi/bnb_node_api/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/bnb_node_api/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_newBlockFilter.json
+++ b/openapi/bnb_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_newFilter.json
+++ b/openapi/bnb_node_api/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/bnb_node_api/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_sendRawTransaction.json
+++ b/openapi/bnb_node_api/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_syncing.json
+++ b/openapi/bnb_node_api/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/eth_uninstallFilter.json
+++ b/openapi/bnb_node_api/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/net_listening.json
+++ b/openapi/bnb_node_api/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/net_peerCount.json
+++ b/openapi/bnb_node_api/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_block.json
+++ b/openapi/bnb_node_api/trace_block.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_call.json
+++ b/openapi/bnb_node_api/trace_call.json
@@ -112,9 +112,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_callMany.json
+++ b/openapi/bnb_node_api/trace_callMany.json
@@ -139,9 +139,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_get.json
+++ b/openapi/bnb_node_api/trace_get.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_replayBlockTransactions.json
+++ b/openapi/bnb_node_api/trace_replayBlockTransactions.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_replayTransaction.json
+++ b/openapi/bnb_node_api/trace_replayTransaction.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/trace_transaction.json
+++ b/openapi/bnb_node_api/trace_transaction.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/bnb_node_api/web3_clientVersion.json
+++ b/openapi/bnb_node_api/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_blockNumber.json
+++ b/openapi/cronos_node_api/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_call.json
+++ b/openapi/cronos_node_api/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_chainId.json
+++ b/openapi/cronos_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_estimateGas.json
+++ b/openapi/cronos_node_api/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_gasPrice.json
+++ b/openapi/cronos_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getBalance.json
+++ b/openapi/cronos_node_api/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getBlockByHash.json
+++ b/openapi/cronos_node_api/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getBlockByNumber.json
+++ b/openapi/cronos_node_api/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/cronos_node_api/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/cronos_node_api/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getCode.json
+++ b/openapi/cronos_node_api/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getFilterChanges.json
+++ b/openapi/cronos_node_api/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getLogs.json
+++ b/openapi/cronos_node_api/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getProof.json
+++ b/openapi/cronos_node_api/eth_getProof.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getStorageAt.json
+++ b/openapi/cronos_node_api/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/cronos_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/cronos_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getTransactionByHash.json
+++ b/openapi/cronos_node_api/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getTransactionCount.json
+++ b/openapi/cronos_node_api/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_getTransactionReceipt.json
+++ b/openapi/cronos_node_api/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/cronos_node_api/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_newBlockFilter.json
+++ b/openapi/cronos_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_newFilter.json
+++ b/openapi/cronos_node_api/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/cronos_node_api/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_sendRawTransaction.json
+++ b/openapi/cronos_node_api/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_syncing.json
+++ b/openapi/cronos_node_api/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/eth_uninstallFilter.json
+++ b/openapi/cronos_node_api/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/net_listening.json
+++ b/openapi/cronos_node_api/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/net_peerCount.json
+++ b/openapi/cronos_node_api/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/cronos_node_api/web3_clientVersion.json
+++ b/openapi/cronos_node_api/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/configuration_info/deposit_contract.json
+++ b/openapi/ethereum_beacon_chain_api/configuration_info/deposit_contract.json
@@ -75,9 +75,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/configuration_info/fork_schedule.json
+++ b/openapi/ethereum_beacon_chain_api/configuration_info/fork_schedule.json
@@ -81,9 +81,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/configuration_info/fork_version_by_state_id.json
+++ b/openapi/ethereum_beacon_chain_api/configuration_info/fork_version_by_state_id.json
@@ -93,9 +93,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/configuration_info/genesis_data.json
+++ b/openapi/ethereum_beacon_chain_api/configuration_info/genesis_data.json
@@ -110,9 +110,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/configuration_info/node_config.json
+++ b/openapi/ethereum_beacon_chain_api/configuration_info/node_config.json
@@ -64,9 +64,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconHeadsV2.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconHeadsV2.json
@@ -113,9 +113,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconStateV2.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugBeaconStateV2.json
@@ -291,9 +291,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/debug/getDebugForkChoice.json
+++ b/openapi/ethereum_beacon_chain_api/debug/getDebugForkChoice.json
@@ -192,9 +192,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/events/subscribe_to_events.json
+++ b/openapi/ethereum_beacon_chain_api/events/subscribe_to_events.json
@@ -71,9 +71,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getBeaconBlockRootByBlockId.json
+++ b/openapi/ethereum_beacon_chain_api/state/getBeaconBlockRootByBlockId.json
@@ -91,9 +91,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getBeaconBlocksByBlockId.json
+++ b/openapi/ethereum_beacon_chain_api/state/getBeaconBlocksByBlockId.json
@@ -119,9 +119,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getBeaconHeadersByBlockId.json
+++ b/openapi/ethereum_beacon_chain_api/state/getBeaconHeadersByBlockId.json
@@ -123,9 +123,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getBeaconHeadersBySlotAndParentRoot.json
+++ b/openapi/ethereum_beacon_chain_api/state/getBeaconHeadersBySlotAndParentRoot.json
@@ -148,9 +148,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getBlobsByBlockId.json
+++ b/openapi/ethereum_beacon_chain_api/state/getBlobsByBlockId.json
@@ -120,9 +120,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getCommitteesByStateIdEpochIndexAndSlot.json
+++ b/openapi/ethereum_beacon_chain_api/state/getCommitteesByStateIdEpochIndexAndSlot.json
@@ -151,9 +151,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getFinalityCheckpoints.json
+++ b/openapi/ethereum_beacon_chain_api/state/getFinalityCheckpoints.json
@@ -117,9 +117,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getStateRoot.json
+++ b/openapi/ethereum_beacon_chain_api/state/getStateRoot.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getSyncCommitteeContribution.json
+++ b/openapi/ethereum_beacon_chain_api/state/getSyncCommitteeContribution.json
@@ -135,9 +135,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/state/getSyncCommitteesByStateIdAndEpoch.json
+++ b/openapi/ethereum_beacon_chain_api/state/getSyncCommitteesByStateIdAndEpoch.json
@@ -121,9 +121,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/attestation_data.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/attestation_data.json
@@ -134,9 +134,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/attestation_of_beacon_block_by_block_id.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/attestation_of_beacon_block_by_block_id.json
@@ -150,9 +150,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/attester_slashings.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/attester_slashings.json
@@ -147,9 +147,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/beacon_pool_attestations.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/beacon_pool_attestations.json
@@ -162,9 +162,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/produce_unsigned_blinded_block.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/produce_unsigned_blinded_block.json
@@ -127,9 +127,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/produce_unsigned_block.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/produce_unsigned_block.json
@@ -127,9 +127,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/proposer_duties.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/proposer_duties.json
@@ -105,9 +105,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/proposer_slashings.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/proposer_slashings.json
@@ -123,9 +123,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/validator_balances.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/validator_balances.json
@@ -119,9 +119,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/validator_information_by_state_id.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/validator_information_by_state_id.json
@@ -115,9 +115,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/validator_information_by_state_id_or_public_key.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/validator_information_by_state_id_or_public_key.json
@@ -104,9 +104,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ethereum_beacon_chain_api/validatiors_info/voluntary_exits.json
+++ b/openapi/ethereum_beacon_chain_api/validatiors_info/voluntary_exits.json
@@ -96,9 +96,5 @@
         ]
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_blockNumber.json
+++ b/openapi/fantom_node_api/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_call.json
+++ b/openapi/fantom_node_api/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_chainId.json
+++ b/openapi/fantom_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_estimateGas.json
+++ b/openapi/fantom_node_api/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_gasPrice.json
+++ b/openapi/fantom_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getBalance.json
+++ b/openapi/fantom_node_api/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getBlockByHash.json
+++ b/openapi/fantom_node_api/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getBlockByNumber.json
+++ b/openapi/fantom_node_api/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/fantom_node_api/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/fantom_node_api/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getCode.json
+++ b/openapi/fantom_node_api/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getFilterChanges.json
+++ b/openapi/fantom_node_api/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getLogs.json
+++ b/openapi/fantom_node_api/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getProof.json
+++ b/openapi/fantom_node_api/eth_getProof.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getStorageAt.json
+++ b/openapi/fantom_node_api/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/fantom_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/fantom_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getTransactionByHash.json
+++ b/openapi/fantom_node_api/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getTransactionCount.json
+++ b/openapi/fantom_node_api/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_getTransactionReceipt.json
+++ b/openapi/fantom_node_api/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/fantom_node_api/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_newBlockFilter.json
+++ b/openapi/fantom_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_newFilter.json
+++ b/openapi/fantom_node_api/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/fantom_node_api/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_sendRawTransaction.json
+++ b/openapi/fantom_node_api/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_syncing.json
+++ b/openapi/fantom_node_api/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/eth_uninstallFilter.json
+++ b/openapi/fantom_node_api/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/net_listening.json
+++ b/openapi/fantom_node_api/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/net_peerCount.json
+++ b/openapi/fantom_node_api/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/fantom_node_api/web3_clientVersion.json
+++ b/openapi/fantom_node_api/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/faucet_api/get_tokens.json
+++ b/openapi/faucet_api/get_tokens.json
@@ -84,9 +84,5 @@
         "scheme": "bearer"
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/faucet_api/transaction_history.json
+++ b/openapi/faucet_api/transaction_history.json
@@ -114,9 +114,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/gnosis_node_api/accounts_info/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/accounts_info/eth_getCode.json
+++ b/openapi/gnosis_node_api/accounts_info/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/gnosis_node_api/accounts_info/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/gnosis_node_api/accounts_info/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/gnosis_node_api/blocks_info/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/chain_info/eth_chainId.json
+++ b/openapi/gnosis_node_api/chain_info/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/chain_info/eth_syncing.json
+++ b/openapi/gnosis_node_api/chain_info/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/client_info/net_listening.json
+++ b/openapi/gnosis_node_api/client_info/net_listening.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/client_info/net_peerCount.json
+++ b/openapi/gnosis_node_api/client_info/net_peerCount.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/client_info/web3_clientVersion.json
+++ b/openapi/gnosis_node_api/client_info/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/execute_transactions/eth_call.json
+++ b/openapi/gnosis_node_api/execute_transactions/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/gnosis_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/gnosis_node_api/filter_handling/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/gnosis_node_api/filter_handling/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/gnosis_node_api/gas_data/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/gnosis_node_api/gas_data/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/gnosis_node_api/logs_and_events/eth_getLogs.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/gnosis_node_api/logs_and_events/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/gnosis_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/gnosis_node_api/transaction_info/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/gnosis_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/gnosis_node_api/transaction_info/eth_newPendingTransactionFilter.json
+++ b/openapi/gnosis_node_api/transaction_info/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/monad_node_api/accounts_info/eth_getBalance.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/accounts_info/eth_getCode.json
+++ b/openapi/monad_node_api/accounts_info/eth_getCode.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/monad_node_api/accounts_info/eth_getStorageAt.json
@@ -51,6 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/monad_node_api/accounts_info/eth_getTransactionCount.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/monad_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/monad_node_api/blocks_info/eth_getBlockByHash.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/monad_node_api/blocks_info/eth_getBlockByNumber.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/monad_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -55,6 +55,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/monad_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -55,6 +55,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/monad_node_api/blocks_info/eth_newBlockFilter.json
@@ -70,9 +70,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/chain_info/eth_chainId.json
+++ b/openapi/monad_node_api/chain_info/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/chain_info/eth_syncing.json
+++ b/openapi/monad_node_api/chain_info/eth_syncing.json
@@ -47,6 +47,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/client_info/net_version.json
+++ b/openapi/monad_node_api/client_info/net_version.json
@@ -47,6 +47,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/client_info/web3_clientVersion.json
+++ b/openapi/monad_node_api/client_info/web3_clientVersion.json
@@ -47,6 +47,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/monad_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -35,6 +35,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/monad_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -35,6 +35,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/monad_node_api/debug_and_trace/debug_traceCall.json
@@ -35,6 +35,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/monad_node_api/debug_and_trace/debug_traceTransaction.json
@@ -35,6 +35,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/execute_transactions/eth_call.json
+++ b/openapi/monad_node_api/execute_transactions/eth_call.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/execute_transactions/eth_createAccessList.json
+++ b/openapi/monad_node_api/execute_transactions/eth_createAccessList.json
@@ -35,6 +35,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/monad_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/monad_node_api/gas_data/eth_estimateGas.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/gas_data/eth_feeHistory.json
+++ b/openapi/monad_node_api/gas_data/eth_feeHistory.json
@@ -50,6 +50,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/monad_node_api/gas_data/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/gas_data/eth_maxPriorityFeePerGas.json
+++ b/openapi/monad_node_api/gas_data/eth_maxPriorityFeePerGas.json
@@ -47,6 +47,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/monad_node_api/logs_and_events/eth_getLogs.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/transaction_info/eth_getBlockReceipts.json
+++ b/openapi/monad_node_api/transaction_info/eth_getBlockReceipts.json
@@ -55,6 +55,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/monad_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -55,6 +55,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/monad_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -55,6 +55,5 @@
         }
       }
     }
-  },
-  "x-readme": {"explorer-enabled": true, "proxy-enabled": true}
+  }
 }

--- a/openapi/monad_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/monad_node_api/transaction_info/eth_getTransactionByHash.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/monad_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/monad_node_api/transaction_info/eth_newPendingTransactionFilter.json
+++ b/openapi/monad_node_api/transaction_info/eth_newPendingTransactionFilter.json
@@ -70,9 +70,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_getModifiedAccountsByHash.json
+++ b/openapi/optimism_node_api/debug_getModifiedAccountsByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_getModifiedAccountsByNumber.json
+++ b/openapi/optimism_node_api/debug_getModifiedAccountsByNumber.json
@@ -87,9 +87,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_storageRangeAt.json
+++ b/openapi/optimism_node_api/debug_storageRangeAt.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_traceBlockByHash.json
+++ b/openapi/optimism_node_api/debug_traceBlockByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_traceBlockByNumber.json
+++ b/openapi/optimism_node_api/debug_traceBlockByNumber.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_traceCall.json
+++ b/openapi/optimism_node_api/debug_traceCall.json
@@ -104,9 +104,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_traceCallMany.json
+++ b/openapi/optimism_node_api/debug_traceCallMany.json
@@ -145,9 +145,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/debug_traceTransaction.json
+++ b/openapi/optimism_node_api/debug_traceTransaction.json
@@ -108,9 +108,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_blockNumber.json
+++ b/openapi/optimism_node_api/eth_blockNumber.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_call.json
+++ b/openapi/optimism_node_api/eth_call.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_callMany.json
+++ b/openapi/optimism_node_api/eth_callMany.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_chainId.json
+++ b/openapi/optimism_node_api/eth_chainId.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_createAccessList.json
+++ b/openapi/optimism_node_api/eth_createAccessList.json
@@ -120,9 +120,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_estimateGas.json
+++ b/openapi/optimism_node_api/eth_estimateGas.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_feeHistory.json
+++ b/openapi/optimism_node_api/eth_feeHistory.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_gasPrice.json
+++ b/openapi/optimism_node_api/eth_gasPrice.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBalance.json
+++ b/openapi/optimism_node_api/eth_getBalance.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBlockByHash.json
+++ b/openapi/optimism_node_api/eth_getBlockByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBlockByNumber.json
+++ b/openapi/optimism_node_api/eth_getBlockByNumber.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBlockReceipts.json
+++ b/openapi/optimism_node_api/eth_getBlockReceipts.json
@@ -154,9 +154,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/optimism_node_api/eth_getBlockTransactionCountByHash.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/optimism_node_api/eth_getBlockTransactionCountByNumber.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getCode.json
+++ b/openapi/optimism_node_api/eth_getCode.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getFilterChanges.json
+++ b/openapi/optimism_node_api/eth_getFilterChanges.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getFilterLogs.json
+++ b/openapi/optimism_node_api/eth_getFilterLogs.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getLogs.json
+++ b/openapi/optimism_node_api/eth_getLogs.json
@@ -137,9 +137,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getProof.json
+++ b/openapi/optimism_node_api/eth_getProof.json
@@ -136,9 +136,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getRawTransactionByBlockHashAndIndex.json
+++ b/openapi/optimism_node_api/eth_getRawTransactionByBlockHashAndIndex.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getRawTransactionByBlockNumberAndIndex.json
+++ b/openapi/optimism_node_api/eth_getRawTransactionByBlockNumberAndIndex.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getRawTransactionByHash.json
+++ b/openapi/optimism_node_api/eth_getRawTransactionByHash.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getStorageAt.json
+++ b/openapi/optimism_node_api/eth_getStorageAt.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/optimism_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/optimism_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -127,9 +127,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getTransactionByHash.json
+++ b/openapi/optimism_node_api/eth_getTransactionByHash.json
@@ -126,9 +126,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getTransactionCount.json
+++ b/openapi/optimism_node_api/eth_getTransactionCount.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getTransactionReceipt.json
+++ b/openapi/optimism_node_api/eth_getTransactionReceipt.json
@@ -155,9 +155,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getUncleCountByBlockHash.json
+++ b/openapi/optimism_node_api/eth_getUncleCountByBlockHash.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_getUncleCountByBlockNumber.json
+++ b/openapi/optimism_node_api/eth_getUncleCountByBlockNumber.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/optimism_node_api/eth_maxPriorityFeePerGas.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_newBlockFilter.json
+++ b/openapi/optimism_node_api/eth_newBlockFilter.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_newFilter.json
+++ b/openapi/optimism_node_api/eth_newFilter.json
@@ -101,9 +101,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_sendRawTransaction.json
+++ b/openapi/optimism_node_api/eth_sendRawTransaction.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_sendRawTransactionSync.json
+++ b/openapi/optimism_node_api/eth_sendRawTransactionSync.json
@@ -125,9 +125,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_syncing.json
+++ b/openapi/optimism_node_api/eth_syncing.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/eth_uninstallFilter.json
+++ b/openapi/optimism_node_api/eth_uninstallFilter.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/net_listening.json
+++ b/openapi/optimism_node_api/net_listening.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/web3_clientVersion.json
+++ b/openapi/optimism_node_api/web3_clientVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/optimism_node_api/web3_sha3.json
+++ b/openapi/optimism_node_api/web3_sha3.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getAccount.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getAccount.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getBalance.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getBalance.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getCode.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getCode.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getProof.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getProof.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getStorageAt.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getStorageAt.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/accounts_info/eth_getTransactionCount.json
+++ b/openapi/plasma_node_api/accounts_info/eth_getTransactionCount.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/plasma_node_api/blocks_info/eth_blockNumber.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getBlockByHash.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getBlockByNumber.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getBlockReceipts.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getBlockReceipts.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getHeaderByHash.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getHeaderByHash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getHeaderByNumber.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getHeaderByNumber.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getUncleByBlockHashAndIndex.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getUncleByBlockHashAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getUncleByBlockNumberAndIndex.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getUncleByBlockNumberAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getUncleCountByBlockHash.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getUncleCountByBlockHash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/blocks_info/eth_getUncleCountByBlockNumber.json
+++ b/openapi/plasma_node_api/blocks_info/eth_getUncleCountByBlockNumber.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/chain_info/eth_accounts.json
+++ b/openapi/plasma_node_api/chain_info/eth_accounts.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/chain_info/eth_chainId.json
+++ b/openapi/plasma_node_api/chain_info/eth_chainId.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/chain_info/eth_hashrate.json
+++ b/openapi/plasma_node_api/chain_info/eth_hashrate.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/chain_info/eth_protocolVersion.json
+++ b/openapi/plasma_node_api/chain_info/eth_protocolVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/chain_info/eth_syncing.json
+++ b/openapi/plasma_node_api/chain_info/eth_syncing.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/client_info/net_listening.json
+++ b/openapi/plasma_node_api/client_info/net_listening.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/client_info/net_peerCount.json
+++ b/openapi/plasma_node_api/client_info/net_peerCount.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/client_info/net_version.json
+++ b/openapi/plasma_node_api/client_info/net_version.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/client_info/web3_clientVersion.json
+++ b/openapi/plasma_node_api/client_info/web3_clientVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/client_info/web3_sha3.json
+++ b/openapi/plasma_node_api/client_info/web3_sha3.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/debug_getRawBlock.json
+++ b/openapi/plasma_node_api/debug_and_trace/debug_getRawBlock.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/debug_getRawHeader.json
+++ b/openapi/plasma_node_api/debug_and_trace/debug_getRawHeader.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/debug_getRawReceipts.json
+++ b/openapi/plasma_node_api/debug_and_trace/debug_getRawReceipts.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/debug_getRawTransaction.json
+++ b/openapi/plasma_node_api/debug_and_trace/debug_getRawTransaction.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/plasma_node_api/debug_and_trace/debug_traceCall.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/trace_block.json
+++ b/openapi/plasma_node_api/debug_and_trace/trace_block.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/trace_call.json
+++ b/openapi/plasma_node_api/debug_and_trace/trace_call.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/trace_callMany.json
+++ b/openapi/plasma_node_api/debug_and_trace/trace_callMany.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/trace_get.json
+++ b/openapi/plasma_node_api/debug_and_trace/trace_get.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/debug_and_trace/trace_replayBlockTransactions.json
+++ b/openapi/plasma_node_api/debug_and_trace/trace_replayBlockTransactions.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/execute_transactions/eth_call.json
+++ b/openapi/plasma_node_api/execute_transactions/eth_call.json
@@ -92,9 +92,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/execute_transactions/eth_createAccessList.json
+++ b/openapi/plasma_node_api/execute_transactions/eth_createAccessList.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/execute_transactions/eth_estimateGas.json
+++ b/openapi/plasma_node_api/execute_transactions/eth_estimateGas.json
@@ -85,9 +85,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/execute_transactions/eth_simulateV1.json
+++ b/openapi/plasma_node_api/execute_transactions/eth_simulateV1.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/filter_handling/eth_newBlockFilter.json
+++ b/openapi/plasma_node_api/filter_handling/eth_newBlockFilter.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/filter_handling/eth_newFilter.json
+++ b/openapi/plasma_node_api/filter_handling/eth_newFilter.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/filter_handling/eth_newPendingTransactionFilter.json
+++ b/openapi/plasma_node_api/filter_handling/eth_newPendingTransactionFilter.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/plasma_node_api/filter_handling/eth_uninstallFilter.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/gas_data/eth_blobBaseFee.json
+++ b/openapi/plasma_node_api/gas_data/eth_blobBaseFee.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/gas_data/eth_feeHistory.json
+++ b/openapi/plasma_node_api/gas_data/eth_feeHistory.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/plasma_node_api/gas_data/eth_gasPrice.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/gas_data/eth_maxPriorityFeePerGas.json
+++ b/openapi/plasma_node_api/gas_data/eth_maxPriorityFeePerGas.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/plasma_node_api/logs_and_events/eth_getLogs.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByBlockHashAndIndex.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByBlockHashAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByBlockNumberAndIndex.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByBlockNumberAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByHash.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getRawTransactionByHash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getTransactionByHash.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getTransactionBySenderAndNonce.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getTransactionBySenderAndNonce.json
@@ -89,9 +89,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/plasma_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/plasma_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/account_info/eth_getBalance.json
+++ b/openapi/polygon_node_api/account_info/eth_getBalance.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/account_info/eth_getCode.json
+++ b/openapi/polygon_node_api/account_info/eth_getCode.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/account_info/eth_getStorageAt.json
+++ b/openapi/polygon_node_api/account_info/eth_getStorageAt.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/account_info/eth_getTransactionCount.json
+++ b/openapi/polygon_node_api/account_info/eth_getTransactionCount.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/chain_info/eth_chainId.json
+++ b/openapi/polygon_node_api/chain_info/eth_chainId.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/chain_info/eth_syncing.json
+++ b/openapi/polygon_node_api/chain_info/eth_syncing.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/client_info/net_listening.json
+++ b/openapi/polygon_node_api/client_info/net_listening.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/client_info/net_peerCount.json
+++ b/openapi/polygon_node_api/client_info/net_peerCount.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/client_info/web3_clientVersion.json
+++ b/openapi/polygon_node_api/client_info/web3_clientVersion.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceCall.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json
@@ -93,9 +93,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/trace_block.json
+++ b/openapi/polygon_node_api/debug_and_trace/trace_block.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/debug_and_trace/trace_transaction.json
+++ b/openapi/polygon_node_api/debug_and_trace/trace_transaction.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/execute_transactions/eth_call.json
+++ b/openapi/polygon_node_api/execute_transactions/eth_call.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/polygon_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/execute_transactions/eth_sendRawTransactionSync.json
+++ b/openapi/polygon_node_api/execute_transactions/eth_sendRawTransactionSync.json
@@ -122,9 +122,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/polygon_node_api/filter_handling/eth_getFilterChanges.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/polygon_node_api/gas_data/eth_estimateGas.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/polygon_node_api/gas_data/eth_gasPrice.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/polygon_node_api/logs_and_events/eth_getLogs.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/polygon_node_api/logs_and_events/eth_newFilter.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json
+++ b/openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_blockNumber.json
+++ b/openapi/polygon_zkevm_node_api/eth_blockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_call.json
+++ b/openapi/polygon_zkevm_node_api/eth_call.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_chainId.json
+++ b/openapi/polygon_zkevm_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_estimateGas.json
+++ b/openapi/polygon_zkevm_node_api/eth_estimateGas.json
@@ -91,9 +91,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_gasPrice.json
+++ b/openapi/polygon_zkevm_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getBalance.json
+++ b/openapi/polygon_zkevm_node_api/eth_getBalance.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getBlockByHash.json
+++ b/openapi/polygon_zkevm_node_api/eth_getBlockByHash.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getBlockByNumber.json
+++ b/openapi/polygon_zkevm_node_api/eth_getBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/polygon_zkevm_node_api/eth_getBlockTransactionCountByHash.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/polygon_zkevm_node_api/eth_getBlockTransactionCountByNumber.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getCode.json
+++ b/openapi/polygon_zkevm_node_api/eth_getCode.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getFilterChanges.json
+++ b/openapi/polygon_zkevm_node_api/eth_getFilterChanges.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getLogs.json
+++ b/openapi/polygon_zkevm_node_api/eth_getLogs.json
@@ -106,9 +106,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getStorageAt.json
+++ b/openapi/polygon_zkevm_node_api/eth_getStorageAt.json
@@ -94,9 +94,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/polygon_zkevm_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/polygon_zkevm_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getTransactionByHash.json
+++ b/openapi/polygon_zkevm_node_api/eth_getTransactionByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getTransactionCount.json
+++ b/openapi/polygon_zkevm_node_api/eth_getTransactionCount.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_getTransactionReceipt.json
+++ b/openapi/polygon_zkevm_node_api/eth_getTransactionReceipt.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_newBlockFilter.json
+++ b/openapi/polygon_zkevm_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_newFilter.json
+++ b/openapi/polygon_zkevm_node_api/eth_newFilter.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_newPendingTransactionFilter.json
+++ b/openapi/polygon_zkevm_node_api/eth_newPendingTransactionFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_sendRawTransaction.json
+++ b/openapi/polygon_zkevm_node_api/eth_sendRawTransaction.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_syncing.json
+++ b/openapi/polygon_zkevm_node_api/eth_syncing.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/eth_uninstallFilter.json
+++ b/openapi/polygon_zkevm_node_api/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/web3_clientVersion.json
+++ b/openapi/polygon_zkevm_node_api/web3_clientVersion.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_batchNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_batchNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_batchNumberByBlockNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_batchNumberByBlockNumber.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_consolidatedBlockNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_consolidatedBlockNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_getBatchByNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_getBatchByNumber.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_isBlockConsolidated.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_isBlockConsolidated.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_isBlockVirtualized.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_isBlockVirtualized.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_verifiedBatchNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_verifiedBatchNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_virtualBatchNumber.json
+++ b/openapi/polygon_zkevm_node_api/zkevm_methods/zkevm_virtualBatchNumber.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/debug_traceBlockByHash.json
+++ b/openapi/ronin_node_api/debug_traceBlockByHash.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/debug_traceBlockByNumber.json
+++ b/openapi/ronin_node_api/debug_traceBlockByNumber.json
@@ -88,9 +88,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/debug_traceCall.json
+++ b/openapi/ronin_node_api/debug_traceCall.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/debug_traceTransaction.json
+++ b/openapi/ronin_node_api/debug_traceTransaction.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_blockNumber.json
+++ b/openapi/ronin_node_api/eth_blockNumber.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_call.json
+++ b/openapi/ronin_node_api/eth_call.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_chainId.json
+++ b/openapi/ronin_node_api/eth_chainId.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_estimateGas.json
+++ b/openapi/ronin_node_api/eth_estimateGas.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_gasPrice.json
+++ b/openapi/ronin_node_api/eth_gasPrice.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getBalance.json
+++ b/openapi/ronin_node_api/eth_getBalance.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getBlockByHash.json
+++ b/openapi/ronin_node_api/eth_getBlockByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getBlockByNumber.json
+++ b/openapi/ronin_node_api/eth_getBlockByNumber.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getBlockTransactionCountByHash.json
+++ b/openapi/ronin_node_api/eth_getBlockTransactionCountByHash.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/ronin_node_api/eth_getBlockTransactionCountByNumber.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getCode.json
+++ b/openapi/ronin_node_api/eth_getCode.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getFilterChanges.json
+++ b/openapi/ronin_node_api/eth_getFilterChanges.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getLogs.json
+++ b/openapi/ronin_node_api/eth_getLogs.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getStorageAt.json
+++ b/openapi/ronin_node_api/eth_getStorageAt.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/ronin_node_api/eth_getTransactionByBlockHashAndIndex.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/ronin_node_api/eth_getTransactionByBlockNumberAndIndex.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getTransactionByHash.json
+++ b/openapi/ronin_node_api/eth_getTransactionByHash.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getTransactionCount.json
+++ b/openapi/ronin_node_api/eth_getTransactionCount.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_getTransactionReceipt.json
+++ b/openapi/ronin_node_api/eth_getTransactionReceipt.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_maxPriorityFeePerGas.json
+++ b/openapi/ronin_node_api/eth_maxPriorityFeePerGas.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_newBlockFilter.json
+++ b/openapi/ronin_node_api/eth_newBlockFilter.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_newFilter.json
+++ b/openapi/ronin_node_api/eth_newFilter.json
@@ -101,9 +101,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_sendRawTransaction.json
+++ b/openapi/ronin_node_api/eth_sendRawTransaction.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_syncing.json
+++ b/openapi/ronin_node_api/eth_syncing.json
@@ -95,9 +95,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/eth_uninstallFilter.json
+++ b/openapi/ronin_node_api/eth_uninstallFilter.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/net_listening.json
+++ b/openapi/ronin_node_api/net_listening.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/net_peerCount.json
+++ b/openapi/ronin_node_api/net_peerCount.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ronin_node_api/web3_clientVersion.json
+++ b/openapi/ronin_node_api/web3_clientVersion.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_call.json
+++ b/openapi/starknet_node_api/starknet_call.json
@@ -102,9 +102,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_estimateFee.json
+++ b/openapi/starknet_node_api/starknet_estimateFee.json
@@ -157,9 +157,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_estimateMessageFee.json
+++ b/openapi/starknet_node_api/starknet_estimateMessageFee.json
@@ -109,9 +109,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getClassAt.json
+++ b/openapi/starknet_node_api/starknet_getClassAt.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getClassHashAt.json
+++ b/openapi/starknet_node_api/starknet_getClassHashAt.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getNonce.json
+++ b/openapi/starknet_node_api/starknet_getNonce.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getStorageAt.json
+++ b/openapi/starknet_node_api/starknet_getStorageAt.json
@@ -58,9 +58,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getTransactionByBlockIdAndIndex.json
+++ b/openapi/starknet_node_api/starknet_getTransactionByBlockIdAndIndex.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_getTransactionByHash.json
+++ b/openapi/starknet_node_api/starknet_getTransactionByHash.json
@@ -56,9 +56,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_simulateTransactions.json
+++ b/openapi/starknet_node_api/starknet_simulateTransactions.json
@@ -172,9 +172,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/starknet_node_api/starknet_traceBlockTransactions.json
+++ b/openapi/starknet_node_api/starknet_traceBlockTransactions.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_accounts.json
+++ b/openapi/tempo_node_api/account_info/eth_accounts.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_getBalance.json
+++ b/openapi/tempo_node_api/account_info/eth_getBalance.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_getCode.json
+++ b/openapi/tempo_node_api/account_info/eth_getCode.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_getProof.json
+++ b/openapi/tempo_node_api/account_info/eth_getProof.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_getStorageAt.json
+++ b/openapi/tempo_node_api/account_info/eth_getStorageAt.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/account_info/eth_getTransactionCount.json
+++ b/openapi/tempo_node_api/account_info/eth_getTransactionCount.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_blockNumber.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockByHash.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockByNumber.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockReceipts.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockReceipts.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/blocks_info/eth_getUncleCountByBlockNumber.json
+++ b/openapi/tempo_node_api/blocks_info/eth_getUncleCountByBlockNumber.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/chain_info/eth_chainId.json
+++ b/openapi/tempo_node_api/chain_info/eth_chainId.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/chain_info/eth_protocolVersion.json
+++ b/openapi/tempo_node_api/chain_info/eth_protocolVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/chain_info/eth_syncing.json
+++ b/openapi/tempo_node_api/chain_info/eth_syncing.json
@@ -92,9 +92,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/client_info/net_listening.json
+++ b/openapi/tempo_node_api/client_info/net_listening.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/client_info/net_peerCount.json
+++ b/openapi/tempo_node_api/client_info/net_peerCount.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/client_info/net_version.json
+++ b/openapi/tempo_node_api/client_info/net_version.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/client_info/web3_clientVersion.json
+++ b/openapi/tempo_node_api/client_info/web3_clientVersion.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/client_info/web3_sha3.json
+++ b/openapi/tempo_node_api/client_info/web3_sha3.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_getBadBlocks.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_getBadBlocks.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_getRawBlock.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_getRawBlock.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_getRawHeader.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_getRawHeader.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_getRawReceipts.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_getRawReceipts.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_getRawTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_getRawTransaction.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceCall.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceCallMany.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceCallMany.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/debug_traceTransaction.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_block.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_block.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_call.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_call.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_callMany.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_callMany.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_filter.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_filter.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_get.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_get.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_rawTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_rawTransaction.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_replayBlockTransactions.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_replayBlockTransactions.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_replayTransaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_replayTransaction.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/debug_and_trace/trace_transaction.json
+++ b/openapi/tempo_node_api/debug_and_trace/trace_transaction.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/tempo_node_api/filter_handling/eth_getFilterChanges.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/filter_handling/eth_newBlockFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_newBlockFilter.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/filter_handling/eth_newFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_newFilter.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/filter_handling/eth_newPendingTransactionFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_newPendingTransactionFilter.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/tempo_node_api/filter_handling/eth_uninstallFilter.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/gas_data/eth_blobBaseFee.json
+++ b/openapi/tempo_node_api/gas_data/eth_blobBaseFee.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/tempo_node_api/gas_data/eth_estimateGas.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/gas_data/eth_feeHistory.json
+++ b/openapi/tempo_node_api/gas_data/eth_feeHistory.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/tempo_node_api/gas_data/eth_gasPrice.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/gas_data/eth_maxPriorityFeePerGas.json
+++ b/openapi/tempo_node_api/gas_data/eth_maxPriorityFeePerGas.json
@@ -73,9 +73,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/logs_and_events/eth_getFilterLogs.json
+++ b/openapi/tempo_node_api/logs_and_events/eth_getFilterLogs.json
@@ -77,9 +77,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/tempo_node_api/logs_and_events/eth_getLogs.json
@@ -84,9 +84,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/tempo_specific/eth_sendRawTransactionSync.json
+++ b/openapi/tempo_node_api/tempo_specific/eth_sendRawTransactionSync.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/tempo_specific/tempo_fundAddress.json
+++ b/openapi/tempo_node_api/tempo_specific/tempo_fundAddress.json
@@ -78,9 +78,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_call.json
+++ b/openapi/tempo_node_api/transaction_info/eth_call.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_createAccessList.json
+++ b/openapi/tempo_node_api/transaction_info/eth_createAccessList.json
@@ -79,9 +79,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionByHash.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/tempo_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/transaction_info/eth_sendRawTransaction.json
+++ b/openapi/tempo_node_api/transaction_info/eth_sendRawTransaction.json
@@ -74,9 +74,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/txpool/txpool_content.json
+++ b/openapi/tempo_node_api/txpool/txpool_content.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/tempo_node_api/txpool/txpool_status.json
+++ b/openapi/tempo_node_api/txpool/txpool_status.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/detectAddress.json
+++ b/openapi/ton_node_api/v2/detectAddress.json
@@ -85,9 +85,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/estimateFee.json
+++ b/openapi/ton_node_api/v2/estimateFee.json
@@ -121,9 +121,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getAddressBalance.json
+++ b/openapi/ton_node_api/v2/getAddressBalance.json
@@ -51,9 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getAddressInformation.json
+++ b/openapi/ton_node_api/v2/getAddressInformation.json
@@ -82,9 +82,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getAddressState.json
+++ b/openapi/ton_node_api/v2/getAddressState.json
@@ -56,9 +56,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getBlockHeader.json
+++ b/openapi/ton_node_api/v2/getBlockHeader.json
@@ -158,9 +158,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getBlockTransactions.json
+++ b/openapi/ton_node_api/v2/getBlockTransactions.json
@@ -129,9 +129,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getBlockTransactionsExt.json
+++ b/openapi/ton_node_api/v2/getBlockTransactionsExt.json
@@ -133,9 +133,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getConfigParam.json
+++ b/openapi/ton_node_api/v2/getConfigParam.json
@@ -56,9 +56,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getConsensusBlock.json
+++ b/openapi/ton_node_api/v2/getConsensusBlock.json
@@ -46,9 +46,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getExtendedAddressInformation.json
+++ b/openapi/ton_node_api/v2/getExtendedAddressInformation.json
@@ -105,9 +105,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getMasterchainBlockSignatures.json
+++ b/openapi/ton_node_api/v2/getMasterchainBlockSignatures.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getMasterchainInfo.json
+++ b/openapi/ton_node_api/v2/getMasterchainInfo.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getShardBlockProof.json
+++ b/openapi/ton_node_api/v2/getShardBlockProof.json
@@ -105,9 +105,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getTokenData.json
+++ b/openapi/ton_node_api/v2/getTokenData.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getTransactions.json
+++ b/openapi/ton_node_api/v2/getTransactions.json
@@ -132,9 +132,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/getWalletInformation.json
+++ b/openapi/ton_node_api/v2/getWalletInformation.json
@@ -80,9 +80,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/lookupBlock.json
+++ b/openapi/ton_node_api/v2/lookupBlock.json
@@ -134,9 +134,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/packAddress.json
+++ b/openapi/ton_node_api/v2/packAddress.json
@@ -51,9 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/runGetMethod.json
+++ b/openapi/ton_node_api/v2/runGetMethod.json
@@ -90,9 +90,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/sendBoc.json
+++ b/openapi/ton_node_api/v2/sendBoc.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/sendBocReturnHash.json
+++ b/openapi/ton_node_api/v2/sendBocReturnHash.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/sendQuery.json
+++ b/openapi/ton_node_api/v2/sendQuery.json
@@ -86,9 +86,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/shards.json
+++ b/openapi/ton_node_api/v2/shards.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/tryLocateResultTx.json
+++ b/openapi/ton_node_api/v2/tryLocateResultTx.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/tryLocateSourceTx.json
+++ b/openapi/ton_node_api/v2/tryLocateSourceTx.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/tryLocateTx.json
+++ b/openapi/ton_node_api/v2/tryLocateTx.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v2/unpackAddress.json
+++ b/openapi/ton_node_api/v2/unpackAddress.json
@@ -51,9 +51,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/estimateFee.json
+++ b/openapi/ton_node_api/v3/estimateFee.json
@@ -113,9 +113,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getAccountInfo.json
+++ b/openapi/ton_node_api/v3/getAccountInfo.json
@@ -72,9 +72,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getAccountStates.json
+++ b/openapi/ton_node_api/v3/getAccountStates.json
@@ -139,9 +139,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getActions.json
+++ b/openapi/ton_node_api/v3/getActions.json
@@ -182,9 +182,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getAddressBookInfo.json
+++ b/openapi/ton_node_api/v3/getAddressBookInfo.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getAddressInformation.json
+++ b/openapi/ton_node_api/v3/getAddressInformation.json
@@ -71,9 +71,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getAdjacentTransactions.json
+++ b/openapi/ton_node_api/v3/getAdjacentTransactions.json
@@ -132,9 +132,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getBlocks.json
+++ b/openapi/ton_node_api/v3/getBlocks.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getEvents.json
+++ b/openapi/ton_node_api/v3/getEvents.json
@@ -145,9 +145,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getJettonBurns.json
+++ b/openapi/ton_node_api/v3/getJettonBurns.json
@@ -136,9 +136,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getJettonMasters.json
+++ b/openapi/ton_node_api/v3/getJettonMasters.json
@@ -101,9 +101,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getJettonTransfers.json
+++ b/openapi/ton_node_api/v3/getJettonTransfers.json
@@ -150,9 +150,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getJettonWallets.json
+++ b/openapi/ton_node_api/v3/getJettonWallets.json
@@ -98,9 +98,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMasterchainBlockShardState.json
+++ b/openapi/ton_node_api/v3/getMasterchainBlockShardState.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMasterchainBlockShards.json
+++ b/openapi/ton_node_api/v3/getMasterchainBlockShards.json
@@ -75,9 +75,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMasterchainInfo.json
+++ b/openapi/ton_node_api/v3/getMasterchainInfo.json
@@ -81,9 +81,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMessages.json
+++ b/openapi/ton_node_api/v3/getMessages.json
@@ -97,9 +97,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMetadata.json
+++ b/openapi/ton_node_api/v3/getMetadata.json
@@ -67,9 +67,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMultisigOrders.json
+++ b/openapi/ton_node_api/v3/getMultisigOrders.json
@@ -130,9 +130,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getMultisigWallets.json
+++ b/openapi/ton_node_api/v3/getMultisigWallets.json
@@ -113,9 +113,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getNFTCollections.json
+++ b/openapi/ton_node_api/v3/getNFTCollections.json
@@ -97,9 +97,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getNFTItems.json
+++ b/openapi/ton_node_api/v3/getNFTItems.json
@@ -155,9 +155,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getNFTTransfers.json
+++ b/openapi/ton_node_api/v3/getNFTTransfers.json
@@ -147,9 +147,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getPendingTraces.json
+++ b/openapi/ton_node_api/v3/getPendingTraces.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getPendingTransactions.json
+++ b/openapi/ton_node_api/v3/getPendingTransactions.json
@@ -99,9 +99,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getTopAccountsByBalance.json
+++ b/openapi/ton_node_api/v3/getTopAccountsByBalance.json
@@ -83,9 +83,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getTraces.json
+++ b/openapi/ton_node_api/v3/getTraces.json
@@ -154,9 +154,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getTransactions.json
+++ b/openapi/ton_node_api/v3/getTransactions.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getTransactionsByMasterchainBlock.json
+++ b/openapi/ton_node_api/v3/getTransactionsByMasterchainBlock.json
@@ -117,9 +117,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getTransactionsByMessage.json
+++ b/openapi/ton_node_api/v3/getTransactionsByMessage.json
@@ -117,9 +117,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getWalletInfo.json
+++ b/openapi/ton_node_api/v3/getWalletInfo.json
@@ -76,9 +76,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/getWalletStates.json
+++ b/openapi/ton_node_api/v3/getWalletStates.json
@@ -105,9 +105,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/runGetMethod.json
+++ b/openapi/ton_node_api/v3/runGetMethod.json
@@ -119,9 +119,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/ton_node_api/v3/sendMessage.json
+++ b/openapi/ton_node_api/v3/sendMessage.json
@@ -62,9 +62,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_L1BatchNumber.json
+++ b/openapi/zksync_node_api/zks_L1BatchNumber.json
@@ -100,9 +100,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_L1ChainId.json
+++ b/openapi/zksync_node_api/zks_L1ChainId.json
@@ -100,9 +100,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_estimateFee.json
+++ b/openapi/zksync_node_api/zks_estimateFee.json
@@ -121,9 +121,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_estimateGasL1ToL2.json
+++ b/openapi/zksync_node_api/zks_estimateGasL1ToL2.json
@@ -121,9 +121,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getAllAccountBalances.json
+++ b/openapi/zksync_node_api/zks_getAllAccountBalances.json
@@ -115,9 +115,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getBlockDetails.json
+++ b/openapi/zksync_node_api/zks_getBlockDetails.json
@@ -135,9 +135,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getBridgeContracts.json
+++ b/openapi/zksync_node_api/zks_getBridgeContracts.json
@@ -103,9 +103,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getBytecodeByHash.json
+++ b/openapi/zksync_node_api/zks_getBytecodeByHash.json
@@ -102,9 +102,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getL1BatchBlockRange.json
+++ b/openapi/zksync_node_api/zks_getL1BatchBlockRange.json
@@ -111,9 +111,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getL1BatchDetails.json
+++ b/openapi/zksync_node_api/zks_getL1BatchDetails.json
@@ -139,9 +139,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getL2ToL1LogProof.json
+++ b/openapi/zksync_node_api/zks_getL2ToL1LogProof.json
@@ -128,9 +128,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getMainContract.json
+++ b/openapi/zksync_node_api/zks_getMainContract.json
@@ -100,9 +100,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getRawBlockTransactions.json
+++ b/openapi/zksync_node_api/zks_getRawBlockTransactions.json
@@ -110,9 +110,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getTestnetPaymaster.json
+++ b/openapi/zksync_node_api/zks_getTestnetPaymaster.json
@@ -100,9 +100,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }

--- a/openapi/zksync_node_api/zks_getTransactionDetails.json
+++ b/openapi/zksync_node_api/zks_getTransactionDetails.json
@@ -107,9 +107,5 @@
         }
       }
     }
-  },
-  "x-readme": {
-    "explorer-enabled": true,
-    "proxy-enabled": true
   }
 }


### PR DESCRIPTION
## What

Batch **x-readme strip** across all remaining protocol specs — completes the spec-first cleanup. 765 specs / 21 surfaces (all node APIs not yet done, plus the Beacon Chain and Faucet APIs).

## Why

`x-readme` is leftover readme.com platform metadata (`explorer-enabled`/`proxy-enabled`) that Mintlify does **not** render. Removing it is pure source hygiene with **zero rendered/`.md` change**. After this PR, **0 `x-readme` remain** anywhere in `openapi/`.

## Safety — content-preserving

- Surgical raw-text removal (no re-serialization), **CRLF-safe** (line endings preserved exactly).
- **3,028 deletions / 16 insertions** (the 16 are `},`→`}` where `x-readme` was a single-line last key).
- Validated: **all 765 changed specs parse and equal (prod minus x-readme)**; `mintlify broken-links` clean. No `.mdx` moves, no URL changes, no page-body changes.

## Note

Companion PR flattens the grouped protocols' nav (separate concern: navigation, not specs).
