### PR TITLE
docs(hyperliquid): add Python + JS body examples to allMids (agent-win pilot)

### DIFF
--- a/reference/hyperliquid-info-allmids.mdx
+++ b/reference/hyperliquid-info-allmids.mdx
@@ -39,6 +39,8 @@ The response may also include internal index keys like `"@142"` alongside humanâ
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -48,6 +50,29 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.hyperliquid.xyz/info",
+    json={"type": "allMids", "dex": ""},
+)
+mids = response.json()
+print(mids["BTC"])  # mid price for BTC, e.g. "62909.5"
+```
+
+```javascript JavaScript
+const response = await fetch("https://api.hyperliquid.xyz/info", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ type: "allMids", dex: "" }),
+});
+const mids = await response.json();
+console.log(mids.BTC); // mid price for BTC, e.g. "62909.5"
+```
+
+</CodeGroup>
 
 ## Use cases
 


### PR DESCRIPTION
## What

Add **Python (`requests`) + JavaScript (`fetch`)** body examples to the Hyperliquid `allMids` page, wrapping the existing curl in a `<CodeGroup>`.

## Why

Per the 2026-06-24 traffic brief: **81% of our agent traffic is ChatGPT** (answer-engine), and HL `info` methods are the densest agent cluster. Body code blocks flow into the agent-facing `.md`, so this lets ChatGPT hand users **runnable code in their language** instead of forcing a curl→Python/JS translation. This is the playbook's "real agent win," and `allMids` is the pilot.

## Safety / correctness

- **All three examples verified to run** against the live public endpoint — identical output (928 keys, BTC mid). Endpoint + request body mirrored exactly from the curl (unchanged).
- curl preserved; +25 lines, 0 deletions; `mintlify broken-links` clean.

## Verify on preview

- [ ] page renders the 3-tab CodeGroup
- [ ] **the `.md` now carries the Python + JS examples** (the actual agent-win — body code flows to `.md`)
