### PR TITLE
docs(hyperliquid): SDK-based body examples — pilot (6 pages)

### DIFF
--- a/reference/hyperliquid-evm-eth-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-block-number.mdx
@@ -104,12 +104,45 @@ pollForNewBlocks((blockNumber) => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm"))
+
+block_number = w3.eth.block_number
+print(block_number)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm");
+
+const blockNumber = await provider.getBlockNumber();
+console.log(blockNumber);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm"),
+});
+
+const blockNumber = await client.getBlockNumber();
+console.log(blockNumber);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-balance.mdx
+++ b/reference/hyperliquid-evm-eth-get-balance.mdx
@@ -74,12 +74,57 @@ The method returns the account balance in wei as a hexadecimal string.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA","latest"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm"))
+
+address = Web3.to_checksum_address("0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA")
+
+# eth_getBalance against the latest block
+balance_wei = w3.eth.get_balance(address, "latest")
+print(balance_wei)
+print(w3.from_wei(balance_wei, "ether"), "HYPE")
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider, formatEther } from "ethers";
+
+const provider = new JsonRpcProvider("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm");
+
+const address = "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA";
+
+// eth_getBalance against the latest block
+const balanceWei = await provider.getBalance(address, "latest");
+console.log(balanceWei.toString());
+console.log(`${formatEther(balanceWei)} HYPE`);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http, formatEther } from "viem";
+
+const client = createPublicClient({
+  transport: http("https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm"),
+});
+
+const address = "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA" as const;
+
+// eth_getBalance against the latest block
+const balanceWei = await client.getBalance({ address, blockTag: "latest" });
+console.log(balanceWei.toString());
+console.log(`${formatEther(balanceWei)} HYPE`);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-exchange-cancel-order.mdx
+++ b/reference/hyperliquid-exchange-cancel-order.mdx
@@ -73,28 +73,42 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
+import eth_account
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
-import eth_account
 
-# Initialize with your private key
-account = eth_account.Account.from_key("0x...")
-exchange = Exchange(account, constants.MAINNET_API_URL)
+# Signing requires a wallet (LocalAccount). Asset index 0 = BTC.
+wallet = eth_account.Account.from_key("0x...")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
 
-# Cancel an order by ID
-cancel_result = exchange.cancel(
-    coin="BTC",
-    oid=77738308
-)
+# Cancel one order by coin name + order ID (oid).
+# This posts the {"type": "cancel", "cancels": [{"a": 0, "o": 77738308}]} action.
+result = exchange.cancel("BTC", 77738308)
 
-# Cancel multiple orders
-cancel_results = exchange.cancel_multiple([
-    {"coin": "BTC", "oid": 77738308},
-    {"coin": "ETH", "oid": 77738309}
-])
+# To cancel several orders in a single request, use bulk_cancel:
+# result = exchange.bulk_cancel([
+#     {"coin": "BTC", "oid": 77738308},
+# ])
 
-print(cancel_result)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Signing requires a wallet. Asset ID 0 = BTC.
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Posts the { type: "cancel", cancels: [{ a: 0, o: 77738308 }] } action.
+const result = await exchange.cancel({
+  cancels: [{ a: 0, o: 77738308 }],
+});
+
+console.log(result);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-place-order.mdx
+++ b/reference/hyperliquid-exchange-place-order.mdx
@@ -111,26 +111,52 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
-import eth_account
+from eth_account import Account
 
-# Initialize with your private key
-account = eth_account.Account.from_key("0x...")
-exchange = Exchange(account, constants.MAINNET_API_URL)
+# Exchange requires a wallet (LocalAccount) to sign the order
+wallet = Account.from_key("0x...")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
 
-# Place a limit buy order for BTC
+# Place a limit buy order. Asset 0 maps to the coin name BTC,
+# matching the curl payload (b: true, p: "50000", s: "0.01", Gtc, grouping "na").
 order_result = exchange.order(
-    coin="BTC",
-    is_buy=True, 
+    name="BTC",
+    is_buy=True,
     sz=0.01,
     limit_px=50000,
     order_type={"limit": {"tif": "Gtc"}},
-    reduce_only=False
+    reduce_only=False,
 )
 
 print(order_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// ExchangeClient signs with a wallet over an HTTP transport (mainnet by default)
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Same payload as the curl: asset 0, buy, price "50000", size "0.01", Gtc, grouping "na"
+const result = await exchange.order({
+  orders: [{
+    a: 0,
+    b: true,
+    p: "50000",
+    s: "0.01",
+    r: false,
+    t: { limit: { tif: "Gtc" } },
+  }],
+  grouping: "na",
+});
+
+console.log(result);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-info-allmids.mdx
+++ b/reference/hyperliquid-info-allmids.mdx
@@ -39,6 +39,8 @@ The response may also include internal index keys like `"@142"` alongside humanâ
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -48,6 +50,30 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# POST /info with {"type": "allMids", "dex": ""}
+mids = info.all_mids(dex="")
+print(mids)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// POST /info with {"type": "allMids", "dex": ""}
+const mids = await info.allMids({ dex: "" });
+console.log(mids);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-l2-book.mdx
+++ b/reference/hyperliquid-info-l2-book.mdx
@@ -111,12 +111,38 @@ Each price level contains the following fields:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "l2Book", "coin": "ETH"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Posts {"type": "l2Book", "coin": "ETH"} to /info
+book = info.l2_snapshot("ETH")
+print(book)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// Posts {"type": "l2Book", "coin": "ETH"} to /info
+const book = await info.l2Book({ coin: "ETH" });
+console.log(book);
+```
+
+</CodeGroup>
 
 ## Example response
 


### PR DESCRIPTION
Pilot of the orchestrated HL SDK-examples pass. 6 pages across info/exchange/evm. Python SDK + nktkas (HyperCore); web3.py + ethers + viem (HyperEVM, no version pins). Verified live (info/evm) / signature-checked (exchange); critic-reviewed; broken-links clean. Validating .md flow before the full ~184-page run.