### PR TITLE
docs(request-units): Polkadot Sidecar at= query reads are archive too

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -221,7 +221,7 @@ Polkadot is served over two transports — the Substrate node JSON-RPC and the [
 
 - `chain_getBlockHash`
 
-**Archive when targeting a historical block (Sidecar REST)** — these endpoints take a block number in the path and are billed as archive (2 RUs) when that block is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, or a `head` path):
+**Archive when targeting a historical block (Sidecar REST)** — a Sidecar request that reads a historical block is billed as archive (2 RUs) when that block is more than 128 behind the chain tip, and full (1 RU) otherwise (recent block, the chain head, or no block specified). The block is taken from the path on these endpoints:
 
 - `/blocks/{number}`
 - `/blocks/{number}/header`
@@ -229,7 +229,9 @@ Polkadot is served over two transports — the Substrate node JSON-RPC and the [
 - `/blocks/{blockId}/extrinsics-raw`
 - `/blocks/{blockId}/para-inclusions`
 
-All other Polkadot methods and Sidecar endpoints — including requests that target the chain head or omit a block parameter — are billed as full (1 RU).
+…or from the `at` query parameter on any other Sidecar endpoint.
+
+All other Polkadot methods and Sidecar endpoints — including requests that target the chain head or omit a block — are billed as full (1 RU).
 
 ## HTTP requests vs WebSocket subscriptions
 


### PR DESCRIPTION
## What

Follow-up to #445. The Polkadot classifier now resolves the Sidecar **`at` query parameter** (smart-proxy [#550](https://github.com/chainstack/smart-proxy/pull/550), CORE-14599). Previously only the path-based `/blocks/...` endpoints triggered archive billing; now **any Sidecar endpoint that reads a historical block via `?at=<block>`** is archive too.

Updates the "Polkadot method scope" section to state the rule by the historical-block principle: a Sidecar request that reads a block more than 128 behind the tip is archive (2 RUs), whether that block comes from the `/blocks/...` path or from the `at` query parameter — otherwise full.

## Why the principle, not a list

The `at` parameter works on essentially every Sidecar state-read endpoint (`balance-info`, `staking-info`, `pallets/.../storage`, `runtime/metadata`, `paras`, …). Enumerating them would read as an exhaustive list and go stale, so the doc states the rule once and keeps only the canonical `/blocks/...` path endpoints explicit. Block-hash `at` values are not resolved (no block-hash resolution) and are intentionally not documented.

## Verification

Checked against the updated `type_polkadot.go` and `type_polkadot_test.go` (passing):
- `?at=100` → archive across `balance-info`, `proxy-info`, `staking-info`, `vesting-info`, `pallets/.../storage`, `pallets/System/events`, `paras`, `paras/.../lease-info`, `runtime/metadata`, `transaction/material`.
- `?at=0x64` (hex) → archive; `?at=950` → full; `?at=872` (exactly 128 behind) → full (boundary stays strictly greater-than); `?at=latest` / invalid / empty → full.
- `/unknown?at=100` → full (the `at` rule only applies to recognized Sidecar paths).

`docs.json` valid; `mint broken-links` passes.