### PR TITLE
docs: flatten all grouped protocols' nav into flat method lists (12 protocols)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1470,122 +1470,67 @@
                   "reference/ethereum-getting-started",
                   "reference/enable-debug-trace-apis-for-your-ethereum-node",
                   "reference/ethereum-rpc-methods-postman-collection",
-                  {
-                    "group": "Blocks info | Ethereum",
-                    "pages": [
-                      "reference/ethereum-blocks-rpc-methods",
-                      "reference/ethereum-getblockbynumber",
-                      "reference/ethereum-getblockbyhash",
-                      "reference/ethereum-getblocknumber",
-                      "reference/ethereum-getblocktransactioncountbyhash",
-                      "reference/ethereum-getblocktransactioncountbynumber",
-                      "reference/ethereum-newblockfilter"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Ethereum",
-                    "pages": [
-                      "reference/ethereum-transactions-rpc-methods",
-                      "reference/ethereum-gettransactionbyhash",
-                      "reference/ethereum-gettransactionreceipt",
-                      "reference/ethereum-gettransactionbyblockhashandindex",
-                      "reference/ethereum-gettransactionbyblocknumberandindex",
-                      "reference/ethereum-getblockreceipts",
-                      "reference/ethereum-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Ethereum",
-                    "pages": [
-                      "reference/ethereum-execution-rpc-methods",
-                      "reference/ethereum-ethcall",
-                      "reference/ethereum-simulatev1",
-                      "reference/ethereum-sendrawtransaction",
-                      "reference/ethereum-sendrawtransactionsync"
-                    ]
-                  },
-                  {
-                    "group": "Debug and Trace | Ethereum",
-                    "pages": [
-                      "reference/ethereum-debug-trace-rpc-methods",
-                      "reference/custom-js-tracing-ethereum",
-                      "reference/ethereum-traceblockbyhash",
-                      "reference/ethereum-tracetransaction",
-                      "reference/ethereum-tracecall",
-                      "reference/ethereum-tracecallmany",
-                      "reference/ethereum-trace_transaction",
-                      "reference/ethereum-trace_block",
-                      "reference/ethereum-traceblockbynumber"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Ethereum",
-                    "pages": [
-                      "reference/ethereum-chain-data-rpc-methods",
-                      "reference/ethereum-syncing",
-                      "reference/ethereum-getchainid"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Ethereum",
-                    "pages": [
-                      "reference/ethereum-gas-data-rpc-methods",
-                      "reference/ethereum-getgasprice",
-                      "reference/ethereum-estimategas",
-                      "reference/ethereum-maxpriorityfeepergas"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Ethereum",
-                    "pages": [
-                      "reference/ethereum-accounts-info-rpc-methods",
-                      "reference/ethereum-getstorageat",
-                      "reference/ethereum-getbalance",
-                      "reference/ethereum-gettransactioncount",
-                      "reference/ethereum-getcode",
-                      "reference/getproof"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Ethereum",
-                    "pages": [
-                      "reference/ethereum-logs-rpc-methods",
-                      "reference/ethereum-newfilter",
-                      "reference/ethereum-getlogs"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Ethereum",
-                    "pages": [
-                      "reference/ethereum-client-data-rpc-methods",
-                      "reference/ethereum-peercount",
-                      "reference/ethereum-listening",
-                      "reference/ethereum-clientversion"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Ethereum",
-                    "pages": [
-                      "reference/ethereum-filters-rpc-methods",
-                      "reference/ethereum-getfilterchanges",
-                      "reference/ethereum-uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Ethereum",
-                    "pages": [
-                      "reference/ethereum-web3js-subscriptions-methods",
-                      "reference/ethereum-native-subscribe-newheads",
-                      "reference/ethereum-native-subscribe-newpendingtransactions",
-                      "reference/ethereum-native-subscribe-logs",
-                      "reference/ethereum-native-unsubscribe",
-                      "reference/ethereum-subscribenewblockheaders",
-                      "reference/ethereum-subscribependingtransactions",
-                      "reference/ethereum-subscribelogs",
-                      "reference/ethereum-subscribesyncing",
-                      "reference/ethereum-clearsubscriptions"
-                    ]
-                  }
+                  "reference/ethereum-blocks-rpc-methods",
+                  "reference/ethereum-getblockbynumber",
+                  "reference/ethereum-getblockbyhash",
+                  "reference/ethereum-getblocknumber",
+                  "reference/ethereum-getblocktransactioncountbyhash",
+                  "reference/ethereum-getblocktransactioncountbynumber",
+                  "reference/ethereum-newblockfilter",
+                  "reference/ethereum-transactions-rpc-methods",
+                  "reference/ethereum-gettransactionbyhash",
+                  "reference/ethereum-gettransactionreceipt",
+                  "reference/ethereum-gettransactionbyblockhashandindex",
+                  "reference/ethereum-gettransactionbyblocknumberandindex",
+                  "reference/ethereum-getblockreceipts",
+                  "reference/ethereum-newpendingtransactionfilter",
+                  "reference/ethereum-execution-rpc-methods",
+                  "reference/ethereum-ethcall",
+                  "reference/ethereum-simulatev1",
+                  "reference/ethereum-sendrawtransaction",
+                  "reference/ethereum-sendrawtransactionsync",
+                  "reference/ethereum-debug-trace-rpc-methods",
+                  "reference/custom-js-tracing-ethereum",
+                  "reference/ethereum-traceblockbyhash",
+                  "reference/ethereum-tracetransaction",
+                  "reference/ethereum-tracecall",
+                  "reference/ethereum-tracecallmany",
+                  "reference/ethereum-trace_transaction",
+                  "reference/ethereum-trace_block",
+                  "reference/ethereum-traceblockbynumber",
+                  "reference/ethereum-chain-data-rpc-methods",
+                  "reference/ethereum-syncing",
+                  "reference/ethereum-getchainid",
+                  "reference/ethereum-gas-data-rpc-methods",
+                  "reference/ethereum-getgasprice",
+                  "reference/ethereum-estimategas",
+                  "reference/ethereum-maxpriorityfeepergas",
+                  "reference/ethereum-accounts-info-rpc-methods",
+                  "reference/ethereum-getstorageat",
+                  "reference/ethereum-getbalance",
+                  "reference/ethereum-gettransactioncount",
+                  "reference/ethereum-getcode",
+                  "reference/getproof",
+                  "reference/ethereum-logs-rpc-methods",
+                  "reference/ethereum-newfilter",
+                  "reference/ethereum-getlogs",
+                  "reference/ethereum-client-data-rpc-methods",
+                  "reference/ethereum-peercount",
+                  "reference/ethereum-listening",
+                  "reference/ethereum-clientversion",
+                  "reference/ethereum-filters-rpc-methods",
+                  "reference/ethereum-getfilterchanges",
+                  "reference/ethereum-uninstallfilter",
+                  "reference/ethereum-web3js-subscriptions-methods",
+                  "reference/ethereum-native-subscribe-newheads",
+                  "reference/ethereum-native-subscribe-newpendingtransactions",
+                  "reference/ethereum-native-subscribe-logs",
+                  "reference/ethereum-native-unsubscribe",
+                  "reference/ethereum-subscribenewblockheaders",
+                  "reference/ethereum-subscribependingtransactions",
+                  "reference/ethereum-subscribelogs",
+                  "reference/ethereum-subscribesyncing",
+                  "reference/ethereum-clearsubscriptions"
                 ]
               },
               {
@@ -1593,125 +1538,75 @@
                 "expanded": false,
                 "pages": [
                   "reference/plasma-getting-started",
-                  {
-                    "group": "Accounts info | Plasma",
-                    "pages": [
-                      "reference/plasma-accounts-info-rpc-methods",
-                      "reference/plasma-eth-getbalance",
-                      "reference/plasma-eth-getcode",
-                      "reference/plasma-eth-getstorageat",
-                      "reference/plasma-eth-gettransactioncount",
-                      "reference/plasma-eth-getproof",
-                      "reference/plasma-eth-getaccount"
-                    ]
-                  },
-                  {
-                    "group": "Blocks info | Plasma",
-                    "pages": [
-                      "reference/plasma-blocks-info-rpc-methods",
-                      "reference/plasma-eth-blocknumber",
-                      "reference/plasma-eth-getblockbynumber",
-                      "reference/plasma-eth-getblockbyhash",
-                      "reference/plasma-eth-getblocktransactioncountbynumber",
-                      "reference/plasma-eth-getblocktransactioncountbyhash",
-                      "reference/plasma-eth-getblockreceipts",
-                      "reference/plasma-eth-getunclecountbyblocknumber",
-                      "reference/plasma-eth-getunclecountbyblockhash",
-                      "reference/plasma-eth-getunclebyblocknumberandindex",
-                      "reference/plasma-eth-getunclebyblockhashandindex",
-                      "reference/plasma-eth-getheaderbynumber",
-                      "reference/plasma-eth-getheaderbyhash"
-                    ]
-                  },
-                  {
-                    "group": "Transaction info | Plasma",
-                    "pages": [
-                      "reference/plasma-transaction-info-rpc-methods",
-                      "reference/plasma-eth-gettransactionbyhash",
-                      "reference/plasma-eth-gettransactionreceipt",
-                      "reference/plasma-eth-gettransactionbyblocknumberandindex",
-                      "reference/plasma-eth-gettransactionbyblockhashandindex",
-                      "reference/plasma-eth-getrawtransactionbyhash",
-                      "reference/plasma-eth-getrawtransactionbyblocknumberandindex",
-                      "reference/plasma-eth-getrawtransactionbyblockhashandindex",
-                      "reference/plasma-eth-gettransactionbysenderandnonce"
-                    ]
-                  },
-                  {
-                    "group": "Execute transactions | Plasma",
-                    "pages": [
-                      "reference/plasma-execute-transactions-rpc-methods",
-                      "reference/plasma-eth-call",
-                      "reference/plasma-eth-estimategas",
-                      "reference/plasma-eth-createaccesslist",
-                      "reference/plasma-eth-simulatev1"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Plasma",
-                    "pages": [
-                      "reference/plasma-gas-data-rpc-methods",
-                      "reference/plasma-eth-gasprice",
-                      "reference/plasma-eth-maxpriorityfeepergas",
-                      "reference/plasma-eth-feehistory",
-                      "reference/plasma-eth-blobbasefee"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Plasma",
-                    "pages": [
-                      "reference/plasma-chain-info-rpc-methods",
-                      "reference/plasma-eth-chainid",
-                      "reference/plasma-eth-syncing",
-                      "reference/plasma-eth-protocolversion",
-                      "reference/plasma-eth-accounts",
-                      "reference/plasma-eth-hashrate"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Plasma",
-                    "pages": [
-                      "reference/plasma-filter-handling-rpc-methods",
-                      "reference/plasma-eth-newfilter",
-                      "reference/plasma-eth-newblockfilter",
-                      "reference/plasma-eth-newpendingtransactionfilter",
-                      "reference/plasma-eth-uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Logs and events | Plasma",
-                    "pages": [
-                      "reference/plasma-logs-and-events-rpc-methods",
-                      "reference/plasma-eth-getlogs"
-                    ]
-                  },
-                  {
-                    "group": "Client info | Plasma",
-                    "pages": [
-                      "reference/plasma-client-info-rpc-methods",
-                      "reference/plasma-web3-clientversion",
-                      "reference/plasma-web3-sha3",
-                      "reference/plasma-net-version",
-                      "reference/plasma-net-listening",
-                      "reference/plasma-net-peercount"
-                    ]
-                  },
-                  {
-                    "group": "Debug and trace | Plasma",
-                    "pages": [
-                      "reference/plasma-debug-and-trace-rpc-methods",
-                      "reference/plasma-debug-getrawheader",
-                      "reference/plasma-debug-getrawblock",
-                      "reference/plasma-debug-getrawtransaction",
-                      "reference/plasma-debug-getrawreceipts",
-                      "reference/plasma-debug-tracecall",
-                      "reference/plasma-trace-call",
-                      "reference/plasma-trace-callmany",
-                      "reference/plasma-trace-replayblocktransactions",
-                      "reference/plasma-trace-block",
-                      "reference/plasma-trace-get"
-                    ]
-                  }
+                  "reference/plasma-accounts-info-rpc-methods",
+                  "reference/plasma-eth-getbalance",
+                  "reference/plasma-eth-getcode",
+                  "reference/plasma-eth-getstorageat",
+                  "reference/plasma-eth-gettransactioncount",
+                  "reference/plasma-eth-getproof",
+                  "reference/plasma-eth-getaccount",
+                  "reference/plasma-blocks-info-rpc-methods",
+                  "reference/plasma-eth-blocknumber",
+                  "reference/plasma-eth-getblockbynumber",
+                  "reference/plasma-eth-getblockbyhash",
+                  "reference/plasma-eth-getblocktransactioncountbynumber",
+                  "reference/plasma-eth-getblocktransactioncountbyhash",
+                  "reference/plasma-eth-getblockreceipts",
+                  "reference/plasma-eth-getunclecountbyblocknumber",
+                  "reference/plasma-eth-getunclecountbyblockhash",
+                  "reference/plasma-eth-getunclebyblocknumberandindex",
+                  "reference/plasma-eth-getunclebyblockhashandindex",
+                  "reference/plasma-eth-getheaderbynumber",
+                  "reference/plasma-eth-getheaderbyhash",
+                  "reference/plasma-transaction-info-rpc-methods",
+                  "reference/plasma-eth-gettransactionbyhash",
+                  "reference/plasma-eth-gettransactionreceipt",
+                  "reference/plasma-eth-gettransactionbyblocknumberandindex",
+                  "reference/plasma-eth-gettransactionbyblockhashandindex",
+                  "reference/plasma-eth-getrawtransactionbyhash",
+                  "reference/plasma-eth-getrawtransactionbyblocknumberandindex",
+                  "reference/plasma-eth-getrawtransactionbyblockhashandindex",
+                  "reference/plasma-eth-gettransactionbysenderandnonce",
+                  "reference/plasma-execute-transactions-rpc-methods",
+                  "reference/plasma-eth-call",
+                  "reference/plasma-eth-estimategas",
+                  "reference/plasma-eth-createaccesslist",
+                  "reference/plasma-eth-simulatev1",
+                  "reference/plasma-gas-data-rpc-methods",
+                  "reference/plasma-eth-gasprice",
+                  "reference/plasma-eth-maxpriorityfeepergas",
+                  "reference/plasma-eth-feehistory",
+                  "reference/plasma-eth-blobbasefee",
+                  "reference/plasma-chain-info-rpc-methods",
+                  "reference/plasma-eth-chainid",
+                  "reference/plasma-eth-syncing",
+                  "reference/plasma-eth-protocolversion",
+                  "reference/plasma-eth-accounts",
+                  "reference/plasma-eth-hashrate",
+                  "reference/plasma-filter-handling-rpc-methods",
+                  "reference/plasma-eth-newfilter",
+                  "reference/plasma-eth-newblockfilter",
+                  "reference/plasma-eth-newpendingtransactionfilter",
+                  "reference/plasma-eth-uninstallfilter",
+                  "reference/plasma-logs-and-events-rpc-methods",
+                  "reference/plasma-eth-getlogs",
+                  "reference/plasma-client-info-rpc-methods",
+                  "reference/plasma-web3-clientversion",
+                  "reference/plasma-web3-sha3",
+                  "reference/plasma-net-version",
+                  "reference/plasma-net-listening",
+                  "reference/plasma-net-peercount",
+                  "reference/plasma-debug-and-trace-rpc-methods",
+                  "reference/plasma-debug-getrawheader",
+                  "reference/plasma-debug-getrawblock",
+                  "reference/plasma-debug-getrawtransaction",
+                  "reference/plasma-debug-getrawreceipts",
+                  "reference/plasma-debug-tracecall",
+                  "reference/plasma-trace-call",
+                  "reference/plasma-trace-callmany",
+                  "reference/plasma-trace-replayblocktransactions",
+                  "reference/plasma-trace-block",
+                  "reference/plasma-trace-get"
                 ]
               },
               {
@@ -1719,61 +1614,41 @@
                 "expanded": false,
                 "pages": [
                   "reference/beacon-chain",
-                  {
-                    "group": "Beacon Chain configuration info",
-                    "pages": [
-                      "reference/beacon-chain-configuration",
-                      "reference/getforkinformation",
-                      "reference/ethereum-beacon-genesis",
-                      "reference/getconfigforkschedule",
-                      "reference/getconfigspec",
-                      "reference/getconfigdepositcontract"
-                    ]
-                  },
-                  {
-                    "group": "Beacon Chain events",
-                    "pages": [
-                      "reference/beacon-chain-events",
-                      "reference/subscribetobeaconevents"
-                    ]
-                  },
-                  {
-                    "group": "Beacon Chain validators info",
-                    "pages": [
-                      "reference/beacon-chain-node",
-                      "reference/getbeaconpoolvoluntaryexits",
-                      "reference/getbeaconpoolproposerslashings",
-                      "reference/getbeaconpoolattesterslashings",
-                      "reference/getbeaconpoolattestationsbyslotandcommitteeindex",
-                      "reference/getvalidatorbalancesbystateidandvalidatorid",
-                      "reference/getvalidatorbystateidandindex",
-                      "reference/getvalidatorinformation",
-                      "reference/getproposerduties",
-                      "reference/produceblock",
-                      "reference/produceblindedblock",
-                      "reference/getattestationdata",
-                      "reference/getbeaconblockattestationsbyblockid"
-                    ]
-                  },
-                  {
-                    "group": "Beacon Chain state",
-                    "pages": [
-                      "reference/beacon-chain-state",
-                      "reference/getbeaconblockrootbyblockid",
-                      "reference/getbeaconblocksbyblockid",
-                      "reference/getbeaconheadersbyblockid",
-                      "reference/getbeaconheadersbyslotandparentroot",
-                      "reference/getsynccommitteecontribution",
-                      "reference/getsynccommitteesbystateidandepoch",
-                      "reference/getcommitteesbystateidepochindexandslot",
-                      "reference/getfinalitycheckpoints",
-                      "reference/getstateroot",
-                      "reference/getblobsbyblockid",
-                      "reference/getdebugbeaconstatev2",
-                      "reference/getdebugbeaconheadsv2",
-                      "reference/getdebugforkchoice"
-                    ]
-                  }
+                  "reference/beacon-chain-configuration",
+                  "reference/getforkinformation",
+                  "reference/ethereum-beacon-genesis",
+                  "reference/getconfigforkschedule",
+                  "reference/getconfigspec",
+                  "reference/getconfigdepositcontract",
+                  "reference/beacon-chain-events",
+                  "reference/subscribetobeaconevents",
+                  "reference/beacon-chain-node",
+                  "reference/getbeaconpoolvoluntaryexits",
+                  "reference/getbeaconpoolproposerslashings",
+                  "reference/getbeaconpoolattesterslashings",
+                  "reference/getbeaconpoolattestationsbyslotandcommitteeindex",
+                  "reference/getvalidatorbalancesbystateidandvalidatorid",
+                  "reference/getvalidatorbystateidandindex",
+                  "reference/getvalidatorinformation",
+                  "reference/getproposerduties",
+                  "reference/produceblock",
+                  "reference/produceblindedblock",
+                  "reference/getattestationdata",
+                  "reference/getbeaconblockattestationsbyblockid",
+                  "reference/beacon-chain-state",
+                  "reference/getbeaconblockrootbyblockid",
+                  "reference/getbeaconblocksbyblockid",
+                  "reference/getbeaconheadersbyblockid",
+                  "reference/getbeaconheadersbyslotandparentroot",
+                  "reference/getsynccommitteecontribution",
+                  "reference/getsynccommitteesbystateidandepoch",
+                  "reference/getcommitteesbystateidepochindexandslot",
+                  "reference/getfinalitycheckpoints",
+                  "reference/getstateroot",
+                  "reference/getblobsbyblockid",
+                  "reference/getdebugbeaconstatev2",
+                  "reference/getdebugbeaconheadsv2",
+                  "reference/getdebugforkchoice"
                 ]
               },
               {
@@ -1781,117 +1656,62 @@
                 "expanded": false,
                 "pages": [
                   "reference/polygon-getting-started",
-                  {
-                    "group": "Blocks Info | Polygon",
-                    "pages": [
-                      "reference/polygon-blocks-rpc-methods",
-                      "reference/polygon-getblocknumber",
-                      "reference/getblockbyhash",
-                      "reference/polygon-getblocktransactioncountbyhash",
-                      "reference/polygon-getblocktransactioncountbynumber",
-                      "reference/polygon-getblockbynumber",
-                      "reference/polygon-newblockfilter"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Polygon",
-                    "pages": [
-                      "reference/polygon-transactions-rpc-methods",
-                      "reference/polygon-gettransactionbyhash",
-                      "reference/polygon-gettransactionreceipt",
-                      "reference/polygon-gettransactionbyblockhashandindex",
-                      "reference/polygon-gettransactionbyblocknumberandindex",
-                      "reference/polygon-getblockreceipts",
-                      "reference/polygon-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Polygon",
-                    "pages": [
-                      "reference/polygon-evm-excecution-rpc-methods",
-                      "reference/ethcall",
-                      "reference/sendrawtransaction",
-                      "reference/polygon-sendrawtransactionsync"
-                    ]
-                  },
-                  {
-                    "group": "Debug & Trace | Polygon",
-                    "pages": [
-                      "reference/polygon-debug-trace-rpc-methods",
-                      "reference/polygon-traceblockbyhash",
-                      "reference/polygon-traceblockbynumber",
-                      "reference/polygon-tracetransaction",
-                      "reference/polygon-tracecall",
-                      "reference/polygon-trace_transaction",
-                      "reference/polygon-trace_block"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Polygon",
-                    "pages": [
-                      "reference/polygon-chain-data-rpc-methods",
-                      "reference/chainid",
-                      "reference/syncing"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Polygon",
-                    "pages": [
-                      "reference/polygon-gas-data-rpc-methods",
-                      "reference/estimategas",
-                      "reference/gasprice"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Polygon",
-                    "pages": [
-                      "reference/polygon-accounts-info-rpc-methods",
-                      "reference/gettransactioncount",
-                      "reference/getbalance",
-                      "reference/getcode",
-                      "reference/getstorageat"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Polygon",
-                    "pages": [
-                      "reference/polygon-logs-rpc-methods",
-                      "reference/getlogs",
-                      "reference/newfilter"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Polygon",
-                    "pages": [
-                      "reference/polygon-filters-rpc-methods",
-                      "reference/getfilterchanges",
-                      "reference/uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Polygon",
-                    "pages": [
-                      "reference/polygon-client-data-rpc-methods",
-                      "reference/clientversion",
-                      "reference/netlistening",
-                      "reference/peercount"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Polygon",
-                    "pages": [
-                      "reference/polygon-web3js-subscriptions-methods",
-                      "reference/polygon-native-subscribe-newheads",
-                      "reference/polygon-native-subscribe-newpendingtransactions",
-                      "reference/polygon-native-subscribe-logs",
-                      "reference/polygon-native-unsubscribe",
-                      "reference/polygon-subscribenewblockheaders",
-                      "reference/polygon-subscribependingtransactions",
-                      "reference/polygon-subscribelogs",
-                      "reference/polygon-subscribesyncing",
-                      "reference/polygon-clearsubscriptions"
-                    ]
-                  }
+                  "reference/polygon-blocks-rpc-methods",
+                  "reference/polygon-getblocknumber",
+                  "reference/getblockbyhash",
+                  "reference/polygon-getblocktransactioncountbyhash",
+                  "reference/polygon-getblocktransactioncountbynumber",
+                  "reference/polygon-getblockbynumber",
+                  "reference/polygon-newblockfilter",
+                  "reference/polygon-transactions-rpc-methods",
+                  "reference/polygon-gettransactionbyhash",
+                  "reference/polygon-gettransactionreceipt",
+                  "reference/polygon-gettransactionbyblockhashandindex",
+                  "reference/polygon-gettransactionbyblocknumberandindex",
+                  "reference/polygon-getblockreceipts",
+                  "reference/polygon-newpendingtransactionfilter",
+                  "reference/polygon-evm-excecution-rpc-methods",
+                  "reference/ethcall",
+                  "reference/sendrawtransaction",
+                  "reference/polygon-sendrawtransactionsync",
+                  "reference/polygon-debug-trace-rpc-methods",
+                  "reference/polygon-traceblockbyhash",
+                  "reference/polygon-traceblockbynumber",
+                  "reference/polygon-tracetransaction",
+                  "reference/polygon-tracecall",
+                  "reference/polygon-trace_transaction",
+                  "reference/polygon-trace_block",
+                  "reference/polygon-chain-data-rpc-methods",
+                  "reference/chainid",
+                  "reference/syncing",
+                  "reference/polygon-gas-data-rpc-methods",
+                  "reference/estimategas",
+                  "reference/gasprice",
+                  "reference/polygon-accounts-info-rpc-methods",
+                  "reference/gettransactioncount",
+                  "reference/getbalance",
+                  "reference/getcode",
+                  "reference/getstorageat",
+                  "reference/polygon-logs-rpc-methods",
+                  "reference/getlogs",
+                  "reference/newfilter",
+                  "reference/polygon-filters-rpc-methods",
+                  "reference/getfilterchanges",
+                  "reference/uninstallfilter",
+                  "reference/polygon-client-data-rpc-methods",
+                  "reference/clientversion",
+                  "reference/netlistening",
+                  "reference/peercount",
+                  "reference/polygon-web3js-subscriptions-methods",
+                  "reference/polygon-native-subscribe-newheads",
+                  "reference/polygon-native-subscribe-newpendingtransactions",
+                  "reference/polygon-native-subscribe-logs",
+                  "reference/polygon-native-unsubscribe",
+                  "reference/polygon-subscribenewblockheaders",
+                  "reference/polygon-subscribependingtransactions",
+                  "reference/polygon-subscribelogs",
+                  "reference/polygon-subscribesyncing",
+                  "reference/polygon-clearsubscriptions"
                 ]
               },
               {
@@ -1899,54 +1719,49 @@
                 "expanded": false,
                 "pages": [
                   "reference/getting-started-bnb-chain",
-                  {
-                    "group": "Endpoints",
-                    "pages": [
-                      "reference/bnb-blocknumber",
-                      "reference/bnb-getblockbynumber",
-                      "reference/bnb-getblockbyhash",
-                      "reference/bnb-getblocktransactioncountbynumber",
-                      "reference/bnb-getblocktransactioncountbyhash",
-                      "reference/bnb-newblockfilter",
-                      "reference/bnb-gettransactionbyhash",
-                      "reference/bnb-gettransactionreceipt",
-                      "reference/bnb-gettransactionbyblocknumberandindex",
-                      "reference/bnb-gettransactionbyblockhashandindex",
-                      "reference/bnb-getblockreceipts",
-                      "reference/bnb-newpendingtransactionfilter",
-                      "reference/bnb-ethcall",
-                      "reference/bnb-sendrawtransaction",
-                      "reference/bnb-getbalance",
-                      "reference/bnb-getcode",
-                      "reference/bnb-getstorageat",
-                      "reference/bnb-gettransactioncount",
-                      "reference/bnb-getproof",
-                      "reference/bnb-getchainid",
-                      "reference/bnb-syncing",
-                      "reference/bnb-netlistening",
-                      "reference/bnb-peercount",
-                      "reference/bnb-clientversion",
-                      "reference/bnb-estimategas",
-                      "reference/bnb-getgasprice",
-                      "reference/bnb-maxpriorityfeepergas",
-                      "reference/bnb-getlogs",
-                      "reference/bnb-newfilter",
-                      "reference/bnb-getfilterchanges",
-                      "reference/bnb-uninstallfilter",
-                      "reference/bnb-customtracer",
-                      "reference/bnb-traceblockbyhash",
-                      "reference/bnb-traceblockbynumber",
-                      "reference/bnb-tracecall",
-                      "reference/bnb-tracetransaction",
-                      "reference/bnb-traceblock",
-                      "reference/trace_transaction",
-                      "reference/bnb-trace-call",
-                      "reference/bnb-tracecallmany",
-                      "reference/bnb-replayblocktransactions",
-                      "reference/bnb-replaytransaction",
-                      "reference/bnb-gettrace"
-                    ]
-                  }
+                  "reference/bnb-blocknumber",
+                  "reference/bnb-getblockbynumber",
+                  "reference/bnb-getblockbyhash",
+                  "reference/bnb-getblocktransactioncountbynumber",
+                  "reference/bnb-getblocktransactioncountbyhash",
+                  "reference/bnb-newblockfilter",
+                  "reference/bnb-gettransactionbyhash",
+                  "reference/bnb-gettransactionreceipt",
+                  "reference/bnb-gettransactionbyblocknumberandindex",
+                  "reference/bnb-gettransactionbyblockhashandindex",
+                  "reference/bnb-getblockreceipts",
+                  "reference/bnb-newpendingtransactionfilter",
+                  "reference/bnb-ethcall",
+                  "reference/bnb-sendrawtransaction",
+                  "reference/bnb-getbalance",
+                  "reference/bnb-getcode",
+                  "reference/bnb-getstorageat",
+                  "reference/bnb-gettransactioncount",
+                  "reference/bnb-getproof",
+                  "reference/bnb-getchainid",
+                  "reference/bnb-syncing",
+                  "reference/bnb-netlistening",
+                  "reference/bnb-peercount",
+                  "reference/bnb-clientversion",
+                  "reference/bnb-estimategas",
+                  "reference/bnb-getgasprice",
+                  "reference/bnb-maxpriorityfeepergas",
+                  "reference/bnb-getlogs",
+                  "reference/bnb-newfilter",
+                  "reference/bnb-getfilterchanges",
+                  "reference/bnb-uninstallfilter",
+                  "reference/bnb-customtracer",
+                  "reference/bnb-traceblockbyhash",
+                  "reference/bnb-traceblockbynumber",
+                  "reference/bnb-tracecall",
+                  "reference/bnb-tracetransaction",
+                  "reference/bnb-traceblock",
+                  "reference/trace_transaction",
+                  "reference/bnb-trace-call",
+                  "reference/bnb-tracecallmany",
+                  "reference/bnb-replayblocktransactions",
+                  "reference/bnb-replaytransaction",
+                  "reference/bnb-gettrace"
                 ]
               },
               {
@@ -1954,80 +1769,70 @@
                 "expanded": false,
                 "pages": [
                   "reference/base-api-reference",
-                  {
-                    "group": "Endpoints",
-                    "pages": [
-                      "reference/base-blocknumber",
-                      "reference/base-getblockbyhash",
-                      "reference/base-getblockbynumber",
-                      "reference/base-getblocktransactioncountbyhash",
-                      "reference/base-getblocktransactioncountbynumber",
-                      "reference/base-getunclecountbyblockhash",
-                      "reference/base-getunclecountbyblocknumber",
-                      "reference/base-getunclebyblocknumberandindex",
-                      "reference/base-getunclebyblockhashandindex",
-                      "reference/base-getblockreceipts",
-                      "reference/base-chainid",
-                      "reference/base-syncing",
-                      "reference/base-call",
-                      "reference/base-callmany",
-                      "reference/base-estimategas",
-                      "reference/debug-createaccesslist",
-                      "reference/debug-gasprice",
-                      "reference/debug-feehistory",
-                      "reference/base-newfilter",
-                      "reference/base-newblockfilter",
-                      "reference/base-uninstallfilter",
-                      "reference/base-getfilterchanges",
-                      "reference/base-getfilterlogs",
-                      "reference/base-getlogs",
-                      "reference/base-accounts",
-                      "reference/base-getbalance",
-                      "reference/base-getstorageat",
-                      "reference/base-gettransactioncount",
-                      "reference/base-getcode",
-                      "reference/base-getproof",
-                      "reference/base-gettransactionbyhash",
-                      "reference/base-getrawtransactionbyhash",
-                      "reference/base-gettransactionbyblockhashandindex",
-                      "reference/base-getrawtransactionbyblockhashandindex",
-                      "reference/base-gettransactionbyblocknumberandindex",
-                      "reference/base-getrawtransactionbyblocknumberandindex",
-                      "reference/base-gettransactionreceipt",
-                      "reference/base-maxpriorityfeepergas",
-                      "reference/base-sendrawtransaction",
-                      "reference/base-sendrawtransactionsync",
-                      "reference/base-newpendingtransactionfilter",
-                      "reference/base-clientversion",
-                      "reference/protocolversion",
-                      "reference/base-sha3",
-                      "reference/base-listening",
-                      "reference/base-getmodifiedaccountsbynumber",
-                      "reference/base-getmodifiedaccountsbyhash",
-                      "reference/base-getstoragerangeat",
-                      "reference/base-traceblockbyhash",
-                      "reference/base-traceblockbynumber",
-                      "reference/base-tracetransaction",
-                      "reference/base-tracecall",
-                      "reference/base-tracecallmany",
-                      "reference/base-trace-call",
-                      "reference/base-trace-callmany",
-                      "reference/base-trace-replayblocktransactions",
-                      "reference/base-trace-replaytransaction",
-                      "reference/debug-tracetransaction",
-                      "reference/base-trace-get",
-                      "reference/base-trace-block"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Base",
-                    "pages": [
-                      "reference/base-subscribe-newflashblocktransactions",
-                      "reference/base-subscribe-pendinglogs",
-                      "reference/base-subscribe-newflashblocks",
-                      "reference/base-unsubscribe"
-                    ]
-                  }
+                  "reference/base-blocknumber",
+                  "reference/base-getblockbyhash",
+                  "reference/base-getblockbynumber",
+                  "reference/base-getblocktransactioncountbyhash",
+                  "reference/base-getblocktransactioncountbynumber",
+                  "reference/base-getunclecountbyblockhash",
+                  "reference/base-getunclecountbyblocknumber",
+                  "reference/base-getunclebyblocknumberandindex",
+                  "reference/base-getunclebyblockhashandindex",
+                  "reference/base-getblockreceipts",
+                  "reference/base-chainid",
+                  "reference/base-syncing",
+                  "reference/base-call",
+                  "reference/base-callmany",
+                  "reference/base-estimategas",
+                  "reference/debug-createaccesslist",
+                  "reference/debug-gasprice",
+                  "reference/debug-feehistory",
+                  "reference/base-newfilter",
+                  "reference/base-newblockfilter",
+                  "reference/base-uninstallfilter",
+                  "reference/base-getfilterchanges",
+                  "reference/base-getfilterlogs",
+                  "reference/base-getlogs",
+                  "reference/base-accounts",
+                  "reference/base-getbalance",
+                  "reference/base-getstorageat",
+                  "reference/base-gettransactioncount",
+                  "reference/base-getcode",
+                  "reference/base-getproof",
+                  "reference/base-gettransactionbyhash",
+                  "reference/base-getrawtransactionbyhash",
+                  "reference/base-gettransactionbyblockhashandindex",
+                  "reference/base-getrawtransactionbyblockhashandindex",
+                  "reference/base-gettransactionbyblocknumberandindex",
+                  "reference/base-getrawtransactionbyblocknumberandindex",
+                  "reference/base-gettransactionreceipt",
+                  "reference/base-maxpriorityfeepergas",
+                  "reference/base-sendrawtransaction",
+                  "reference/base-sendrawtransactionsync",
+                  "reference/base-newpendingtransactionfilter",
+                  "reference/base-clientversion",
+                  "reference/protocolversion",
+                  "reference/base-sha3",
+                  "reference/base-listening",
+                  "reference/base-getmodifiedaccountsbynumber",
+                  "reference/base-getmodifiedaccountsbyhash",
+                  "reference/base-getstoragerangeat",
+                  "reference/base-traceblockbyhash",
+                  "reference/base-traceblockbynumber",
+                  "reference/base-tracetransaction",
+                  "reference/base-tracecall",
+                  "reference/base-tracecallmany",
+                  "reference/base-trace-call",
+                  "reference/base-trace-callmany",
+                  "reference/base-trace-replayblocktransactions",
+                  "reference/base-trace-replaytransaction",
+                  "reference/debug-tracetransaction",
+                  "reference/base-trace-get",
+                  "reference/base-trace-block",
+                  "reference/base-subscribe-newflashblocktransactions",
+                  "reference/base-subscribe-pendinglogs",
+                  "reference/base-subscribe-newflashblocks",
+                  "reference/base-unsubscribe"
                 ]
               },
               {
@@ -2199,112 +2004,57 @@
                 "expanded": false,
                 "pages": [
                   "reference/avalanche-getting-started",
-                  {
-                    "group": "Blocks Info | Avalanche",
-                    "pages": [
-                      "reference/avalanche-blocks-rpc-methods",
-                      "reference/avalanche-getblocknumber",
-                      "reference/avalanche-getblockbyhash",
-                      "reference/avalanche-getblockbynumber",
-                      "reference/avalanche-getblocktransactioncountbyhash",
-                      "reference/avalanche-getblocktransactioncountbynumber",
-                      "reference/avalanche-newblockfilter"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Avalanche",
-                    "pages": [
-                      "reference/avalanche-transactions-rpc-methods",
-                      "reference/avalanche-gettransactionbyhash",
-                      "reference/avalanche-gettransactionreceipt",
-                      "reference/avalanche-gettransactionbyblockhashandindex",
-                      "reference/avalanche-gettransactionbyblocknumberandindex",
-                      "reference/avalanche-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Avalanche",
-                    "pages": [
-                      "reference/avalanche-execution-rpc-methods",
-                      "reference/avalanche-ethcall",
-                      "reference/avalanche-sendrawtransaction"
-                    ]
-                  },
-                  {
-                    "group": "Debug & Trace | Avalanche",
-                    "pages": [
-                      "reference/avalanche-debug-trace-rpc-methods",
-                      "reference/avalanche-traceblockbyhash",
-                      "reference/avalanche-traceblockbynumber",
-                      "reference/avalanche-tracecall",
-                      "reference/avalanche-tracetransaction"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Avalanche",
-                    "pages": [
-                      "reference/avalanche-chain-data-rpc-methods",
-                      "reference/avalanche-getchainid",
-                      "reference/avalanche-syncing"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Avalanche",
-                    "pages": [
-                      "reference/avalanche-gas-data-rpc-methods",
-                      "reference/avalanche-estimategas",
-                      "reference/avalanche-getgasprice"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Avalanche",
-                    "pages": [
-                      "reference/avalanche-accounts-info-rpc-methods",
-                      "reference/avalanche-gettransactioncount",
-                      "reference/avalanche-getbalance",
-                      "reference/avalanche-getcode",
-                      "reference/avalanche-getstorageat"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Avalanche",
-                    "pages": [
-                      "reference/avalanche-logs-rpc-methods",
-                      "reference/avalanche-getlogs",
-                      "reference/avalanche-newfilter"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Avalanche",
-                    "pages": [
-                      "reference/avalanche-filters-rpc-methods",
-                      "reference/avalanche-getfilterchanges",
-                      "reference/avalanche-uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Avalanche",
-                    "pages": [
-                      "reference/avalanche-client-data-rpc-methods",
-                      "reference/avalanche-clientversion",
-                      "reference/avalanche-listening"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Avalanche",
-                    "pages": [
-                      "reference/avalanche-web3js-subscriptions-methods",
-                      "reference/avalanche-native-subscribe-newheads",
-                      "reference/avalanche-native-subscribe-newpendingtransactions",
-                      "reference/avalanche-native-subscribe-logs",
-                      "reference/avalanche-native-unsubscribe",
-                      "reference/avalanche-subscribenewblockheaders",
-                      "reference/avalanche-subscribependingtransactions",
-                      "reference/avalanche-subscribelogs",
-                      "reference/avalanche-subscribesyncing",
-                      "reference/avalanche-clearsubscriptions"
-                    ]
-                  }
+                  "reference/avalanche-blocks-rpc-methods",
+                  "reference/avalanche-getblocknumber",
+                  "reference/avalanche-getblockbyhash",
+                  "reference/avalanche-getblockbynumber",
+                  "reference/avalanche-getblocktransactioncountbyhash",
+                  "reference/avalanche-getblocktransactioncountbynumber",
+                  "reference/avalanche-newblockfilter",
+                  "reference/avalanche-transactions-rpc-methods",
+                  "reference/avalanche-gettransactionbyhash",
+                  "reference/avalanche-gettransactionreceipt",
+                  "reference/avalanche-gettransactionbyblockhashandindex",
+                  "reference/avalanche-gettransactionbyblocknumberandindex",
+                  "reference/avalanche-newpendingtransactionfilter",
+                  "reference/avalanche-execution-rpc-methods",
+                  "reference/avalanche-ethcall",
+                  "reference/avalanche-sendrawtransaction",
+                  "reference/avalanche-debug-trace-rpc-methods",
+                  "reference/avalanche-traceblockbyhash",
+                  "reference/avalanche-traceblockbynumber",
+                  "reference/avalanche-tracecall",
+                  "reference/avalanche-tracetransaction",
+                  "reference/avalanche-chain-data-rpc-methods",
+                  "reference/avalanche-getchainid",
+                  "reference/avalanche-syncing",
+                  "reference/avalanche-gas-data-rpc-methods",
+                  "reference/avalanche-estimategas",
+                  "reference/avalanche-getgasprice",
+                  "reference/avalanche-accounts-info-rpc-methods",
+                  "reference/avalanche-gettransactioncount",
+                  "reference/avalanche-getbalance",
+                  "reference/avalanche-getcode",
+                  "reference/avalanche-getstorageat",
+                  "reference/avalanche-logs-rpc-methods",
+                  "reference/avalanche-getlogs",
+                  "reference/avalanche-newfilter",
+                  "reference/avalanche-filters-rpc-methods",
+                  "reference/avalanche-getfilterchanges",
+                  "reference/avalanche-uninstallfilter",
+                  "reference/avalanche-client-data-rpc-methods",
+                  "reference/avalanche-clientversion",
+                  "reference/avalanche-listening",
+                  "reference/avalanche-web3js-subscriptions-methods",
+                  "reference/avalanche-native-subscribe-newheads",
+                  "reference/avalanche-native-subscribe-newpendingtransactions",
+                  "reference/avalanche-native-subscribe-logs",
+                  "reference/avalanche-native-unsubscribe",
+                  "reference/avalanche-subscribenewblockheaders",
+                  "reference/avalanche-subscribependingtransactions",
+                  "reference/avalanche-subscribelogs",
+                  "reference/avalanche-subscribesyncing",
+                  "reference/avalanche-clearsubscriptions"
                 ]
               },
               {
@@ -2508,94 +2258,49 @@
                 "expanded": false,
                 "pages": [
                   "reference/monad-getting-started",
-                  {
-                    "group": "Blocks info | Monad",
-                    "pages": [
-                      "reference/monad-blocks-rpc-methods",
-                      "reference/monad-getblocknumber",
-                      "reference/monad-getblockbynumber",
-                      "reference/monad-getblockbyhash",
-                      "reference/monad-getblocktransactioncountbyhash",
-                      "reference/monad-getblocktransactioncountbynumber",
-                      "reference/monad-newblockfilter",
-                      "reference/monad-subscribe-monadnewheads"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Monad",
-                    "pages": [
-                      "reference/monad-transactions-rpc-methods",
-                      "reference/monad-gettransactionbyhash",
-                      "reference/monad-gettransactionreceipt",
-                      "reference/monad-gettransactionbyblockhashandindex",
-                      "reference/monad-gettransactionbyblocknumberandindex",
-                      "reference/monad-getblockreceipts",
-                      "reference/monad-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Monad",
-                    "pages": [
-                      "reference/monad-execution-rpc-methods",
-                      "reference/monad-ethcall",
-                      "reference/monad-sendrawtransaction",
-                      "reference/monad-createaccesslist"
-                    ]
-                  },
-                  {
-                    "group": "Debug and Trace | Monad",
-                    "pages": [
-                      "reference/monad-debug-trace-rpc-methods",
-                      "reference/monad-tracetransaction",
-                      "reference/monad-traceblockbynumber",
-                      "reference/monad-traceblockbyhash",
-                      "reference/monad-tracecall"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Monad",
-                    "pages": [
-                      "reference/monad-chain-data-rpc-methods",
-                      "reference/monad-getchainid",
-                      "reference/monad-syncing"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Monad",
-                    "pages": [
-                      "reference/monad-gas-data-rpc-methods",
-                      "reference/monad-getgasprice",
-                      "reference/monad-estimategas",
-                      "reference/monad-maxpriorityfeepergas",
-                      "reference/monad-feehistory"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Monad",
-                    "pages": [
-                      "reference/monad-accounts-info-rpc-methods",
-                      "reference/monad-getbalance",
-                      "reference/monad-gettransactioncount",
-                      "reference/monad-getcode",
-                      "reference/monad-getstorageat"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Monad",
-                    "pages": [
-                      "reference/monad-logs-rpc-methods",
-                      "reference/monad-getlogs"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Monad",
-                    "pages": [
-                      "reference/monad-client-data-rpc-methods",
-                      "reference/monad-clientversion",
-                      "reference/monad-netversion",
-                      "reference/monad-listening"
-                    ]
-                  }
+                  "reference/monad-blocks-rpc-methods",
+                  "reference/monad-getblocknumber",
+                  "reference/monad-getblockbynumber",
+                  "reference/monad-getblockbyhash",
+                  "reference/monad-getblocktransactioncountbyhash",
+                  "reference/monad-getblocktransactioncountbynumber",
+                  "reference/monad-newblockfilter",
+                  "reference/monad-subscribe-monadnewheads",
+                  "reference/monad-transactions-rpc-methods",
+                  "reference/monad-gettransactionbyhash",
+                  "reference/monad-gettransactionreceipt",
+                  "reference/monad-gettransactionbyblockhashandindex",
+                  "reference/monad-gettransactionbyblocknumberandindex",
+                  "reference/monad-getblockreceipts",
+                  "reference/monad-newpendingtransactionfilter",
+                  "reference/monad-execution-rpc-methods",
+                  "reference/monad-ethcall",
+                  "reference/monad-sendrawtransaction",
+                  "reference/monad-createaccesslist",
+                  "reference/monad-debug-trace-rpc-methods",
+                  "reference/monad-tracetransaction",
+                  "reference/monad-traceblockbynumber",
+                  "reference/monad-traceblockbyhash",
+                  "reference/monad-tracecall",
+                  "reference/monad-chain-data-rpc-methods",
+                  "reference/monad-getchainid",
+                  "reference/monad-syncing",
+                  "reference/monad-gas-data-rpc-methods",
+                  "reference/monad-getgasprice",
+                  "reference/monad-estimategas",
+                  "reference/monad-maxpriorityfeepergas",
+                  "reference/monad-feehistory",
+                  "reference/monad-accounts-info-rpc-methods",
+                  "reference/monad-getbalance",
+                  "reference/monad-gettransactioncount",
+                  "reference/monad-getcode",
+                  "reference/monad-getstorageat",
+                  "reference/monad-logs-rpc-methods",
+                  "reference/monad-getlogs",
+                  "reference/monad-client-data-rpc-methods",
+                  "reference/monad-clientversion",
+                  "reference/monad-netversion",
+                  "reference/monad-listening"
                 ]
               },
               {
@@ -2672,132 +2377,77 @@
                 "expanded": false,
                 "pages": [
                   "reference/arbitrum-getting-started",
-                  {
-                    "group": "Blocks info | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-blocks-rpc-methods",
-                      "reference/arbitrum-eth_blocknumber",
-                      "reference/arbitrum-getblockbyhash",
-                      "reference/arbitrum-getblockbynumber",
-                      "reference/arbitrum-getblocktransactioncountbyhash",
-                      "reference/arbitrum-getblocktransactioncountbynumber",
-                      "reference/arbitrum-newblockfilter"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-transactions-rpc-methods",
-                      "reference/arbitrum-gettransactionbyhash",
-                      "reference/arbitrum-gettransactionreceipt",
-                      "reference/arbitrum-gettransactionbyblockhashandindex",
-                      "reference/arbitrum-gettransactionbyblocknumberandindex",
-                      "reference/arbitrum-simulatev1"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-evm-excecution-rpc-methods",
-                      "reference/arbitrum-ethcall",
-                      "reference/arbitrum-sendrawtransaction",
-                      "reference/arbitrum-sendrawtransactionsync"
-                    ]
-                  },
-                  {
-                    "group": "Debug & Trace | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-debug-and-trace-rpc-methods",
-                      "reference/arbitrum-debug-accountrange",
-                      "reference/arbitrum-debug-dumpblock",
-                      "reference/arbitrum-debug-getaccessiblestate",
-                      "reference/arbitrum-debug-getmodifiedaccountsbyhash",
-                      "reference/arbitrum-debug-getmodifiedaccountsbynumber",
-                      "reference/arbitrum-debug-getrawblock",
-                      "reference/arbitrum-debug-getrawheader",
-                      "reference/arbitrum-debug-getrawreceipts",
-                      "reference/arbitrum-debug-getrawtransaction",
-                      "reference/arbitrum-debug-intermediateroots",
-                      "reference/arbitrum-debug-preimage",
-                      "reference/arbitrum-debug-printblock",
-                      "reference/arbitrum-debug-tracebadblock",
-                      "reference/arbitrum-debug-traceblockbyhash",
-                      "reference/arbitrum-debug-traceblockbynumber",
-                      "reference/arbitrum-debug-tracecall",
-                      "reference/arbitrum-debug-tracetransaction",
-                      "reference/arbitrum-arbtrace-block",
-                      "reference/arbitrum-arbtrace-call",
-                      "reference/arbitrum-arbtrace-callmany",
-                      "reference/arbitrum-arbtrace-filter",
-                      "reference/arbitrum-arbtrace-get",
-                      "reference/arbitrum-arbtrace-replayblocktransactions",
-                      "reference/arbitrum-arbtrace-replaytransaction",
-                      "reference/arbitrum-arbtrace-transaction",
-                      "reference/arbitrum-tracetransaction"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-chain-data-rpc-methods",
-                      "reference/arbitrum-getchainid",
-                      "reference/arbitrum-syncing"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-gas-data-rpc-methods",
-                      "reference/arbitrum-estimategas",
-                      "reference/arbitrum-getgasprice"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-accounts-info-rpc-methods",
-                      "reference/arbitrum-gettransactioncount",
-                      "reference/arbitrum-getbalance",
-                      "reference/arbitrum-getcode",
-                      "reference/arbitrum-getstorageat"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-logs-rpc-methods",
-                      "reference/arbitrum-getlogs",
-                      "reference/arbitrum-newfilter"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-filters-rpc-methods",
-                      "reference/arbitrum-getfilterchanges",
-                      "reference/arbitrum-uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-client-data-rpc-methods",
-                      "reference/arbitrum-clientversion"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Arbitrum",
-                    "pages": [
-                      "reference/arbitrum-web3js-subscriptions-methods",
-                      "reference/arbitrum-native-subscribe-newheads",
-                      "reference/arbitrum-native-subscribe-logs",
-                      "reference/arbitrum-native-unsubscribe",
-                      "reference/arbitrum-subscribenewblockheaders",
-                      "reference/arbitrum-subscribelogs",
-                      "reference/arbitrum-subscribesyncing",
-                      "reference/arbitrum-clearsubscriptions"
-                    ]
-                  }
+                  "reference/arbitrum-blocks-rpc-methods",
+                  "reference/arbitrum-eth_blocknumber",
+                  "reference/arbitrum-getblockbyhash",
+                  "reference/arbitrum-getblockbynumber",
+                  "reference/arbitrum-getblocktransactioncountbyhash",
+                  "reference/arbitrum-getblocktransactioncountbynumber",
+                  "reference/arbitrum-newblockfilter",
+                  "reference/arbitrum-transactions-rpc-methods",
+                  "reference/arbitrum-gettransactionbyhash",
+                  "reference/arbitrum-gettransactionreceipt",
+                  "reference/arbitrum-gettransactionbyblockhashandindex",
+                  "reference/arbitrum-gettransactionbyblocknumberandindex",
+                  "reference/arbitrum-simulatev1",
+                  "reference/arbitrum-evm-excecution-rpc-methods",
+                  "reference/arbitrum-ethcall",
+                  "reference/arbitrum-sendrawtransaction",
+                  "reference/arbitrum-sendrawtransactionsync",
+                  "reference/arbitrum-debug-and-trace-rpc-methods",
+                  "reference/arbitrum-debug-accountrange",
+                  "reference/arbitrum-debug-dumpblock",
+                  "reference/arbitrum-debug-getaccessiblestate",
+                  "reference/arbitrum-debug-getmodifiedaccountsbyhash",
+                  "reference/arbitrum-debug-getmodifiedaccountsbynumber",
+                  "reference/arbitrum-debug-getrawblock",
+                  "reference/arbitrum-debug-getrawheader",
+                  "reference/arbitrum-debug-getrawreceipts",
+                  "reference/arbitrum-debug-getrawtransaction",
+                  "reference/arbitrum-debug-intermediateroots",
+                  "reference/arbitrum-debug-preimage",
+                  "reference/arbitrum-debug-printblock",
+                  "reference/arbitrum-debug-tracebadblock",
+                  "reference/arbitrum-debug-traceblockbyhash",
+                  "reference/arbitrum-debug-traceblockbynumber",
+                  "reference/arbitrum-debug-tracecall",
+                  "reference/arbitrum-debug-tracetransaction",
+                  "reference/arbitrum-arbtrace-block",
+                  "reference/arbitrum-arbtrace-call",
+                  "reference/arbitrum-arbtrace-callmany",
+                  "reference/arbitrum-arbtrace-filter",
+                  "reference/arbitrum-arbtrace-get",
+                  "reference/arbitrum-arbtrace-replayblocktransactions",
+                  "reference/arbitrum-arbtrace-replaytransaction",
+                  "reference/arbitrum-arbtrace-transaction",
+                  "reference/arbitrum-tracetransaction",
+                  "reference/arbitrum-chain-data-rpc-methods",
+                  "reference/arbitrum-getchainid",
+                  "reference/arbitrum-syncing",
+                  "reference/arbitrum-gas-data-rpc-methods",
+                  "reference/arbitrum-estimategas",
+                  "reference/arbitrum-getgasprice",
+                  "reference/arbitrum-accounts-info-rpc-methods",
+                  "reference/arbitrum-gettransactioncount",
+                  "reference/arbitrum-getbalance",
+                  "reference/arbitrum-getcode",
+                  "reference/arbitrum-getstorageat",
+                  "reference/arbitrum-logs-rpc-methods",
+                  "reference/arbitrum-getlogs",
+                  "reference/arbitrum-newfilter",
+                  "reference/arbitrum-filters-rpc-methods",
+                  "reference/arbitrum-getfilterchanges",
+                  "reference/arbitrum-uninstallfilter",
+                  "reference/arbitrum-client-data-rpc-methods",
+                  "reference/arbitrum-clientversion",
+                  "reference/arbitrum-web3js-subscriptions-methods",
+                  "reference/arbitrum-native-subscribe-newheads",
+                  "reference/arbitrum-native-subscribe-logs",
+                  "reference/arbitrum-native-unsubscribe",
+                  "reference/arbitrum-subscribenewblockheaders",
+                  "reference/arbitrum-subscribelogs",
+                  "reference/arbitrum-subscribesyncing",
+                  "reference/arbitrum-clearsubscriptions"
                 ]
               },
               {
@@ -2805,124 +2455,69 @@
                 "expanded": false,
                 "pages": [
                   "reference/tempo-getting-started",
-                  {
-                    "group": "Tempo specific | Tempo",
-                    "pages": [
-                      "reference/tempo-tempo-fundaddress",
-                      "reference/tempo-eth-sendrawtransactionsync"
-                    ]
-                  },
-                  {
-                    "group": "Blocks info | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-blocknumber",
-                      "reference/tempo-eth-getblockbyhash",
-                      "reference/tempo-eth-getblockbynumber",
-                      "reference/tempo-eth-newblockfilter",
-                      "reference/tempo-eth-getblockreceipts",
-                      "reference/tempo-eth-getblocktransactioncountbyhash",
-                      "reference/tempo-eth-getblocktransactioncountbynumber",
-                      "reference/tempo-eth-getunclecountbyblocknumber"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-gettransactionbyhash",
-                      "reference/tempo-eth-gettransactionreceipt",
-                      "reference/tempo-eth-sendrawtransaction",
-                      "reference/tempo-eth-call",
-                      "reference/tempo-eth-gettransactionbyblockhashandindex",
-                      "reference/tempo-eth-gettransactionbyblocknumberandindex",
-                      "reference/tempo-eth-createaccesslist"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-chainid",
-                      "reference/tempo-eth-syncing",
-                      "reference/tempo-eth-protocolversion",
-                      "reference/tempo-eth-accounts"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-gasprice",
-                      "reference/tempo-eth-estimategas",
-                      "reference/tempo-eth-maxpriorityfeepergas",
-                      "reference/tempo-eth-feehistory",
-                      "reference/tempo-eth-blobbasefee"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-getbalance",
-                      "reference/tempo-eth-gettransactioncount",
-                      "reference/tempo-eth-getcode",
-                      "reference/tempo-eth-getstorageat",
-                      "reference/tempo-eth-getproof"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-getlogs",
-                      "reference/tempo-eth-newfilter",
-                      "reference/tempo-eth-getfilterlogs"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Tempo",
-                    "pages": [
-                      "reference/tempo-eth-getfilterchanges",
-                      "reference/tempo-eth-uninstallfilter",
-                      "reference/tempo-eth-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Debug & trace | Tempo",
-                    "pages": [
-                      "reference/tempo-debug-tracetransaction",
-                      "reference/tempo-debug-tracecall",
-                      "reference/tempo-debug-traceblockbynumber",
-                      "reference/tempo-debug-traceblockbyhash",
-                      "reference/tempo-debug-tracecallmany",
-                      "reference/tempo-debug-getbadblocks",
-                      "reference/tempo-debug-getrawblock",
-                      "reference/tempo-debug-getrawheader",
-                      "reference/tempo-debug-getrawreceipts",
-                      "reference/tempo-debug-getrawtransaction",
-                      "reference/tempo-trace-block",
-                      "reference/tempo-trace-transaction",
-                      "reference/tempo-trace-call",
-                      "reference/tempo-trace-callmany",
-                      "reference/tempo-trace-get",
-                      "reference/tempo-trace-rawtransaction",
-                      "reference/tempo-trace-filter",
-                      "reference/tempo-trace-replayblocktransactions",
-                      "reference/tempo-trace-replaytransaction"
-                    ]
-                  },
-                  {
-                    "group": "Transaction pool | Tempo",
-                    "pages": [
-                      "reference/tempo-txpool-status",
-                      "reference/tempo-txpool-content"
-                    ]
-                  },
-                  {
-                    "group": "Client info | Tempo",
-                    "pages": [
-                      "reference/tempo-web3-clientversion",
-                      "reference/tempo-net-version",
-                      "reference/tempo-net-listening",
-                      "reference/tempo-net-peercount",
-                      "reference/tempo-web3-sha3"
-                    ]
-                  }
+                  "reference/tempo-tempo-fundaddress",
+                  "reference/tempo-eth-sendrawtransactionsync",
+                  "reference/tempo-eth-blocknumber",
+                  "reference/tempo-eth-getblockbyhash",
+                  "reference/tempo-eth-getblockbynumber",
+                  "reference/tempo-eth-newblockfilter",
+                  "reference/tempo-eth-getblockreceipts",
+                  "reference/tempo-eth-getblocktransactioncountbyhash",
+                  "reference/tempo-eth-getblocktransactioncountbynumber",
+                  "reference/tempo-eth-getunclecountbyblocknumber",
+                  "reference/tempo-eth-gettransactionbyhash",
+                  "reference/tempo-eth-gettransactionreceipt",
+                  "reference/tempo-eth-sendrawtransaction",
+                  "reference/tempo-eth-call",
+                  "reference/tempo-eth-gettransactionbyblockhashandindex",
+                  "reference/tempo-eth-gettransactionbyblocknumberandindex",
+                  "reference/tempo-eth-createaccesslist",
+                  "reference/tempo-eth-chainid",
+                  "reference/tempo-eth-syncing",
+                  "reference/tempo-eth-protocolversion",
+                  "reference/tempo-eth-accounts",
+                  "reference/tempo-eth-gasprice",
+                  "reference/tempo-eth-estimategas",
+                  "reference/tempo-eth-maxpriorityfeepergas",
+                  "reference/tempo-eth-feehistory",
+                  "reference/tempo-eth-blobbasefee",
+                  "reference/tempo-eth-getbalance",
+                  "reference/tempo-eth-gettransactioncount",
+                  "reference/tempo-eth-getcode",
+                  "reference/tempo-eth-getstorageat",
+                  "reference/tempo-eth-getproof",
+                  "reference/tempo-eth-getlogs",
+                  "reference/tempo-eth-newfilter",
+                  "reference/tempo-eth-getfilterlogs",
+                  "reference/tempo-eth-getfilterchanges",
+                  "reference/tempo-eth-uninstallfilter",
+                  "reference/tempo-eth-newpendingtransactionfilter",
+                  "reference/tempo-debug-tracetransaction",
+                  "reference/tempo-debug-tracecall",
+                  "reference/tempo-debug-traceblockbynumber",
+                  "reference/tempo-debug-traceblockbyhash",
+                  "reference/tempo-debug-tracecallmany",
+                  "reference/tempo-debug-getbadblocks",
+                  "reference/tempo-debug-getrawblock",
+                  "reference/tempo-debug-getrawheader",
+                  "reference/tempo-debug-getrawreceipts",
+                  "reference/tempo-debug-getrawtransaction",
+                  "reference/tempo-trace-block",
+                  "reference/tempo-trace-transaction",
+                  "reference/tempo-trace-call",
+                  "reference/tempo-trace-callmany",
+                  "reference/tempo-trace-get",
+                  "reference/tempo-trace-rawtransaction",
+                  "reference/tempo-trace-filter",
+                  "reference/tempo-trace-replayblocktransactions",
+                  "reference/tempo-trace-replaytransaction",
+                  "reference/tempo-txpool-status",
+                  "reference/tempo-txpool-content",
+                  "reference/tempo-web3-clientversion",
+                  "reference/tempo-net-version",
+                  "reference/tempo-net-listening",
+                  "reference/tempo-net-peercount",
+                  "reference/tempo-web3-sha3"
                 ]
               },
               {
@@ -2952,20 +2547,15 @@
                 "expanded": false,
                 "pages": [
                   "reference/zkevm-getting-started",
-                  {
-                    "group": "zkEVM methods | Polygon zkEVM",
-                    "pages": [
-                      "reference/zkevm-rpc-methods",
-                      "reference/zkevm-consolidatedblocknumber",
-                      "reference/zkevm-isblockvirtualized",
-                      "reference/zkevm-isblockconsolidated",
-                      "reference/zkevm-batchnumberbyblocknumber",
-                      "reference/zkevm-batchnumber",
-                      "reference/zkevm-virtualbatchnumber",
-                      "reference/zkevm-verifiedbatchnumber",
-                      "reference/zkevm-getbatchbynumber"
-                    ]
-                  },
+                  "reference/zkevm-rpc-methods",
+                  "reference/zkevm-consolidatedblocknumber",
+                  "reference/zkevm-isblockvirtualized",
+                  "reference/zkevm-isblockconsolidated",
+                  "reference/zkevm-batchnumberbyblocknumber",
+                  "reference/zkevm-batchnumber",
+                  "reference/zkevm-virtualbatchnumber",
+                  "reference/zkevm-verifiedbatchnumber",
+                  "reference/zkevm-getbatchbynumber",
                   "reference/zkevm-eth_blocknumber",
                   "reference/zkevm-getblockbynumber",
                   "reference/zkevm-getblockbyhash",
@@ -3177,103 +2767,53 @@
                 "pages": [
                   "reference/gnosis-getting-started",
                   "reference/gnosis-beacon-chain",
-                  {
-                    "group": "Blocks info | Gnosis",
-                    "pages": [
-                      "reference/gnosis-blocks-rpc-methods",
-                      "reference/gnosis-blocknumber",
-                      "reference/gnosis-getblockbyhash",
-                      "reference/gnosis-getblockbynumber",
-                      "reference/gnosis-getblocktransactioncountbyhash",
-                      "reference/gnosis-getblocktransactioncountbynumber",
-                      "reference/gnosis-newblockfilter"
-                    ]
-                  },
-                  {
-                    "group": "Transactions info | Gnosis",
-                    "pages": [
-                      "reference/gnosis-transactions-rpc-methods",
-                      "reference/gnosis-gettransactionbyhash",
-                      "reference/gnosis-gettransactionreceipt",
-                      "reference/gnosis-gettransactionbyblockhashandindex",
-                      "reference/gnosis-gettransactionbyblocknumberandindex",
-                      "reference/gnosis-newpendingtransactionfilter"
-                    ]
-                  },
-                  {
-                    "group": "Executing transactions | Gnosis",
-                    "pages": [
-                      "reference/gnosis-excecution-rpc-methods",
-                      "reference/gnosis-ethcall",
-                      "reference/gnosis-sendrawtransaction"
-                    ]
-                  },
-                  {
-                    "group": "Chain info | Gnosis",
-                    "pages": [
-                      "reference/gnosis-chain-data-rpc-methods",
-                      "reference/gnosis-getchainid",
-                      "reference/gnosis-syncing"
-                    ]
-                  },
-                  {
-                    "group": "Gas data | Gnosis",
-                    "pages": [
-                      "reference/gnosis-gas-data-rpc-methods",
-                      "reference/gnosis-estimategas",
-                      "reference/gnosis-getgasprice"
-                    ]
-                  },
-                  {
-                    "group": "Accounts info | Gnosis",
-                    "pages": [
-                      "reference/gnosis-accounts-info-rpc-methods",
-                      "reference/gnosis-gettransactioncount",
-                      "reference/gnosis-getbalance",
-                      "reference/gnosis-getcode",
-                      "reference/gnosis-getstorageat"
-                    ]
-                  },
-                  {
-                    "group": "Logs & events | Gnosis",
-                    "pages": [
-                      "reference/gnosis-logs-rpc-methods",
-                      "reference/gnosis-getlogs",
-                      "reference/gnosis-newfilter"
-                    ]
-                  },
-                  {
-                    "group": "Filter handling | Gnosis",
-                    "pages": [
-                      "reference/gnosis-filters-rpc-methods",
-                      "reference/gnosis-getfilterchanges",
-                      "reference/gnosis-uninstallfilter"
-                    ]
-                  },
-                  {
-                    "group": "Client information | Gnosis",
-                    "pages": [
-                      "reference/gnosis-client-data-rpc-methods",
-                      "reference/gnosis-clientversion",
-                      "reference/gnosis-listening",
-                      "reference/gnosis-peercount"
-                    ]
-                  },
-                  {
-                    "group": "Subscriptions | Gnosis",
-                    "pages": [
-                      "reference/gnosis-web3js-subscriptions-methods",
-                      "reference/gnosis-native-subscribe-newheads",
-                      "reference/gnosis-native-subscribe-newpendingtransactions",
-                      "reference/gnosis-native-subscribe-logs",
-                      "reference/gnosis-native-unsubscribe",
-                      "reference/gnosis-subscribenewblockheaders",
-                      "reference/gnosis-subscribependingtransactions",
-                      "reference/gnosis-subscribelogs",
-                      "reference/gnosis-subscribesyncing",
-                      "reference/gnosis-clearsubscriptions"
-                    ]
-                  }
+                  "reference/gnosis-blocks-rpc-methods",
+                  "reference/gnosis-blocknumber",
+                  "reference/gnosis-getblockbyhash",
+                  "reference/gnosis-getblockbynumber",
+                  "reference/gnosis-getblocktransactioncountbyhash",
+                  "reference/gnosis-getblocktransactioncountbynumber",
+                  "reference/gnosis-newblockfilter",
+                  "reference/gnosis-transactions-rpc-methods",
+                  "reference/gnosis-gettransactionbyhash",
+                  "reference/gnosis-gettransactionreceipt",
+                  "reference/gnosis-gettransactionbyblockhashandindex",
+                  "reference/gnosis-gettransactionbyblocknumberandindex",
+                  "reference/gnosis-newpendingtransactionfilter",
+                  "reference/gnosis-excecution-rpc-methods",
+                  "reference/gnosis-ethcall",
+                  "reference/gnosis-sendrawtransaction",
+                  "reference/gnosis-chain-data-rpc-methods",
+                  "reference/gnosis-getchainid",
+                  "reference/gnosis-syncing",
+                  "reference/gnosis-gas-data-rpc-methods",
+                  "reference/gnosis-estimategas",
+                  "reference/gnosis-getgasprice",
+                  "reference/gnosis-accounts-info-rpc-methods",
+                  "reference/gnosis-gettransactioncount",
+                  "reference/gnosis-getbalance",
+                  "reference/gnosis-getcode",
+                  "reference/gnosis-getstorageat",
+                  "reference/gnosis-logs-rpc-methods",
+                  "reference/gnosis-getlogs",
+                  "reference/gnosis-newfilter",
+                  "reference/gnosis-filters-rpc-methods",
+                  "reference/gnosis-getfilterchanges",
+                  "reference/gnosis-uninstallfilter",
+                  "reference/gnosis-client-data-rpc-methods",
+                  "reference/gnosis-clientversion",
+                  "reference/gnosis-listening",
+                  "reference/gnosis-peercount",
+                  "reference/gnosis-web3js-subscriptions-methods",
+                  "reference/gnosis-native-subscribe-newheads",
+                  "reference/gnosis-native-subscribe-newpendingtransactions",
+                  "reference/gnosis-native-subscribe-logs",
+                  "reference/gnosis-native-unsubscribe",
+                  "reference/gnosis-subscribenewblockheaders",
+                  "reference/gnosis-subscribependingtransactions",
+                  "reference/gnosis-subscribelogs",
+                  "reference/gnosis-subscribesyncing",
+                  "reference/gnosis-clearsubscriptions"
                 ]
               },
               {


### PR DESCRIPTION
## What

Flatten the **12 remaining grouped protocols** — replace their category subgroups with one flat method list each: Ethereum, Plasma, Ethereum Beacon Chain, Polygon, BNB, Base, Avalanche, Monad, Arbitrum, Tempo, Polygon zkEVM, Gnosis Chain.

After this, **every protocol under Node APIs is a flat, Cmd-F-able list** (matching Solana/TON/TRON/Hyperliquid).

## Why

The converged IA is a flat method list inside each protocol so a user expands the protocol and Cmd-F's any method. Grouped protocols hid most methods in collapsed category subgroups (e.g. an Ethereum page rendered only ~11 of ~60 methods). This completes that IA.

## Safety — content-preserving, page-size validated

- **Nav-only.** Page set identical (**1998 leaves before and after**), no `.mdx` moves, no URL changes, `mintlify broken-links` clean.
- **Page-size safe.** These are 36–72 methods each — well under TRON's 156, which already validated **PASS** (~35K converted, score held at 100/A+) in #455.

## Companion

Pairs with the x-readme strip PR (specs); together they finish the spec-first migration of all protocols.
