### PR TITLE
docs(hyperliquid): SDK code examples across 185 method pages

### DIFF
--- a/reference/hyperliquid-evm-debug-get-raw-block.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-block.mdx
@@ -66,6 +66,8 @@ getRawBlock('latest').then(blockData => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -79,6 +81,47 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# debug_getRawBlock has no convenience wrapper, so call it through the provider
+response = w3.provider.make_request("debug_getRawBlock", ["latest"])
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// debug_getRawBlock has no convenience wrapper, so use the generic send method
+const rawBlock = await provider.send("debug_getRawBlock", ["latest"]);
+console.log(rawBlock);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// debug_getRawBlock is non-standard, so call it through the request method
+const rawBlock = await client.request({
+  method: "debug_getRawBlock",
+  params: ["latest"],
+});
+console.log(rawBlock);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-get-raw-header.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-header.mdx
@@ -66,6 +66,8 @@ getRawHeader('latest').then(header => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -79,6 +81,47 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# debug_getRawHeader has no first-class web3.py wrapper, so call it through the provider
+response = w3.provider.make_request("debug_getRawHeader", ["latest"])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// send() reaches methods that have no high-level API in the Provider
+const rawHeader = await provider.send("debug_getRawHeader", ["latest"]);
+console.log(rawHeader);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// request() issues a raw JSON-RPC call for methods without a built-in action
+const rawHeader = await client.request({
+  method: "debug_getRawHeader",
+  params: ["latest"],
+});
+console.log(rawHeader);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-get-raw-receipts.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-receipts.mdx
@@ -68,6 +68,8 @@ getRawReceipts('latest').then(receipts => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -81,6 +83,47 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# debug_getRawReceipts has no typed helper, so call it via the raw provider request
+response = w3.provider.make_request("debug_getRawReceipts", ["latest"])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// debug_getRawReceipts has no typed helper, so call it via the generic send method
+const receipts = await provider.send("debug_getRawReceipts", ["latest"]);
+console.log(receipts);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// debug_getRawReceipts has no typed action, so call it via the generic request method
+const receipts = await client.request({
+  method: "debug_getRawReceipts",
+  params: ["latest"],
+} as any);
+console.log(receipts);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-get-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-debug-get-raw-transaction.mdx
@@ -67,6 +67,8 @@ getRawTransaction(txHash).then(rawTx => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -80,6 +82,55 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31"
+
+# debug_getRawTransaction has no typed wrapper, so call it directly
+response = w3.provider.make_request("debug_getRawTransaction", [tx_hash])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// debug_getRawTransaction has no typed wrapper, so use the generic send
+const rawTx = await provider.send("debug_getRawTransaction", [txHash]);
+console.log(rawTx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// debug_getRawTransaction has no typed action, so use the raw request method
+const rawTx = await client.request({
+  method: "debug_getRawTransaction",
+  params: [txHash],
+});
+console.log(rawTx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-trace-block-by-number.mdx
+++ b/reference/hyperliquid-evm-debug-trace-block-by-number.mdx
@@ -41,12 +41,61 @@ The response is an array of trace objects, one per transaction in the block. Wit
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "debug_traceBlockByNumber", "params": ["0x1", {"tracer": "callTracer"}], "id": 1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+traces = w3.manager.request_blocking(
+    "debug_traceBlockByNumber",
+    ["0x1", {"tracer": "callTracer"}],
+)
+
+print(traces)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const traces = await provider.send("debug_traceBlockByNumber", [
+  "0x1",
+  { tracer: "callTracer" },
+]);
+
+console.log(traces);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const traces = await client.request({
+  method: "debug_traceBlockByNumber",
+  params: ["0x1", { tracer: "callTracer" }],
+});
+
+console.log(traces);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-evm-debug-trace-block.mdx
+++ b/reference/hyperliquid-evm-debug-trace-block.mdx
@@ -217,6 +217,8 @@ analyzeBlockExecution(blockHash).then(analysis => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -232,6 +234,61 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"
+
+# debug_traceBlockByHash is not wrapped by web3.py, so call it directly.
+traces = w3.provider.make_request(
+    "debug_traceBlockByHash",
+    [block_hash, {"tracer": "callTracer"}],
+)
+print(traces["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// debug_traceBlockByHash has no dedicated helper, so use the raw send method.
+const traces = await provider.send("debug_traceBlockByHash", [
+  blockHash,
+  { tracer: "callTracer" },
+]);
+console.log(traces);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// debug_traceBlockByHash is not a first-class action, so use the request method.
+const traces = await client.request({
+  method: "debug_traceBlockByHash",
+  params: [blockHash, { tracer: "callTracer" }],
+} as any);
+console.log(traces);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-trace-call.mdx
+++ b/reference/hyperliquid-evm-debug-trace-call.mdx
@@ -185,6 +185,8 @@ simulateContractCall().then(trace => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -209,6 +211,78 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+call_object = {
+    "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+    "to": "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+    "gas": "0x76c0",
+    "gasPrice": "0x9184e72a000",
+    "value": "0xde0b6b3a7640000",
+    "data": "0x",
+}
+
+trace = w3.manager.request_blocking(
+    "debug_traceCall",
+    [call_object, "latest", {"tracer": "callTracer"}],
+)
+print(trace)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const callObject = {
+  from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+  gas: "0x76c0",
+  gasPrice: "0x9184e72a000",
+  value: "0xde0b6b3a7640000",
+  data: "0x",
+};
+
+const trace = await provider.send("debug_traceCall", [
+  callObject,
+  "latest",
+  { tracer: "callTracer" },
+]);
+console.log(trace);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const callObject = {
+  from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+  gas: "0x76c0",
+  gasPrice: "0x9184e72a000",
+  value: "0xde0b6b3a7640000",
+  data: "0x",
+};
+
+const trace = await client.request({
+  method: "debug_traceCall",
+  params: [callObject, "latest", { tracer: "callTracer" }],
+});
+console.log(trace);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-debug-trace-transaction.mdx
+++ b/reference/hyperliquid-evm-debug-trace-transaction.mdx
@@ -133,6 +133,8 @@ analyzeTransaction(txHash).then(trace => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -149,6 +151,68 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31"
+
+# debug_traceTransaction is not a standard eth_* method, so call it via the provider
+trace = w3.provider.make_request(
+    "debug_traceTransaction",
+    [tx_hash, {"tracer": "callTracer"}],
+)
+
+print(trace["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// debug_traceTransaction is not exposed as a typed method, so use send()
+const trace = await provider.send("debug_traceTransaction", [
+  txHash,
+  { tracer: "callTracer" },
+]);
+
+console.log(trace);
+```
+
+```typescript viem
+import { createPublicClient, http, type Hash } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash: Hash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// debug_traceTransaction is not a standard action, so type the request with a custom RPC schema
+const trace = await client.request<{
+  Method: "debug_traceTransaction";
+  Parameters: [Hash, { tracer: string }];
+  ReturnType: unknown;
+}>({
+  method: "debug_traceTransaction",
+  params: [txHash, { tracer: "callTracer" }],
+});
+
+console.log(trace);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-erigon-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-erigon-get-header-by-number.mdx
@@ -52,6 +52,10 @@ The method returns a block header object with the following fields:
 
 ## Usage example
 
+`erigon_getHeaderByNumber` is a non-standard JSON-RPC method, so the EVM client libraries below call it through their raw request interface rather than a named helper.
+
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -62,6 +66,44 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+response = w3.provider.make_request("erigon_getHeaderByNumber", [1000])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const header = await provider.send("erigon_getHeaderByNumber", [1000]);
+console.log(header);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const header = await client.request({
+  method: "erigon_getHeaderByNumber",
+  params: [1000],
+} as any);
+console.log(header);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-eth-big-block-gas-price.mdx
+++ b/reference/hyperliquid-evm-eth-big-block-gas-price.mdx
@@ -120,12 +120,54 @@ const compareGasPrices = async () => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_bigBlockGasPrice","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_bigBlockGasPrice is a Hyperliquid-specific method, so call it directly.
+big_block_gas_price = w3.manager.request_blocking("eth_bigBlockGasPrice", [])
+print(big_block_gas_price)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_bigBlockGasPrice is a Hyperliquid-specific method, so send it directly.
+const bigBlockGasPrice = await provider.send("eth_bigBlockGasPrice", []);
+console.log(bigBlockGasPrice);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// eth_bigBlockGasPrice is a Hyperliquid-specific method, so request it directly.
+const bigBlockGasPrice = await client.request({
+  method: "eth_bigBlockGasPrice",
+});
+console.log(bigBlockGasPrice);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-blob-base-fee.mdx
+++ b/reference/hyperliquid-evm-eth-blob-base-fee.mdx
@@ -138,12 +138,49 @@ monitorBlobFees((feeData) => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blobBaseFee","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+blob_base_fee = w3.eth.get_blob_base_fee()
+print(blob_base_fee)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blobBaseFee = await provider.send("eth_blobBaseFee", []);
+console.log(blobBaseFee);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blobBaseFee = await client.getBlobBaseFee();
+console.log(blobBaseFee);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-block-number.mdx
@@ -104,12 +104,49 @@ pollForNewBlocks((blockNumber) => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_number = w3.eth.block_number
+print(block_number)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockNumber = await provider.getBlockNumber();
+console.log(blockNumber);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockNumber = await client.getBlockNumber();
+console.log(blockNumber);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-call-many.mdx
+++ b/reference/hyperliquid-evm-eth-call-many.mdx
@@ -55,6 +55,8 @@ The method returns an array of results corresponding to each call.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -83,6 +85,95 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_callMany is a non-standard method, so call it through the raw JSON-RPC interface.
+call_context = [
+    {
+        "transactions": [
+            {
+                "to": "0x5555555555555555555555555555555555555555",
+                "data": "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+            },
+            {
+                "to": "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+                "data": "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+            },
+        ]
+    }
+]
+block_state = {"blockNumber": "latest"}
+
+result = w3.provider.make_request("eth_callMany", [call_context, block_state])
+print(result["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_callMany is a non-standard method, so use the generic send() interface.
+const callContext = [
+  {
+    transactions: [
+      {
+        to: "0x5555555555555555555555555555555555555555",
+        data: "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+      },
+      {
+        to: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+        data: "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+      },
+    ],
+  },
+];
+const blockState = { blockNumber: "latest" };
+
+const result = await provider.send("eth_callMany", [callContext, blockState]);
+console.log(result);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// eth_callMany is a non-standard method, so use the low-level request() interface.
+const callContext = [
+  {
+    transactions: [
+      {
+        to: "0x5555555555555555555555555555555555555555",
+        data: "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+      },
+      {
+        to: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb",
+        data: "0x70a082310000000000000000000000008D25Fb438C6efCD08679ffA82766869B50E24608",
+      },
+    ],
+  },
+];
+const blockState = { blockNumber: "latest" };
+
+const result = await client.request({
+  method: "eth_callMany" as any,
+  params: [callContext, blockState] as any,
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+  **Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-call.mdx
+++ b/reference/hyperliquid-evm-eth-call.mdx
@@ -124,12 +124,61 @@ The method returns the result of the contract call as a hexadecimal string.
 
 This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0x5555555555555555555555555555555555555555","data":"0x18160ddd"},"latest"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+result = w3.eth.call({
+    "to": "0x5555555555555555555555555555555555555555",
+    "data": "0x18160ddd",
+}, "latest")
+
+print(result.hex())
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const result = await provider.call({
+  to: "0x5555555555555555555555555555555555555555",
+  data: "0x18160ddd",
+});
+
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const result = await client.call({
+  to: "0x5555555555555555555555555555555555555555",
+  data: "0x18160ddd",
+});
+
+console.log(result.data);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-chain-id.mdx
+++ b/reference/hyperliquid-evm-eth-chain-id.mdx
@@ -109,12 +109,49 @@ verifyNetwork()
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+chain_id = w3.eth.chain_id
+print(chain_id)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const network = await provider.getNetwork();
+console.log(network.chainId);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const chainId = await client.getChainId();
+console.log(chainId);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-create-access-list.mdx
+++ b/reference/hyperliquid-evm-eth-create-access-list.mdx
@@ -71,6 +71,8 @@ The method returns an access list and estimated gas for the transaction.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -91,6 +93,70 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+access_list = w3.eth.create_access_list(
+    {
+        "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+        "to": "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+        "gas": "0x76c0",
+        "gasPrice": "0x9184e72a000",
+        "value": "0xde0b6b3a7640000",
+        "data": "0x",
+    },
+    "latest",
+)
+
+print(access_list)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const accessList = await provider.send("eth_createAccessList", [
+  {
+    from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+    to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+    gas: "0x76c0",
+    gasPrice: "0x9184e72a000",
+    value: "0xde0b6b3a7640000",
+    data: "0x",
+  },
+  "latest",
+]);
+
+console.log(accessList);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const accessList = await client.createAccessList({
+  account: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+  value: 1000000000000000000n,
+  data: "0x",
+  blockTag: "latest",
+});
+
+console.log(accessList);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-estimate-gas.mdx
+++ b/reference/hyperliquid-evm-eth-estimate-gas.mdx
@@ -67,12 +67,64 @@ The method returns the estimated gas amount as a hexadecimal string.
 
 This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA","to":"0x5555555555555555555555555555555555555555","data":"0xa9059cbb000000000000000000000000fefefefefefefefefefefefefefefefefefefefe0000000000000000000000000000000000000000000000000de0b6b3a7640000"}],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+gas = w3.eth.estimate_gas({
+    "from": "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+    "to": "0x5555555555555555555555555555555555555555",
+    "data": "0xa9059cbb000000000000000000000000fefefefefefefefefefefefefefefefefefefefe0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+})
+
+print(gas)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const gas = await provider.estimateGas({
+  from: "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+  to: "0x5555555555555555555555555555555555555555",
+  data: "0xa9059cbb000000000000000000000000fefefefefefefefefefefefefefefefefefefefe0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+});
+
+console.log(gas);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const gas = await client.estimateGas({
+  account: "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+  to: "0x5555555555555555555555555555555555555555",
+  data: "0xa9059cbb000000000000000000000000fefefefefefefefefefefefefefefefefefefefe0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+});
+
+console.log(gas);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-fee-history.mdx
+++ b/reference/hyperliquid-evm-eth-fee-history.mdx
@@ -154,12 +154,57 @@ analyzeFeeHistory()
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x4","latest",[25,50,75]],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+fee_history = w3.eth.fee_history(4, "latest", [25, 50, 75])
+print(fee_history)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const feeHistory = await provider.send("eth_feeHistory", [
+  "0x4",
+  "latest",
+  [25, 50, 75],
+]);
+console.log(feeHistory);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const feeHistory = await client.getFeeHistory({
+  blockCount: 4,
+  rewardPercentiles: [25, 50, 75],
+  blockTag: "latest",
+});
+console.log(feeHistory);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-gas-price.mdx
+++ b/reference/hyperliquid-evm-eth-gas-price.mdx
@@ -151,12 +151,49 @@ getGasPrice()
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+gas_price = w3.eth.gas_price
+print(gas_price)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const { gasPrice } = await provider.getFeeData();
+console.log(gasPrice);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const gasPrice = await client.getGasPrice();
+console.log(gasPrice);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-balance.mdx
+++ b/reference/hyperliquid-evm-eth-get-balance.mdx
@@ -74,12 +74,52 @@ The method returns the account balance in wei as a hexadecimal string.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA","latest"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+balance = w3.eth.get_balance("0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA", "latest")
+print(balance)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const balance = await provider.getBalance("0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA", "latest");
+console.log(balance);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const balance = await client.getBalance({
+  address: "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+  blockTag: "latest",
+});
+console.log(balance);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-block-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-by-hash.mdx
@@ -92,12 +92,56 @@ The method returns detailed information about the specified block, or `null` if 
 
 ## Example request
 
+<CodeGroup>
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a",false],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block = w3.eth.get_block(
+    "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a",
+    full_transactions=False,
+)
+print(block)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const block = await provider.getBlock(
+  "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a"
+);
+console.log(block);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const block = await client.getBlock({
+  blockHash:
+    "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a",
+  includeTransactions: false,
+});
+console.log(block);
+```
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-block-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-by-number.mdx
@@ -93,12 +93,52 @@ The method returns detailed information about the specified block, or `null` if 
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x9d0c37",false],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block = w3.eth.get_block(10291255, full_transactions=False)
+print(block)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const block = await provider.getBlock(10291255, false);
+console.log(block);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const block = await client.getBlock({
+  blockNumber: 10291255n,
+  includeTransactions: false,
+});
+console.log(block);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-block-receipts.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-receipts.mdx
@@ -194,12 +194,66 @@ extractBlockEvents('0x9d0c37')
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":["0x9d0c37"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# Get all transaction receipts for a block
+receipts = w3.eth.get_block_receipts(0x9d0c37)
+
+print(f"Receipts in block: {len(receipts)}")
+for receipt in receipts:
+    print(receipt["transactionHash"].hex(), receipt["status"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_getBlockReceipts is not a typed provider method in ethers v6,
+// so call it directly with send().
+const receipts = await provider.send("eth_getBlockReceipts", ["0x9d0c37"]);
+
+console.log(`Receipts in block: ${receipts.length}`);
+for (const receipt of receipts) {
+  console.log(receipt.transactionHash, receipt.status);
+}
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// Get all transaction receipts for a block
+const receipts = await client.getBlockReceipts({
+  blockNumber: 0x9d0c37n,
+});
+
+console.log(`Receipts in block: ${receipts.length}`);
+for (const receipt of receipts) {
+  console.log(receipt.transactionHash, receipt.status);
+}
+```
+
+</CodeGroup>
+
+<Note>
+  **Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-block-transaction-count-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-transaction-count-by-hash.mdx
@@ -165,12 +165,62 @@ analyzeBlockActivity(blockHashes)
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByHash","params":["0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a"
+
+# Passing a block hash routes to eth_getBlockTransactionCountByHash
+count = w3.eth.get_block_transaction_count(block_hash)
+print(count)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a";
+
+// ethers v6 has no dedicated helper, so call the method directly
+const count = await provider.send("eth_getBlockTransactionCountByHash", [
+  blockHash,
+]);
+console.log(parseInt(count, 16));
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a";
+
+// Passing blockHash routes to eth_getBlockTransactionCountByHash
+const count = await client.getBlockTransactionCount({ blockHash });
+console.log(count);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-block-transaction-count-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-block-transaction-count-by-number.mdx
@@ -168,12 +168,52 @@ analyzeBlockRange(100, 110)
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["0x9d0c37"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# Block 0x9d0c37 (10,291,255). Pass an int for by-number, or "latest" for the tip.
+count = w3.eth.get_block_transaction_count(10291255)
+print(count)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ethers v6 has no high-level wrapper for this RPC, so call it directly.
+const count = await provider.send("eth_getBlockTransactionCountByNumber", ["0x9d0c37"]);
+console.log(parseInt(count, 16));
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// blockNumber is a bigint; omit it (or use blockTag: "latest") for the tip.
+const count = await client.getBlockTransactionCount({ blockNumber: 10291255n });
+console.log(count);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-code.mdx
+++ b/reference/hyperliquid-evm-eth-get-code.mdx
@@ -59,12 +59,61 @@ The method returns the contract bytecode as a hexadecimal string, or `"0x"` if n
 
 This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x5555555555555555555555555555555555555555","latest"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+code = w3.eth.get_code(
+    Web3.to_checksum_address("0x5555555555555555555555555555555555555555"),
+    "latest",
+)
+
+print(code.hex())
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const code = await provider.getCode(
+  "0x5555555555555555555555555555555555555555",
+  "latest"
+);
+
+console.log(code);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const code = await client.getBytecode({
+  address: "0x5555555555555555555555555555555555555555",
+  blockTag: "latest",
+});
+
+console.log(code);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-filter-changes.mdx
+++ b/reference/hyperliquid-evm-eth-get-filter-changes.mdx
@@ -252,6 +252,8 @@ createEventDashboard().then(dashboard => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -265,6 +267,44 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+changes = w3.eth.get_filter_changes("0x1")
+print(changes)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const changes = await provider.send("eth_getFilterChanges", ["0x1"]);
+console.log(changes);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const changes = await client.request({
+  method: "eth_getFilterChanges",
+  params: ["0x1"],
+});
+console.log(changes);
+```
+
+</CodeGroup>
+
+<Note>
+  **Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-filter-logs.mdx
+++ b/reference/hyperliquid-evm-eth-get-filter-logs.mdx
@@ -273,6 +273,8 @@ compareFilterStates(filterId).then(comparison => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -286,6 +288,44 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+logs = w3.eth.get_filter_logs("0x1")
+print(logs)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const logs = await provider.send("eth_getFilterLogs", ["0x1"]);
+console.log(logs);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const logs = await client.request({
+  method: "eth_getFilterLogs",
+  params: ["0x1"],
+});
+console.log(logs);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-header-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-header-by-hash.mdx
@@ -178,6 +178,8 @@ getBlockAncestry(blockHash, 3).then(ancestry => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -191,6 +193,55 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"
+
+# eth_getHeaderByHash has no high-level wrapper, so call it via the provider
+header = w3.provider.make_request("eth_getHeaderByHash", [block_hash])
+print(header["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// eth_getHeaderByHash has no high-level wrapper, so send the raw JSON-RPC call
+const header = await provider.send("eth_getHeaderByHash", [blockHash]);
+console.log(header);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// eth_getHeaderByHash has no high-level action, so use the EIP-1193 request method
+const header = await client.request({
+  method: "eth_getHeaderByHash" as any,
+  params: [blockHash] as any,
+});
+console.log(header);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-header-by-number.mdx
@@ -148,6 +148,8 @@ monitorBlockHeaders((header) => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -161,6 +163,60 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_getHeaderByNumber is not a standard web3.py method, so call it directly.
+response = w3.provider.make_request("eth_getHeaderByNumber", ["latest"])
+header = response["result"]
+
+print(header)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_getHeaderByNumber is not a standard ethers method, so send the raw request.
+const header = await provider.send("eth_getHeaderByNumber", ["latest"]);
+
+console.log(header);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http, rpcSchema } from "viem";
+
+// eth_getHeaderByNumber is not a standard JSON-RPC method, so declare its schema.
+type CustomRpcSchema = [
+  {
+    Method: "eth_getHeaderByNumber";
+    Parameters: [blockNumber: string];
+    ReturnType: object | null;
+  },
+];
+
+const client = createPublicClient({
+  rpcSchema: rpcSchema<CustomRpcSchema>(),
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const header = await client.request({
+  method: "eth_getHeaderByNumber",
+  params: ["latest"],
+});
+
+console.log(header);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-logs.mdx
+++ b/reference/hyperliquid-evm-eth-get-logs.mdx
@@ -195,12 +195,64 @@ The method returns an array of log objects matching the filter criteria.
 
 This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x5555555555555555555555555555555555555555","fromBlock":"0x9d0c37","toBlock":"0x9d0c42"}],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+logs = w3.eth.get_logs({
+    "address": "0x5555555555555555555555555555555555555555",
+    "fromBlock": "0x9d0c37",
+    "toBlock": "0x9d0c42",
+})
+
+print(logs)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const logs = await provider.getLogs({
+  address: "0x5555555555555555555555555555555555555555",
+  fromBlock: "0x9d0c37",
+  toBlock: "0x9d0c42",
+});
+
+console.log(logs);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const logs = await client.getLogs({
+  address: "0x5555555555555555555555555555555555555555",
+  fromBlock: 10292279n,
+  toBlock: 10292290n,
+});
+
+console.log(logs);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR\_CHAINSTACK\_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-proof.mdx
+++ b/reference/hyperliquid-evm-eth-get-proof.mdx
@@ -88,6 +88,8 @@ The method returns the account proof and storage proofs if requested.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -102,6 +104,53 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+proof = w3.eth.get_proof(
+    "0x69835D480110e4919B7899f465aAB101e21c8A87",
+    [],
+    "latest",
+)
+print(proof)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const proof = await provider.send("eth_getProof", [
+  "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  [],
+  "latest",
+]);
+console.log(proof);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const proof = await client.getProof({
+  address: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  storageKeys: [],
+  blockTag: "latest",
+});
+console.log(proof);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-hash-and-index.mdx
@@ -35,6 +35,82 @@ The raw transaction data is RLP-encoded and includes all transaction fields in t
 Transaction indices start from 0x0. Use hex format for the index parameter (e.g., "0x0" for the first transaction, "0x1" for the second).
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "eth_getRawTransactionByBlockHashAndIndex",
+    "params": [
+      "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e",
+      "0x0"
+    ],
+    "id": 1
+  }' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"
+tx_index = "0x0"
+
+# eth_getRawTransactionByBlockHashAndIndex has no typed wrapper, so call it directly
+response = w3.provider.make_request(
+    "eth_getRawTransactionByBlockHashAndIndex", [block_hash, tx_index]
+)
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+const txIndex = "0x0";
+
+// eth_getRawTransactionByBlockHashAndIndex has no typed wrapper, so use the generic send
+const rawTx = await provider.send("eth_getRawTransactionByBlockHashAndIndex", [
+  blockHash,
+  txIndex,
+]);
+console.log(rawTx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+const txIndex = "0x0";
+
+// eth_getRawTransactionByBlockHashAndIndex has no typed action, so use the raw request method
+const rawTx = await client.request({
+  method: "eth_getRawTransactionByBlockHashAndIndex",
+  params: [blockHash, txIndex],
+});
+console.log(rawTx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Block analysis** — Extract raw transactions from specific blocks

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-block-number-and-index.mdx
@@ -43,3 +43,63 @@ Transaction indices start from 0x0. Use hex format for the index parameter. Bloc
 * **Data pipeline integration** — Feed raw transaction data to processing systems
 * **Backup and recovery** — Create transaction backups in original format
 * **Performance testing** — Replay transactions for load testing
+
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x9d0c37","0x0"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# This RPC returns RLP-encoded bytes with no high-level wrapper, so call it directly.
+# Block 0x9d0c37 (10,291,255), transaction index 0x0; use "latest" for the tip.
+raw_tx = w3.manager.request_blocking(
+    "eth_getRawTransactionByBlockNumberAndIndex", ["0x9d0c37", "0x0"]
+)
+print(raw_tx)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ethers v6 has no high-level wrapper for this RPC, so call it directly.
+// Block 0x9d0c37 (10,291,255), transaction index 0x0; use "latest" for the tip.
+const rawTx = await provider.send(
+  "eth_getRawTransactionByBlockNumberAndIndex",
+  ["0x9d0c37", "0x0"]
+);
+console.log(rawTx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// viem has no high-level action for this RPC, so issue a raw request.
+// Block 0x9d0c37 (10,291,255), transaction index 0x0; use "latest" for the tip.
+const rawTx = await client.request({
+  method: "eth_getRawTransactionByBlockNumberAndIndex",
+  params: ["0x9d0c37", "0x0"],
+});
+console.log(rawTx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>

--- a/reference/hyperliquid-evm-eth-get-raw-transaction-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-raw-transaction-by-hash.mdx
@@ -34,6 +34,63 @@ The raw transaction data is RLP-encoded and includes all transaction fields in t
 Raw transaction data can be decoded using RLP decoding libraries to extract individual transaction fields like nonce, gas price, gas limit, recipient, value, and signature components.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getRawTransactionByHash","params":["0x66112ff0438f84686c8003f3a855057694c9018f07905c0e15f2f20f4dd0791a"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_getRawTransactionByHash has no high-level helper, so call it directly
+response = w3.provider.make_request(
+    "eth_getRawTransactionByHash",
+    ["0x66112ff0438f84686c8003f3a855057694c9018f07905c0e15f2f20f4dd0791a"],
+)
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_getRawTransactionByHash has no high-level helper, so use send()
+const rawTx = await provider.send("eth_getRawTransactionByHash", [
+  "0x66112ff0438f84686c8003f3a855057694c9018f07905c0e15f2f20f4dd0791a",
+]);
+console.log(rawTx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// eth_getRawTransactionByHash has no high-level action, so use request()
+const rawTx = await client.request({
+  method: "eth_getRawTransactionByHash",
+  params: ["0x66112ff0438f84686c8003f3a855057694c9018f07905c0e15f2f20f4dd0791a"],
+});
+console.log(rawTx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Transaction broadcasting** — Re-broadcast transactions to other networks

--- a/reference/hyperliquid-evm-eth-get-storage-at.mdx
+++ b/reference/hyperliquid-evm-eth-get-storage-at.mdx
@@ -241,12 +241,65 @@ getStorageAt(contractAddress, '0x0')
 
 This an example call with wrapped HYPE (wHYPE) on the Hyperliquid mainnet deployed at [0x5555555555555555555555555555555555555555](https://hyperevmscan.io/token/0x5555555555555555555555555555555555555555).
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getStorageAt","params":["0x5555555555555555555555555555555555555555","0x0","latest"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+value = w3.eth.get_storage_at(
+    "0x5555555555555555555555555555555555555555",
+    0,
+    "latest",  # Only "latest" is supported on Hyperliquid
+)
+
+print(value.hex())
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// Only "latest" is supported on Hyperliquid
+const value = await provider.getStorage(
+  "0x5555555555555555555555555555555555555555",
+  "0x0",
+  "latest",
+);
+
+console.log(value);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const value = await client.getStorageAt({
+  address: "0x5555555555555555555555555555555555555555",
+  slot: "0x0",
+  blockTag: "latest", // Only "latest" is supported on Hyperliquid
+});
+
+console.log(value);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-hash.mdx
@@ -214,12 +214,65 @@ analyzeSystemTransactions(blockHash)
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getSystemTxsByBlockHash","params":["0x1970d9c7ce6f00a982b421610ad400a79522c102a26db24ef3ec1f2bd621c399"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x1970d9c7ce6f00a982b421610ad400a79522c102a26db24ef3ec1f2bd621c399"
+
+# eth_getSystemTxsByBlockHash is a HyperEVM extension, so call it via the raw request manager
+system_txs = w3.manager.request_blocking("eth_getSystemTxsByBlockHash", [block_hash])
+print(system_txs)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x1970d9c7ce6f00a982b421610ad400a79522c102a26db24ef3ec1f2bd621c399";
+
+// eth_getSystemTxsByBlockHash is a HyperEVM extension, so send the raw JSON-RPC call
+const systemTxs = await provider.send("eth_getSystemTxsByBlockHash", [
+  blockHash,
+]);
+console.log(systemTxs);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x1970d9c7ce6f00a982b421610ad400a79522c102a26db24ef3ec1f2bd621c399";
+
+// eth_getSystemTxsByBlockHash is a HyperEVM extension, so issue the raw JSON-RPC request
+const systemTxs = await client.request({
+  method: "eth_getSystemTxsByBlockHash" as any,
+  params: [blockHash],
+});
+console.log(systemTxs);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-system-txs-by-block-number.mdx
@@ -209,12 +209,58 @@ monitorSystemTxsRange(10291248, 10291258)
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getSystemTxsByBlockNumber","params":["0x9d16cf"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_getSystemTxsByBlockNumber is a HyperEVM-specific method, so call it
+# directly through the request manager rather than a typed helper.
+system_txs = w3.manager.request_blocking("eth_getSystemTxsByBlockNumber", ["0x9d16cf"])
+print(system_txs)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_getSystemTxsByBlockNumber is a HyperEVM-specific method, so use the
+// generic send() to issue the raw JSON-RPC request.
+const systemTxs = await provider.send("eth_getSystemTxsByBlockNumber", ["0x9d16cf"]);
+console.log(systemTxs);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// eth_getSystemTxsByBlockNumber is a HyperEVM-specific method, so use the
+// low-level request() to issue the raw JSON-RPC request.
+const systemTxs = await client.request({
+  method: "eth_getSystemTxsByBlockNumber",
+  params: ["0x9d16cf"],
+});
+console.log(systemTxs);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-transaction-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-block-hash-and-index.mdx
@@ -90,12 +90,62 @@ The method returns detailed transaction information, or `null` if the transactio
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0","method": "eth_getTransactionByBlockHashAndIndex","params": ["0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a","0x0"],"id": 1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a"
+tx = w3.eth.get_transaction_by_block(block_hash, 0)
+
+print(tx)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a";
+const tx = await provider.getTransaction(
+  // ethers resolves the transaction hash from the block hash and index
+  (await provider.getBlock(blockHash)).transactions[0]
+);
+
+console.log(tx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const tx = await client.getTransaction({
+  blockHash:
+    "0x53e84f299e6893680383c6a53329574122a7292e5bb9397bb6a0b51b4db5957a",
+  index: 0,
+});
+
+console.log(tx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-transaction-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-block-number-and-index.mdx
@@ -156,12 +156,58 @@ The method returns detailed transaction information, or `null` if the transactio
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberAndIndex","params":["0x9d0c37","0x0"],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# Block 10,291,255 (0x9d0c37), transaction at index 0
+tx = w3.eth.get_transaction_by_block(10_291_255, 0)
+print(tx)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// Block 0x9d0c37, transaction at index 0x0
+const tx = await provider.send("eth_getTransactionByBlockNumberAndIndex", [
+  "0x9d0c37",
+  "0x0",
+]);
+console.log(tx);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// Block 10,291,255 (0x9d0c37), transaction at index 0
+const tx = await client.getTransaction({
+  blockNumber: 10_291_255n,
+  index: 0,
+});
+console.log(tx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-transaction-by-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-hash.mdx
@@ -47,6 +47,54 @@ Returns a transaction object, or `null` if the transaction is not found.
 On Hyperliquid, priority fees are always zero. EIP-1559 transactions use only the base fee.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx = w3.eth.get_transaction("0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0")
+print(tx)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const tx = await provider.getTransaction("0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0");
+console.log(tx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const tx = await client.getTransaction({
+  hash: "0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0",
+});
+console.log(tx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Transaction verification** — Confirm transaction details and status

--- a/reference/hyperliquid-evm-eth-get-transaction-by-sender-and-nonce.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-by-sender-and-nonce.mdx
@@ -142,6 +142,8 @@ getTransactionBySenderAndNonce(sender, nonce).then(tx => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -156,6 +158,61 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_getTransactionBySenderAndNonce is a Hyperliquid-specific method with no
+# dedicated web3.py call, so send it through the raw provider request.
+response = w3.provider.make_request(
+    "eth_getTransactionBySenderAndNonce",
+    ["0x69835D480110e4919B7899f465aAB101e21c8A87", "0x0"],
+)
+
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// send() is the escape hatch for methods without a high-level provider API.
+const tx = await provider.send("eth_getTransactionBySenderAndNonce", [
+  "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  "0x0",
+]);
+
+console.log(tx);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// Type the custom method through request(), since it is not in viem's schema.
+const tx = await client.request<{
+  method: "eth_getTransactionBySenderAndNonce";
+  Parameters: [string, string];
+  ReturnType: unknown;
+}>({
+  method: "eth_getTransactionBySenderAndNonce",
+  params: ["0x69835D480110e4919B7899f465aAB101e21c8A87", "0x0"],
+});
+
+console.log(tx);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-transaction-count.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-count.mdx
@@ -33,6 +33,55 @@ Returns the transaction count (nonce) as a hexadecimal string.
 On Hyperliquid, only the `"latest"` block parameter is supported for this method. The `"pending"` state is not supported on the default RPC.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA","latest"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+nonce = w3.eth.get_transaction_count("0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA", "latest")
+print(nonce)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const nonce = await provider.getTransactionCount("0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA", "latest");
+console.log(nonce);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const nonce = await client.getTransactionCount({
+  address: "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+  blockTag: "latest",
+});
+console.log(nonce);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Transaction creation** — Get the correct nonce for new transactions

--- a/reference/hyperliquid-evm-eth-get-transaction-receipt.mdx
+++ b/reference/hyperliquid-evm-eth-get-transaction-receipt.mdx
@@ -52,6 +52,57 @@ Returns a transaction receipt object, or `null` if the transaction is not found 
 Transaction receipts are only available for mined transactions. Pending transactions return `null`.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell cURL
+curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0"],"id":1}'
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+receipt = w3.eth.get_transaction_receipt(
+    "0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0"
+)
+print(receipt)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const receipt = await provider.getTransactionReceipt(
+  "0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0"
+);
+console.log(receipt);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const receipt = await client.getTransactionReceipt({
+  hash: "0x33c3321b162edac1fdbb53af2962b2940c07e334a4f5ff758f1d5ef1235e55d0",
+});
+console.log(receipt);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Transaction verification** — Confirm transaction execution and success status

--- a/reference/hyperliquid-evm-eth-get-uncle-by-block-hash-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-by-block-hash-and-index.mdx
@@ -106,6 +106,8 @@ checkBlockUncles(blockHash).then(uncles => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -120,6 +122,55 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"
+uncle = w3.eth.get_uncle_by_block(block_hash, 0)
+
+print(uncle)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+const uncle = await provider.send("eth_getUncleByBlockHashAndIndex", [
+  blockHash,
+  "0x0",
+]);
+
+console.log(uncle);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+const uncle = await client.request({
+  method: "eth_getUncleByBlockHashAndIndex",
+  params: [blockHash, "0x0"],
+});
+
+console.log(uncle);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-uncle-by-block-number-and-index.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-by-block-number-and-index.mdx
@@ -132,6 +132,8 @@ checkBlockUncles('0x100').then(result => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -146,6 +148,47 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+uncle = w3.eth.get_uncle_by_block("latest", 0)
+print(uncle)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const uncle = await provider.send("eth_getUncleByBlockNumberAndIndex", [
+  "latest",
+  "0x0",
+]);
+console.log(uncle);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const uncle = await client.request({
+  method: "eth_getUncleByBlockNumberAndIndex",
+  params: ["latest", "0x0"],
+});
+console.log(uncle);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-get-uncle-count-by-block-hash.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-count-by-block-hash.mdx
@@ -32,6 +32,66 @@ Returns the number of uncle blocks as a hex-encoded integer, or `null` if the bl
 On Hyperliquid, uncle blocks are not part of the consensus mechanism. This method is included for Ethereum compatibility but will typically return "0x0" as Hyperliquid doesn't produce uncle blocks.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockHash","params":["0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e"
+
+# Passing a block hash routes to eth_getUncleCountByBlockHash
+count = w3.eth.get_uncle_count(block_hash)
+print(count)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// ethers v6 has no dedicated helper, so call the method directly
+const count = await provider.send("eth_getUncleCountByBlockHash", [blockHash]);
+console.log(parseInt(count, 16));
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0x2ce91ae0ed242b4b78b432a45b982fb81a414d6b04167762ed3c7446710a4b8e";
+
+// viem v2 has no dedicated action, so call the method directly
+const count = await client.request({
+  method: "eth_getUncleCountByBlockHash",
+  params: [blockHash],
+});
+console.log(parseInt(count, 16));
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Ethereum compatibility** — Maintain compatibility with Ethereum RPC interfaces

--- a/reference/hyperliquid-evm-eth-get-uncle-count-by-block-number.mdx
+++ b/reference/hyperliquid-evm-eth-get-uncle-count-by-block-number.mdx
@@ -32,6 +32,55 @@ Returns the number of uncle blocks as a hex-encoded integer, or `null` if the bl
 On Hyperliquid, uncle blocks are not part of the consensus mechanism. This method is included for Ethereum compatibility but will typically return "0x0" as Hyperliquid doesn't produce uncle blocks.
 </Note>
 
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getUncleCountByBlockNumber","params":["latest"],"id":1}' \
+  https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+uncle_count = w3.eth.get_uncle_count("latest")
+print(uncle_count)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const uncleCount = await provider.send("eth_getUncleCountByBlockNumber", ["latest"]);
+console.log(uncleCount);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const uncleCount = await client.request({
+  method: "eth_getUncleCountByBlockNumber",
+  params: ["latest"],
+});
+console.log(uncleCount);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 * **Ethereum compatibility** — Maintain compatibility with Ethereum RPC interfaces

--- a/reference/hyperliquid-evm-eth-max-priority-fee-per-gas.mdx
+++ b/reference/hyperliquid-evm-eth-max-priority-fee-per-gas.mdx
@@ -32,14 +32,51 @@ Returns the maximum priority fee per gas as a hexadecimal string. On Hyperliquid
 On Hyperliquid, priority fees are always zero. The network uses only base fees for transaction pricing, so setting a priority fee will not affect transaction inclusion speed or priority.
 </Warning>
 
-## cURL example
+## Example request
 
-```bash
+<CodeGroup>
+
+```bash Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+max_priority_fee = w3.eth.max_priority_fee
+print(max_priority_fee)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const maxPriorityFee = await provider.send("eth_maxPriorityFeePerGas", []);
+console.log(maxPriorityFee);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const maxPriorityFee = await client.estimateMaxPriorityFeePerGas();
+console.log(maxPriorityFee);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 Example response:
 

--- a/reference/hyperliquid-evm-eth-new-block-filter.mdx
+++ b/reference/hyperliquid-evm-eth-new-block-filter.mdx
@@ -197,6 +197,8 @@ trackBlockStatistics().then(({ stats, monitor }) => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -208,6 +210,44 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# Create a filter that notifies on every new block.
+block_filter = w3.eth.filter("latest")
+print(block_filter.filter_id)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_newBlockFilter has no high-level wrapper, so send the raw call.
+const filterId = await provider.send("eth_newBlockFilter", []);
+console.log(filterId);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// createBlockFilter maps to eth_newBlockFilter.
+const filter = await client.createBlockFilter();
+console.log(filter.id);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-new-filter.mdx
+++ b/reference/hyperliquid-evm-eth-new-filter.mdx
@@ -174,6 +174,8 @@ monitorMultipleContracts(addresses).then(filterId => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -192,6 +194,64 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# Create a filter for logs from a contract over the latest block
+log_filter = w3.eth.filter({
+    "fromBlock": "latest",
+    "toBlock": "latest",
+    "address": "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+    "topics": [],
+})
+
+# filter_id holds the eth_newFilter result
+print(log_filter.filter_id)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_newFilter has no high-level helper, so call it directly
+const filterId = await provider.send("eth_newFilter", [
+  {
+    fromBlock: "latest",
+    toBlock: "latest",
+    address: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+    topics: [],
+  },
+]);
+
+console.log(filterId);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// createEventFilter maps to eth_newFilter and returns a filter whose id is the result
+const filter = await client.createEventFilter({
+  address: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+  fromBlock: "latest",
+  toBlock: "latest",
+});
+
+console.log(filter.id);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-protocol-version.mdx
+++ b/reference/hyperliquid-evm-eth-protocol-version.mdx
@@ -105,12 +105,49 @@ checkCompatibility(65).then(isCompatible => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_protocolVersion","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+protocol_version = w3.eth.protocol_version
+print(protocol_version)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const protocolVersion = await provider.send("eth_protocolVersion", []);
+console.log(protocolVersion);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const protocolVersion = await client.request({ method: "eth_protocolVersion" });
+console.log(protocolVersion);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-send-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-eth-send-raw-transaction.mdx
@@ -73,6 +73,8 @@ The method returns the transaction hash if the transaction was successfully subm
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -85,6 +87,51 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+signed_transaction_data = "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89"
+
+tx_hash = w3.eth.send_raw_transaction(signed_transaction_data)
+print(tx_hash.hex())
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const signedTransactionData =
+  "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89";
+
+const txResponse = await provider.broadcastTransaction(signedTransactionData);
+console.log(txResponse.hash);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const signedTransactionData =
+  "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89";
+
+const txHash = await client.sendRawTransaction({
+  serializedTransaction: signedTransactionData,
+});
+console.log(txHash);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-simulate-v1.mdx
+++ b/reference/hyperliquid-evm-eth-simulate-v1.mdx
@@ -104,6 +104,8 @@ simulateTransaction().then(result => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -137,6 +139,105 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_simulateV1 has no high-level web3.py wrapper, so send it as a raw JSON-RPC request.
+params = [
+    {
+        "blockStateCalls": [
+            {
+                "calls": [
+                    {
+                        "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+                        "to": "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+                        "gas": "0x5208",
+                        "gasPrice": "0x9184e72a000",
+                        "value": "0xde0b6b3a7640000",
+                        "data": "0x",
+                    }
+                ],
+                "blockOverride": {"number": "latest"},
+            }
+        ],
+        "traceTransfers": False,
+        "validation": True,
+    }
+]
+
+response = w3.provider.make_request("eth_simulateV1", params)
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_simulateV1 has no dedicated ethers method, so send it via provider.send.
+const result = await provider.send("eth_simulateV1", [
+  {
+    blockStateCalls: [
+      {
+        calls: [
+          {
+            from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+            to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+            gas: "0x5208",
+            gasPrice: "0x9184e72a000",
+            value: "0xde0b6b3a7640000",
+            data: "0x",
+          },
+        ],
+        blockOverride: { number: "latest" },
+      },
+    ],
+    traceTransfers: false,
+    validation: true,
+  },
+]);
+
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// viem wraps eth_simulateV1 with the simulateBlocks action.
+const result = await client.simulateBlocks({
+  blocks: [
+    {
+      calls: [
+        {
+          from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+          to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+          gas: 21000n,
+          gasPrice: 10000000000000n,
+          value: 1000000000000000000n,
+          data: "0x",
+        },
+      ],
+    },
+  ],
+  traceTransfers: false,
+  validation: true,
+});
+
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-subscribe-logs.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-logs.mdx
@@ -254,6 +254,79 @@ const monitorNFTTransfers = async (nftContract, fromAddress = null, toAddress = 
 };
 ```
 
+## Example request
+
+`eth_subscribe` is a WebSocket-only method, so every example connects over a WebSocket endpoint.
+
+<CodeGroup>
+
+```shell wscat
+$ wscat -c wss://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+# Wait for the connection to be established
+
+Connected (press CTRL+C to quit)
+
+# Subscribe to all logs from a specific contract
+> {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["logs",{"address":"0x5555555555555555555555555555555555555555"}]}
+< {"jsonrpc":"2.0","id":1,"result":"0x1234567890abcdef"}
+
+# Log notifications will stream in as events are emitted:
+< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x1234567890abcdef","result":{"address":"0x5555555555555555555555555555555555555555","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],"data":"0x00000000000000000000000000000000000000000000000000000000000186a0","blockNumber":"0x1234","transactionHash":"0x...","transactionIndex":"0x0","blockHash":"0x...","logIndex":"0x0","removed":false}}}
+```
+
+```python Python (web3.py)
+import asyncio
+from web3 import AsyncWeb3
+from web3.providers.persistent import WebSocketProvider
+
+# eth_subscribe requires a WebSocket connection.
+async def main():
+    async with AsyncWeb3(WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT")) as w3:
+        # subscribe("logs", ...) maps to eth_subscribe("logs", ...).
+        sub_id = await w3.eth.subscribe("logs", {
+            "address": "0x5555555555555555555555555555555555555555",
+        })
+        print(sub_id)
+
+        async for message in w3.socket.process_subscriptions():
+            print(message)
+
+asyncio.run(main())
+```
+
+```javascript JavaScript (ethers.js)
+import { WebSocketProvider } from "ethers";
+
+// eth_subscribe requires a WebSocket connection.
+const provider = new WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// A log filter subscription maps to eth_subscribe("logs", ...).
+const filter = { address: "0x5555555555555555555555555555555555555555" };
+provider.on(filter, (log) => {
+  console.log(log);
+});
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, webSocket } from "viem";
+
+// Over a WebSocket transport, watchEvent uses eth_subscribe("logs", ...).
+const client = createPublicClient({
+  transport: webSocket("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const unwatch = client.watchEvent({
+  address: "0x5555555555555555555555555555555555555555",
+  onLogs: (logs) => console.log(logs),
+});
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 The `eth_subscribe("logs")` method is essential for applications that need to:

--- a/reference/hyperliquid-evm-eth-subscribe-newheads.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-newheads.mdx
@@ -175,6 +175,74 @@ async def subscribe_to_new_blocks():
 asyncio.run(subscribe_to_new_blocks())
 ```
 
+## Example request
+
+`eth_subscribe("newHeads")` runs over a WebSocket connection, so each example below opens a WebSocket to the endpoint and streams new block headers. The Shell tab uses `wscat` for a quick check; the Python, JavaScript, and TypeScript tabs use the WebSocket transport of each library.
+
+<CodeGroup>
+
+```shell wscat
+$ wscat -c wss://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+# Wait for the connection to be established
+
+Connected (press CTRL+C to quit)
+
+> {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"]}
+< {"jsonrpc":"2.0","id":1,"result":"0x1234567890abcdef"}
+
+# New block notifications will stream in:
+< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x1234567890abcdef","result":{"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","gasUsed":"0x5208","hash":"0x...","logsBloom":"0x...","miner":"0x...","nonce":"0x0000000000000000","number":"0x1234","parentHash":"0x...","receiptsRoot":"0x...","sha3Uncles":"0x...","size":"0x220","stateRoot":"0x...","timestamp":"0x65abc123","transactionsRoot":"0x..."}}}
+```
+
+```python web3.py
+import asyncio
+from web3 import AsyncWeb3, WebSocketProvider
+
+
+async def subscribe_to_new_heads():
+    async with AsyncWeb3(WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT")) as w3:
+        subscription_id = await w3.eth.subscribe("newHeads")
+        print(f"Subscribed with ID: {subscription_id}")
+
+        async for message in w3.socket.process_subscriptions():
+            header = message["result"]
+            print(f"New block: {header['number']} {header['hash'].hex()}")
+
+
+asyncio.run(subscribe_to_new_heads())
+```
+
+```javascript ethers.js
+import { WebSocketProvider } from "ethers";
+
+const provider = new WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+provider.on("block", async (blockNumber) => {
+  const header = await provider.getBlock(blockNumber);
+  console.log(`New block: ${header.number} ${header.hash}`);
+});
+```
+
+```typescript viem
+import { createPublicClient, webSocket } from "viem";
+
+const client = createPublicClient({
+  transport: webSocket("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const unwatch = await client.watchBlocks({
+  onBlock: (block) => {
+    console.log(`New block: ${block.number} ${block.hash}`);
+  },
+});
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 The `eth_subscribe("newHeads")` method is essential for applications that need to:

--- a/reference/hyperliquid-evm-eth-syncing.mdx
+++ b/reference/hyperliquid-evm-eth-syncing.mdx
@@ -32,14 +32,51 @@ Returns the synchronization status. On Hyperliquid, this is always `false`, indi
 On Hyperliquid, this method always returns `false`. The network architecture ensures nodes are always synchronized, so there's no syncing state.
 </Note>
 
-## cURL example
+## Example request
 
-```bash
+<CodeGroup>
+
+```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+syncing = w3.eth.syncing
+print(syncing)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const syncing = await provider.send("eth_syncing", []);
+console.log(syncing);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const syncing = await client.request({ method: "eth_syncing" });
+console.log(syncing);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 Example response:
 

--- a/reference/hyperliquid-evm-eth-uninstall-filter.mdx
+++ b/reference/hyperliquid-evm-eth-uninstall-filter.mdx
@@ -320,6 +320,8 @@ batchFilterOperations(filterIdsToCleanup).then(results => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -333,6 +335,44 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+removed = w3.eth.uninstall_filter("0x1")
+print(removed)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const removed = await provider.send("eth_uninstallFilter", ["0x1"]);
+console.log(removed);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const removed = await client.request({
+  method: "eth_uninstallFilter",
+  params: ["0x1"],
+});
+console.log(removed);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-eth-unsubscribe.mdx
+++ b/reference/hyperliquid-evm-eth-unsubscribe.mdx
@@ -458,6 +458,79 @@ await manager.manageSubscription(
 );
 ```
 
+## Example request
+
+`eth_unsubscribe` runs over a WebSocket connection — it cancels a subscription created by `eth_subscribe` and returns `true` on success. The Shell tab uses `wscat` to create a subscription and then cancel it; the Python, JavaScript, and TypeScript tabs use the WebSocket transport of each library and stop the subscription, which sends `eth_unsubscribe` for you.
+
+<CodeGroup>
+
+```shell wscat
+$ wscat -c wss://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+# Wait for the connection to be established
+
+Connected (press CTRL+C to quit)
+
+# First create a subscription
+> {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"]}
+< {"jsonrpc":"2.0","id":1,"result":"0x1234567890abcdef"}
+
+# Now unsubscribe using the subscription ID
+> {"id":2,"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0x1234567890abcdef"]}
+< {"jsonrpc":"2.0","id":2,"result":true}
+```
+
+```python web3.py
+import asyncio
+from web3 import AsyncWeb3, WebSocketProvider
+
+
+async def main():
+    async with AsyncWeb3(WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT")) as w3:
+        subscription_id = await w3.eth.subscribe("newHeads")
+        print(f"Subscribed with ID: {subscription_id}")
+
+        # Cancel the subscription — sends eth_unsubscribe and returns a boolean
+        success = await w3.eth.unsubscribe(subscription_id)
+        print(f"Unsubscribed: {success}")
+
+
+asyncio.run(main())
+```
+
+```javascript ethers.js
+import { WebSocketProvider } from "ethers";
+
+const provider = new WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const onBlock = (blockNumber) => console.log(`New block: ${blockNumber}`);
+provider.on("block", onBlock);
+
+// Removing the listener sends eth_unsubscribe for the underlying subscription
+provider.off("block", onBlock);
+provider.destroy();
+```
+
+```typescript viem
+import { createPublicClient, webSocket } from "viem";
+
+const client = createPublicClient({
+  transport: webSocket("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const unwatch = await client.watchBlocks({
+  onBlock: (block) => console.log(`New block: ${block.number}`),
+});
+
+// Calling unwatch sends eth_unsubscribe for the underlying subscription
+unwatch();
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 The `eth_unsubscribe` method is essential for:

--- a/reference/hyperliquid-evm-eth-using-big-blocks.mdx
+++ b/reference/hyperliquid-evm-eth-using-big-blocks.mdx
@@ -20,6 +20,61 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 </Check>
 </Visibility>
 
+## Example request
+
+`eth_usingBigBlocks` is a Hyperliquid-specific JSON-RPC method, so the EVM libraries call it through their generic raw-request escape hatch rather than a wrapped helper.
+
+<CodeGroup>
+
+```shell cURL
+curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_usingBigBlocks","params":["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA"],"id":1}'
+```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# eth_usingBigBlocks is Hyperliquid-specific, so use the raw provider request
+response = w3.provider.make_request("eth_usingBigBlocks", ["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA"])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// eth_usingBigBlocks is Hyperliquid-specific, so send a raw JSON-RPC request
+const result = await provider.send("eth_usingBigBlocks", [
+  "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
+]);
+console.log(result);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// eth_usingBigBlocks is Hyperliquid-specific, so use the generic request method
+const result = await client.request({
+  method: "eth_usingBigBlocks" as any,
+  params: ["0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA"] as any,
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Parameters
 
 * `address` (string, required) — The 20-byte address to check for big blocks configuration

--- a/reference/hyperliquid-evm-net-listening.mdx
+++ b/reference/hyperliquid-evm-net-listening.mdx
@@ -108,12 +108,52 @@ performHealthCheck().then(health => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"net_listening","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# net_listening is exposed as a property on the net module
+is_listening = w3.net.listening
+print(is_listening)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ethers has no high-level wrapper, so send the raw JSON-RPC method
+const isListening = await provider.send("net_listening", []);
+console.log(isListening);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// viem has no high-level wrapper, so send the raw JSON-RPC method
+const isListening = await client.request({ method: "net_listening" });
+console.log(isListening);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-net-peer-count.mdx
+++ b/reference/hyperliquid-evm-net-peer-count.mdx
@@ -296,6 +296,8 @@ setInterval(() => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -307,6 +309,41 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+peer_count = w3.net.peer_count
+print(peer_count)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const peerCount = await provider.send("net_peerCount", []);
+console.log(peerCount);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const peerCount = await client.request({ method: "net_peerCount" });
+console.log(peerCount);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-net-version.mdx
+++ b/reference/hyperliquid-evm-net-version.mdx
@@ -28,14 +28,51 @@ This method takes no parameters.
 
 Returns the network ID as a string. For Hyperliquid mainnet, this is `"999"`.
 
-## cURL example
+## Example request
 
-```bash
+<CodeGroup>
+
+```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+network_id = w3.net.version
+print(network_id)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const networkId = await provider.send("net_version", []);
+console.log(networkId);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const networkId = await client.request({ method: "net_version" });
+console.log(networkId);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 Example response:
 

--- a/reference/hyperliquid-evm-ots-get-api-level.mdx
+++ b/reference/hyperliquid-evm-ots-get-api-level.mdx
@@ -34,6 +34,8 @@ The method returns an integer representing the API level version.
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -44,6 +46,47 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# ots_getApiLevel is an Otterscan-namespace method, so call it as a raw JSON-RPC request.
+response = w3.provider.make_request("ots_getApiLevel", [])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_getApiLevel is an Otterscan-namespace method, so use the generic send call.
+const apiLevel = await provider.send("ots_getApiLevel", []);
+console.log(apiLevel);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_getApiLevel is an Otterscan-namespace method, so issue it as a custom request.
+const apiLevel = await client.request({
+  method: "ots_getApiLevel" as any,
+  params: [],
+});
+console.log(apiLevel);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-block-details-by-hash.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-details-by-hash.mdx
@@ -49,6 +49,8 @@ The method returns an enhanced block object with additional calculated fields.
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -59,6 +61,55 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+block_hash = "0xe8399bf41516f5ca663c79bc30db02b4989385c2f3a96f42958dea5753cbf4a9"
+
+# ots_getBlockDetailsByHash is an Otterscan method, so call it via the raw provider
+response = w3.provider.make_request("ots_getBlockDetailsByHash", [block_hash])
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const blockHash =
+  "0xe8399bf41516f5ca663c79bc30db02b4989385c2f3a96f42958dea5753cbf4a9";
+
+// ots_getBlockDetailsByHash is an Otterscan method, so use the generic send()
+const details = await provider.send("ots_getBlockDetailsByHash", [blockHash]);
+console.log(details);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const blockHash =
+  "0xe8399bf41516f5ca663c79bc30db02b4989385c2f3a96f42958dea5753cbf4a9";
+
+// ots_getBlockDetailsByHash is an Otterscan method, so call it via request()
+const details = await client.request({
+  method: "ots_getBlockDetailsByHash",
+  params: [blockHash],
+} as any);
+console.log(details);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-block-details.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-details.mdx
@@ -49,6 +49,10 @@ The method returns an enhanced block object with additional calculated fields.
 
 ## Usage example
 
+`ots_getBlockDetails` is an Otterscan-namespace method, so the mainstream EVM libraries have no typed helper for it — call it through each client's raw JSON-RPC request method, as shown below.
+
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -59,6 +63,44 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+response = w3.provider.make_request("ots_getBlockDetails", [1000])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const result = await provider.send("ots_getBlockDetails", [1000]);
+console.log(result);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const result = await client.request({
+  method: "ots_getBlockDetails",
+  params: [1000],
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-block-transactions.mdx
+++ b/reference/hyperliquid-evm-ots-get-block-transactions.mdx
@@ -52,6 +52,7 @@ The method returns a paginated response with transaction data and receipts.
 
 ## Usage example
 
+<CodeGroup>
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -62,6 +63,46 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# ots_getBlockTransactions is an Otterscan method, so call it through the raw provider.
+response = w3.provider.make_request("ots_getBlockTransactions", [1000, 0, 10])
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_getBlockTransactions is an Otterscan method, so send it as a raw request.
+const result = await provider.send("ots_getBlockTransactions", [1000, 0, 10]);
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_getBlockTransactions is an Otterscan method, so issue it as a raw request.
+const result = await client.request({
+  method: "ots_getBlockTransactions",
+  params: [1000, 0, 10],
+});
+console.log(result);
+```
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-contract-creator.mdx
+++ b/reference/hyperliquid-evm-ots-get-contract-creator.mdx
@@ -35,6 +35,8 @@ The method returns an object containing the creator address and deployment trans
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -45,6 +47,52 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# ots_getContractCreator is an Otterscan-namespace method, so call it as a raw JSON-RPC request
+response = w3.provider.make_request(
+    "ots_getContractCreator",
+    ["0x5555555555555555555555555555555555555555"],
+)
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_getContractCreator is an Otterscan-namespace method, so send it as a raw JSON-RPC request
+const result = await provider.send("ots_getContractCreator", [
+  "0x5555555555555555555555555555555555555555",
+]);
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_getContractCreator is an Otterscan-namespace method, so call it as a raw JSON-RPC request
+const result = await client.request({
+  method: "ots_getContractCreator",
+  params: ["0x5555555555555555555555555555555555555555"],
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response (contract found)
 

--- a/reference/hyperliquid-evm-ots-get-header-by-number.mdx
+++ b/reference/hyperliquid-evm-ots-get-header-by-number.mdx
@@ -52,6 +52,10 @@ The method returns a block header object with the following fields:
 
 ## Usage example
 
+`ots_getHeaderByNumber` is an Otterscan-namespace method, so the EVM libraries below call it through their raw JSON-RPC request interface rather than a named helper.
+
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -62,6 +66,47 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# ots_getHeaderByNumber has no named web3.py helper, so call it via the raw provider request.
+response = w3.provider.make_request("ots_getHeaderByNumber", [1000])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_getHeaderByNumber has no named ethers.js helper, so use the generic send method.
+const header = await provider.send("ots_getHeaderByNumber", [1000]);
+console.log(header);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_getHeaderByNumber is not a built-in viem action, so call it through client.request.
+const header = await client.request({
+  method: "ots_getHeaderByNumber",
+  params: [1000],
+} as any);
+console.log(header);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-internal-operations.mdx
+++ b/reference/hyperliquid-evm-ots-get-internal-operations.mdx
@@ -38,6 +38,8 @@ Each internal operation contains:
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -48,6 +50,55 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381"
+
+# ots_getInternalOperations is an Otterscan method, so call it via the raw JSON-RPC provider
+response = w3.provider.make_request("ots_getInternalOperations", [tx_hash])
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+
+// ots_getInternalOperations is an Otterscan method, so send a raw JSON-RPC request
+const operations = await provider.send("ots_getInternalOperations", [txHash]);
+console.log(operations);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+
+// ots_getInternalOperations is an Otterscan method, so use the raw request method
+const operations = await client.request({
+  method: "ots_getInternalOperations" as any,
+  params: [txHash] as any,
+});
+console.log(operations);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-get-transaction-by-sender-and-nonce.mdx
+++ b/reference/hyperliquid-evm-ots-get-transaction-by-sender-and-nonce.mdx
@@ -35,6 +35,8 @@ The method returns the transaction hash if found, or null if no transaction exis
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -45,6 +47,56 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+# ots_getTransactionBySenderAndNonce is an Otterscan namespace method, so
+# call it through the provider directly instead of a typed web3.py binding.
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+response = w3.provider.make_request(
+    "ots_getTransactionBySenderAndNonce",
+    ["0x5555555555555555555555555555555555555555", 0],
+)
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_getTransactionBySenderAndNonce is an Otterscan namespace method, so
+// send the raw JSON-RPC request through the provider.
+const txHash = await provider.send("ots_getTransactionBySenderAndNonce", [
+  "0x5555555555555555555555555555555555555555",
+  0,
+]);
+console.log(txHash);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_getTransactionBySenderAndNonce is an Otterscan namespace method, so
+// issue the raw JSON-RPC request through the client.
+const txHash = await client.request({
+  method: "ots_getTransactionBySenderAndNonce",
+  params: ["0x5555555555555555555555555555555555555555", 0],
+});
+console.log(txHash);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response (transaction found)
 

--- a/reference/hyperliquid-evm-ots-get-transaction-error.mdx
+++ b/reference/hyperliquid-evm-ots-get-transaction-error.mdx
@@ -34,6 +34,10 @@ The method returns the raw error data from the failed transaction, or null if th
 
 ## Usage example
 
+`ots_getTransactionError` is an Otterscan-specific method, so the EVM libraries below call it through their generic JSON-RPC request interfaces rather than a dedicated helper.
+
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -44,6 +48,52 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381"
+response = w3.provider.make_request("ots_getTransactionError", [tx_hash])
+
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+const result = await provider.send("ots_getTransactionError", [txHash]);
+
+console.log(result);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+const result = await client.request({
+  method: "ots_getTransactionError",
+  params: [txHash],
+});
+
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response (with error)
 

--- a/reference/hyperliquid-evm-ots-has-code.mdx
+++ b/reference/hyperliquid-evm-ots-has-code.mdx
@@ -38,6 +38,8 @@ The method returns a boolean value indicating whether the address contains code.
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -48,6 +50,53 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# ots_hasCode is an Otterscan namespace method, so call it as a raw JSON-RPC request.
+response = w3.provider.make_request(
+    "ots_hasCode",
+    ["0x5555555555555555555555555555555555555555", "latest"],
+)
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ots_hasCode is an Otterscan namespace method, so send it as a raw JSON-RPC request.
+const hasCode = await provider.send("ots_hasCode", [
+  "0x5555555555555555555555555555555555555555",
+  "latest",
+]);
+console.log(hasCode);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// ots_hasCode is an Otterscan namespace method, so issue it through the low-level request method.
+const hasCode = await client.request({
+  method: "ots_hasCode" as any,
+  params: ["0x5555555555555555555555555555555555555555", "latest"] as any,
+});
+console.log(hasCode);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-ots-trace-transaction.mdx
+++ b/reference/hyperliquid-evm-ots-trace-transaction.mdx
@@ -41,6 +41,8 @@ Each trace entry contains:
 
 ## Usage example
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -51,6 +53,55 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381"
+
+# ots_traceTransaction has no typed helper in web3.py, so call it directly.
+trace = w3.manager.request_blocking("ots_traceTransaction", [tx_hash])
+print(trace)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+
+// ots_traceTransaction has no typed helper in ethers, so use the generic send.
+const trace = await provider.send("ots_traceTransaction", [txHash]);
+console.log(trace);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash =
+  "0xf94f3d2ed5b59aefb6a0e566af8e86552014d84f6ed2f38a1366dedffe723381";
+
+// ots_traceTransaction has no typed action in viem, so use the EIP-1193 request.
+const trace = await client.request({
+  method: "ots_traceTransaction" as any,
+  params: [txHash] as any,
+});
+console.log(trace);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ### Example response
 

--- a/reference/hyperliquid-evm-trace-block.mdx
+++ b/reference/hyperliquid-evm-trace-block.mdx
@@ -94,6 +94,8 @@ analyzeBlockExecution('latest').then(traces => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -107,6 +109,54 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# trace_block is an OpenEthereum-style method, so call it through the raw provider
+response = w3.provider.make_request("trace_block", ["latest"])
+traces = response["result"]
+
+print(f"Traces in block: {len(traces)}")
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// send() reaches the OpenEthereum-style trace_block method directly
+const traces = await provider.send("trace_block", ["latest"]);
+
+console.log(`Traces in block: ${traces.length}`);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// trace_block is outside viem's typed schema, so use the request escape hatch
+const traces = await (client.request as (args: {
+  method: "trace_block";
+  params: [string];
+}) => Promise<unknown[]>)({
+  method: "trace_block",
+  params: ["latest"],
+});
+
+console.log(`Traces in block: ${traces.length}`);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-call-many.mdx
+++ b/reference/hyperliquid-evm-trace-call-many.mdx
@@ -114,6 +114,8 @@ testMultipleScenarios().then(results => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -151,6 +153,122 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# trace_callMany is a Parity/Erigon-style trace method, so call it via the raw RPC interface
+call_trace_pairs = [
+    [
+        {
+            "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+            "to": "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+            "gas": "0x76c0",
+            "gasPrice": "0x9184e72a000",
+            "value": "0xde0b6b3a7640000",
+            "data": "0x",
+        },
+        ["trace"],
+    ],
+    [
+        {
+            "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+            "to": "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+            "gas": "0x5208",
+            "gasPrice": "0x9184e72a000",
+            "value": "0x1bc16d674ec80000",
+            "data": "0x",
+        },
+        ["trace"],
+    ],
+]
+
+result = w3.manager.request_blocking("trace_callMany", [call_trace_pairs, "latest"])
+print(result)
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// trace_callMany is a Parity/Erigon-style trace method, so call it via the generic send
+const callTracePairs = [
+  [
+    {
+      from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+      to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+      gas: "0x76c0",
+      gasPrice: "0x9184e72a000",
+      value: "0xde0b6b3a7640000",
+      data: "0x",
+    },
+    ["trace"],
+  ],
+  [
+    {
+      from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+      to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+      gas: "0x5208",
+      gasPrice: "0x9184e72a000",
+      value: "0x1bc16d674ec80000",
+      data: "0x",
+    },
+    ["trace"],
+  ],
+];
+
+const result = await provider.send("trace_callMany", [callTracePairs, "latest"]);
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// trace_callMany is a Parity/Erigon-style trace method, so call it via the generic request
+const callTracePairs = [
+  [
+    {
+      from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+      to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+      gas: "0x76c0",
+      gasPrice: "0x9184e72a000",
+      value: "0xde0b6b3a7640000",
+      data: "0x",
+    },
+    ["trace"],
+  ],
+  [
+    {
+      from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+      to: "0xb4DcFE4590adBd275aC3Ef1A3dd10e819d11648c",
+      gas: "0x5208",
+      gasPrice: "0x9184e72a000",
+      value: "0x1bc16d674ec80000",
+      data: "0x",
+    },
+    ["trace"],
+  ],
+];
+
+const result = await client.request({
+  method: "trace_callMany",
+  params: [callTracePairs, "latest"],
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-call.mdx
+++ b/reference/hyperliquid-evm-trace-call.mdx
@@ -111,6 +111,8 @@ analyzeContractCall().then(traces => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -133,6 +135,79 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+call_object = {
+    "from": "0x69835D480110e4919B7899f465aAB101e21c8A87",
+    "to": "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+    "gas": "0x76c0",
+    "gasPrice": "0x9184e72a000",
+    "value": "0xde0b6b3a7640000",
+    "data": "0x",
+}
+
+# trace_call is OpenEthereum-style tracing, not a core eth_* method,
+# so call it through the provider's raw JSON-RPC interface.
+response = w3.provider.make_request(
+    "trace_call", [call_object, ["trace"], "latest"]
+)
+print(response["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const callObject = {
+  from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+  gas: "0x76c0",
+  gasPrice: "0x9184e72a000",
+  value: "0xde0b6b3a7640000",
+  data: "0x",
+};
+
+// trace_call is OpenEthereum-style tracing, not a core eth_* method,
+// so send it as a raw JSON-RPC request.
+const trace = await provider.send("trace_call", [callObject, ["trace"], "latest"]);
+console.log(trace);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const callObject = {
+  from: "0x69835D480110e4919B7899f465aAB101e21c8A87",
+  to: "0xB7C609cFfa0e47DB2467ea03fF3e598bf59361A5",
+  gas: "0x76c0",
+  gasPrice: "0x9184e72a000",
+  value: "0xde0b6b3a7640000",
+  data: "0x",
+} as const;
+
+// trace_call is OpenEthereum-style tracing, not a core eth_* method,
+// so reach it through the client's low-level request method.
+const trace = await client.request({
+  method: "trace_call" as any,
+  params: [callObject, ["trace"], "latest"] as any,
+});
+console.log(trace);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-filter.mdx
+++ b/reference/hyperliquid-evm-trace-filter.mdx
@@ -195,6 +195,8 @@ analyzeContractDeployments(500);
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm \
   -H "Content-Type: application/json" \
@@ -212,6 +214,82 @@ curl -X POST https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577
     "id": 1
   }'
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+trace_filter = {
+    "fromBlock": "0xb92f20",
+    "toBlock": "0xb92f6d",
+    "toAddress": ["0x5555555555555555555555555555555555555555"],
+    "count": 5,
+}
+
+traces = w3.tracing.trace_filter(trace_filter)
+print(traces)
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const filter = {
+  fromBlock: "0xb92f20",
+  toBlock: "0xb92f6d",
+  toAddress: ["0x5555555555555555555555555555555555555555"],
+  count: 5,
+};
+
+const traces = await provider.send("trace_filter", [filter]);
+console.log(traces);
+```
+
+```typescript viem
+import { createPublicClient, http, rpcSchema, type Address, type Hex } from "viem";
+
+type TraceFilterSchema = [
+  {
+    Method: "trace_filter";
+    Parameters: [
+      {
+        fromBlock?: Hex;
+        toBlock?: Hex;
+        fromAddress?: Address[];
+        toAddress?: Address[];
+        count?: number;
+      },
+    ];
+    ReturnType: unknown[];
+  },
+];
+
+const client = createPublicClient({
+  rpcSchema: rpcSchema<TraceFilterSchema>(),
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const traces = await client.request({
+  method: "trace_filter",
+  params: [
+    {
+      fromBlock: "0xb92f20",
+      toBlock: "0xb92f6d",
+      toAddress: ["0x5555555555555555555555555555555555555555"],
+      count: 5,
+    },
+  ],
+});
+console.log(traces);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-raw-transaction.mdx
+++ b/reference/hyperliquid-evm-trace-raw-transaction.mdx
@@ -81,6 +81,8 @@ traceRawTransaction(rawTx).then(traces => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -95,6 +97,55 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+raw_tx = "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89"
+
+# trace_rawTransaction is a non-standard JSON-RPC method, so call it directly.
+response = w3.provider.make_request("trace_rawTransaction", [raw_tx, ["trace"]])
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const rawTx =
+  "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89";
+
+// trace_rawTransaction is a non-standard JSON-RPC method, so send it directly.
+const traces = await provider.send("trace_rawTransaction", [rawTx, ["trace"]]);
+console.log(traces);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const rawTx =
+  "0xf86d80843b9aca0082520894b7c609cffa0e47db2467ea03ff3e598bf59361a5880de0b6b3a7640000808207f2a02d013b9980176ca8674f77797ac04e928b8de3be92dd452501ec26acbb2b1abca054041f43109eeadbb4d6b712a20dc71e5dbe1225e549644be3de803b55041a89";
+
+// trace_rawTransaction is a non-standard JSON-RPC method, so request it directly.
+const traces = await client.request({
+  method: "trace_rawTransaction",
+  params: [rawTx, ["trace"]],
+});
+console.log(traces);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-replay-block-transactions.mdx
+++ b/reference/hyperliquid-evm-trace-replay-block-transactions.mdx
@@ -81,6 +81,8 @@ replayBlockTransactions('latest').then(results => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -95,6 +97,53 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python Python (web3.py)
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+# trace_replayBlockTransactions has no typed wrapper in web3.py — use the generic JSON-RPC call
+response = w3.provider.make_request(
+    "trace_replayBlockTransactions",
+    ["latest", ["trace"]],
+)
+print(response["result"])
+```
+
+```javascript JavaScript (ethers.js)
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// trace_replayBlockTransactions has no typed wrapper in ethers.js — use the generic send method
+const result = await provider.send("trace_replayBlockTransactions", [
+  "latest",
+  ["trace"],
+]);
+console.log(result);
+```
+
+```typescript TypeScript (viem)
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// trace_replayBlockTransactions has no typed action in viem — use the generic request method
+const result = await client.request({
+  method: "trace_replayBlockTransactions",
+  params: ["latest", ["trace"]],
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-trace-replay-transaction.mdx
+++ b/reference/hyperliquid-evm-trace-replay-transaction.mdx
@@ -81,6 +81,8 @@ replayTransaction(txHash).then(result => {
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -95,6 +97,55 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
 ```
+
+```python web3.py
+from web3 import Web3
+
+w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+
+tx_hash = "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31"
+
+# trace_replayTransaction is not a typed web3.py method, so call it via the raw provider.
+result = w3.provider.make_request("trace_replayTransaction", [tx_hash, ["trace"]])
+print(result["result"])
+```
+
+```javascript ethers.js
+import { JsonRpcProvider } from "ethers";
+
+const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+const txHash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// trace_replayTransaction is not a typed ethers method, so send the raw JSON-RPC request.
+const result = await provider.send("trace_replayTransaction", [txHash, ["trace"]]);
+console.log(result);
+```
+
+```typescript viem
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({
+  transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+const txHash =
+  "0x07712544ce8f50091c6c3b227921f763b342bf9465a22f0226d651a3246adb31";
+
+// trace_replayTransaction is not a typed viem action, so use the raw request method.
+const result = await client.request({
+  method: "trace_replayTransaction",
+  params: [txHash, ["trace"]],
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-evm-web3-client-version.mdx
+++ b/reference/hyperliquid-evm-web3-client-version.mdx
@@ -32,12 +32,49 @@ Returns the client version as a string (e.g., "HyperEVM/v1.0.0").
  
  ## cURL example
  
- ```bash
+ <CodeGroup>
+ 
+ ```bash Shell curl
  curl -X POST \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' \
    https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
  ```
+ 
+ ```python Python web3.py
+ from web3 import Web3
+ 
+ w3 = Web3(Web3.HTTPProvider("YOUR_CHAINSTACK_ENDPOINT"))
+ 
+ client_version = w3.client_version
+ print(client_version)
+ ```
+ 
+ ```javascript JavaScript ethers.js
+ import { JsonRpcProvider } from "ethers";
+ 
+ const provider = new JsonRpcProvider("YOUR_CHAINSTACK_ENDPOINT");
+ 
+ const clientVersion = await provider.send("web3_clientVersion", []);
+ console.log(clientVersion);
+ ```
+ 
+ ```typescript TypeScript viem
+ import { createPublicClient, http } from "viem";
+ 
+ const client = createPublicClient({
+   transport: http("YOUR_CHAINSTACK_ENDPOINT"),
+ });
+ 
+ const clientVersion = await client.request({ method: "web3_clientVersion" });
+ console.log(clientVersion);
+ ```
+ 
+ </CodeGroup>
+ 
+ <Note>
+ **Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+ </Note>
  
  Example response:
  

--- a/reference/hyperliquid-exchange-agent-enable-dex-abstraction.mdx
+++ b/reference/hyperliquid-exchange-agent-enable-dex-abstraction.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,36 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# The wallet must be the approved agent wallet for the user.
+wallet = Account.from_key("YOUR_AGENT_PRIVATE_KEY")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Signs the action (EIP-712) and posts it. Deprecated in favor of agent_set_abstraction.
+result = exchange.agent_enable_dex_abstraction()
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// The wallet must be the approved agent wallet for the user.
+const wallet = privateKeyToAccount("YOUR_AGENT_PRIVATE_KEY"); // viem or ethers
+const transport = new hl.HttpTransport(); // public mainnet API
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Signs the action (EIP-712) and posts it. Deprecated in favor of agentSetAbstraction.
+const result = await client.agentEnableDexAbstraction();
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-agent-set-abstraction.mdx
+++ b/reference/hyperliquid-exchange-agent-set-abstraction.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,38 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Agent wallet approved to act on behalf of the user
+agent = Account.from_key("AGENT_PRIVATE_KEY")
+
+exchange = Exchange(agent, constants.MAINNET_API_URL)
+
+# abstraction is one of "u" (unifiedAccount), "p" (portfolioMargin), "i" (disabled)
+result = exchange.agent_set_abstraction("u")
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Agent wallet approved to act on behalf of the user
+const wallet = privateKeyToAccount("0x...");
+
+const transport = new HttpTransport(); // default public Hyperliquid API
+const exchange = new ExchangeClient({ transport, wallet });
+
+// abstraction is one of "u" (unifiedAccount), "p" (portfolioMargin), "i" (disabled)
+const result = await exchange.agentSetAbstraction({ abstraction: "u" });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-approve-agent.mdx
+++ b/reference/hyperliquid-exchange-approve-agent.mdx
@@ -50,6 +50,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -59,6 +61,46 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from eth_account.signers.local import LocalAccount
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Your master account wallet (this signs the approval).
+wallet: LocalAccount = eth_account.Account.from_key("0x_your_private_key")
+
+# Public Hyperliquid mainnet API.
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# approve_agent generates a fresh agent key internally and returns the API
+# response together with the agent's private key. Pass an optional name to
+# create a named (persistent) agent.
+approve_result, agent_key = exchange.approve_agent("myAgent")
+print(approve_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Your master account wallet (this signs the approval).
+const wallet = privateKeyToAccount("0x_your_private_key");
+
+// Public Hyperliquid mainnet API.
+const transport = new HttpTransport();
+const client = new ExchangeClient({ transport, wallet });
+
+const result = await client.approveAgent({
+  agentAddress: "0x_agent_address",
+  agentName: "myAgent",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-approve-builder-fee.mdx
+++ b/reference/hyperliquid-exchange-approve-builder-fee.mdx
@@ -50,6 +50,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -59,6 +61,44 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Wallet that signs the EIP-712 action
+wallet = eth_account.Account.from_key("YOUR_PRIVATE_KEY")
+
+# Public Hyperliquid API (this method is not available through Chainstack)
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+result = exchange.approve_builder_fee(
+    builder="0x0000000000000000000000000000000000000000",
+    max_fee_rate="0.01%",
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Wallet that signs the EIP-712 action
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+
+// Public Hyperliquid API (this method is not available through Chainstack)
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+const result = await client.approveBuilderFee({
+  maxFeeRate: "0.01%",
+  builder: "0x0000000000000000000000000000000000000000",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-batch-modify.mdx
+++ b/reference/hyperliquid-exchange-batch-modify.mdx
@@ -100,37 +100,83 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
 
-# Initialize with your private key
+# Initialize with your private key (public Hyperliquid API)
 account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Modify multiple orders at once
-modifications = [
+modifies = [
     {
         "oid": 77738308,
-        "coin": "BTC",
-        "is_buy": True,
-        "sz": 0.02,
-        "limit_px": 51000,
-        "order_type": {"limit": {"tif": "Gtc"}}
+        "order": {
+            "coin": "BTC",
+            "is_buy": True,
+            "sz": 0.02,
+            "limit_px": 51000,
+            "order_type": {"limit": {"tif": "Gtc"}},
+            "reduce_only": False,
+        },
     },
     {
         "oid": 77738309,
-        "coin": "ETH",
-        "is_buy": False,
-        "sz": 0.5,
-        "limit_px": 3200,
-        "order_type": {"limit": {"tif": "Gtc"}}
-    }
+        "order": {
+            "coin": "ETH",
+            "is_buy": False,
+            "sz": 0.5,
+            "limit_px": 3200,
+            "order_type": {"limit": {"tif": "Gtc"}},
+            "reduce_only": False,
+        },
+    },
 ]
 
-batch_result = exchange.batch_modify_orders(modifications)
+batch_result = exchange.bulk_modify_orders_new(modifies)
 print(batch_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key (public Hyperliquid API)
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Modify multiple orders at once
+const result = await exchange.batchModify({
+  modifies: [
+    {
+      oid: 77738308,
+      order: {
+        a: 0,
+        b: true,
+        p: "51000",
+        s: "0.02",
+        r: false,
+        t: { limit: { tif: "Gtc" } },
+      },
+    },
+    {
+      oid: 77738309,
+      order: {
+        a: 1,
+        b: false,
+        p: "3200",
+        s: "0.5",
+        r: false,
+        t: { limit: { tif: "Gtc" } },
+      },
+    },
+  ],
+});
+
+console.log(result);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-c-deposit.mdx
+++ b/reference/hyperliquid-exchange-c-deposit.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,58 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+# The hyperliquid-python-sdk has no cDeposit convenience method,
+# so build and sign the user-signed action with the SDK primitives.
+import eth_account
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils.constants import MAINNET_API_URL
+from hyperliquid.utils.signing import get_timestamp_ms, sign_user_signed_action
+
+# EIP-712 payload for the cDeposit action.
+C_DEPOSIT_SIGN_TYPES = [
+    {"name": "hyperliquidChain", "type": "string"},
+    {"name": "wei", "type": "uint64"},
+    {"name": "nonce", "type": "uint64"},
+]
+
+wallet = eth_account.Account.from_key("0x...")  # your private key
+exchange = Exchange(wallet, MAINNET_API_URL)  # public mainnet endpoint
+
+nonce = get_timestamp_ms()
+action = {
+    "type": "cDeposit",
+    "wei": 1 * 10**8,  # amount of wei to deposit into staking (float \* 1e8)
+    "nonce": nonce,
+}
+signature = sign_user_signed_action(
+    wallet,
+    action,
+    C_DEPOSIT_SIGN_TYPES,
+    "HyperliquidTransaction:CDeposit",
+    True,  # is_mainnet
+)
+result = exchange._post_action(action, signature, nonce)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // your private key
+const transport = new HttpTransport(); // public mainnet endpoint
+const exchange = new ExchangeClient({ transport, wallet });
+
+const result = await exchange.cDeposit({
+  wei: 1 * 1e8, // amount of wei to deposit into staking (float \* 1e8)
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-c-signer-action.mdx
+++ b/reference/hyperliquid-exchange-c-signer-action.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,48 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from eth_account import Account
+
+# Validator signer wallet — replace with your own key handling
+wallet = Account.from_key("0x...")
+
+# Public-only method: use the Hyperliquid mainnet API
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Jail self as a validator signer
+result = exchange.c_signer_jail_self()
+
+# Unjail self as a validator signer
+# result = exchange.c_signer_unjail_self()
+
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Validator signer wallet — replace with your own key handling
+const wallet = privateKeyToAccount("0x...");
+
+// Public-only method: default transport targets the Hyperliquid mainnet API
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Jail self as a validator signer
+const result = await exchange.cSignerAction({ jailSelf: null });
+
+// Unjail self as a validator signer
+// const result = await exchange.cSignerAction({ unjailSelf: null });
+
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-c-validator-action.mdx
+++ b/reference/hyperliquid-exchange-c-validator-action.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,71 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the validator signer wallet (keep the key out of source control).
+wallet = eth_account.Account.from_key("0x_your_private_key")
+
+# CValidatorAction is public-only — use the public Hyperliquid mainnet API.
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Register a validator.
+result = exchange.c_validator_register(
+    node_ip="1.2.3.4",
+    name="my-validator",
+    description="My Hyperliquid validator",
+    delegations_disabled=False,
+    commission_bps=100,
+    signer="0x_validator_signer_address",
+    unjailed=True,
+    initial_wei=10000000000,
+)
+print(result)
+
+# Update the validator profile.
+exchange.c_validator_change_profile(
+    node_ip="1.2.3.4",
+    name="my-validator",
+    description="Updated description",
+    unjailed=True,
+    disable_delegations=False,
+    commission_bps=100,
+    signer=None,
+)
+
+# Unregister the validator.
+exchange.c_validator_unregister()
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load the validator signer wallet (keep the key out of source control).
+const wallet = privateKeyToAccount("0x_your_private_key");
+
+// CValidatorAction is public-only — HttpTransport defaults to the public Hyperliquid API.
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+await client.cValidatorAction({
+  changeProfile: {
+    node_ip: { Ip: "1.2.3.4" },
+    name: "my-validator",
+    description: "Updated description",
+    unjailed: true,
+    disable_delegations: false,
+    commission_bps: 100,
+    signer: null,
+  },
+});
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-c-withdraw.mdx
+++ b/reference/hyperliquid-exchange-c-withdraw.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,56 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import get_timestamp_ms, sign_user_signed_action
+
+# EIP-712 types for the cWithdraw action (withdraw from staking).
+CWITHDRAW_TYPES = [
+    {"name": "hyperliquidChain", "type": "string"},
+    {"name": "wei", "type": "uint64"},
+    {"name": "nonce", "type": "uint64"},
+]
+
+wallet = eth_account.Account.from_key("0x...")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Amount of wei to withdraw from the staking balance (float * 1e8).
+nonce = get_timestamp_ms()
+action = {"type": "cWithdraw", "wei": int(1 * 1e8), "nonce": nonce}
+
+# The Python SDK exposes no dedicated cWithdraw helper, so sign the
+# user-signed action directly with the generic signer.
+signature = sign_user_signed_action(
+    wallet,
+    action,
+    CWITHDRAW_TYPES,
+    "HyperliquidTransaction:CWithdraw",
+    is_mainnet=True,
+)
+
+result = exchange._post_action(action, signature, nonce)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+
+const transport = new HttpTransport(); // public Hyperliquid API
+const client = new ExchangeClient({ transport, wallet });
+
+// Amount of wei to withdraw from staking into the spot account (float * 1e8).
+const result = await client.cWithdraw({ wei: 1 * 1e8 });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-cancel-order-by-cloid.mdx
+++ b/reference/hyperliquid-exchange-cancel-order-by-cloid.mdx
@@ -71,9 +71,10 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python hyperliquid-python-sdk
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
+from hyperliquid.utils.types import Cloid
 import eth_account
 
 # Initialize with your private key
@@ -82,11 +83,30 @@ exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Cancel an order by client order ID
 cancel_result = exchange.cancel_by_cloid(
-    coin="BTC",
-    cloid="0x1234567890abcdef1234567890abcdef"
+    name="BTC",
+    cloid=Cloid.from_str("0x1234567890abcdef1234567890abcdef"),
 )
 
 print(cancel_result)
+```
+
+```typescript @nktkas/hyperliquid
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Set up the client with a wallet and the public transport
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Cancel an order by client order ID
+const result = await exchange.cancelByCloid({
+  cancels: [
+    { asset: 0, cloid: "0x1234567890abcdef1234567890abcdef" },
+  ],
+});
+
+console.log(result);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-cancel-order.mdx
+++ b/reference/hyperliquid-exchange-cancel-order.mdx
@@ -73,7 +73,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -82,19 +82,32 @@ import eth_account
 account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
-# Cancel an order by ID
-cancel_result = exchange.cancel(
-    coin="BTC",
-    oid=77738308
-)
-
-# Cancel multiple orders
-cancel_results = exchange.cancel_multiple([
-    {"coin": "BTC", "oid": 77738308},
-    {"coin": "ETH", "oid": 77738309}
-])
-
+# Cancel a single order by ID
+cancel_result = exchange.cancel(name="BTC", oid=77738308)
 print(cancel_result)
+
+# Cancel multiple orders in one request
+cancel_results = exchange.bulk_cancel([
+    {"coin": "BTC", "oid": 77738308},
+    {"coin": "ETH", "oid": 77738309},
+])
+print(cancel_results)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Cancel one or multiple orders by asset index (a) and order ID (o)
+const cancelResult = await exchange.cancel({
+  cancels: [{ a: 0, o: 77738308 }],
+});
+console.log(cancelResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-convert-to-multi-sig-user.mdx
+++ b/reference/hyperliquid-exchange-convert-to-multi-sig-user.mdx
@@ -48,6 +48,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -57,6 +59,56 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the wallet that authorizes the conversion
+wallet = eth_account.Account.from_key("YOUR_PRIVATE_KEY")
+
+# Public Hyperliquid mainnet endpoint
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Convert the account to multi-sig with a list of authorized signers and a threshold
+result = exchange.convert_to_multi_sig_user(
+    authorized_users=[
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+    ],
+    threshold=2,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load the wallet that authorizes the conversion
+const wallet = privateKeyToAccount("0x...");
+
+// Public Hyperliquid mainnet endpoint
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Convert the account to multi-sig with a list of authorized signers and a threshold
+const result = await exchange.convertToMultiSigUser({
+  signers: {
+    authorizedUsers: [
+      "0x0000000000000000000000000000000000000001",
+      "0x0000000000000000000000000000000000000002",
+      "0x0000000000000000000000000000000000000003",
+    ],
+    threshold: 2,
+  },
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-create-sub-account.mdx
+++ b/reference/hyperliquid-exchange-create-sub-account.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,40 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load your wallet from a private key (use a secure source in production)
+wallet = eth_account.Account.from_key("0x...")
+
+# Public Hyperliquid mainnet API — this method is not available through Chainstack
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Create a sub-account under your main account
+result = exchange.create_sub_account(name="my-sub-account")
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load your wallet from a private key (use a secure source in production)
+const wallet = privateKeyToAccount("0x...");
+
+// Default transport targets the public Hyperliquid mainnet API
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Create a sub-account under your main account
+const result = await client.createSubAccount({ name: "my-sub-account" });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-evm-user-modify.mdx
+++ b/reference/hyperliquid-exchange-evm-user-modify.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,40 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the wallet that signs the action.
+wallet = eth_account.Account.from_key("YOUR_PRIVATE_KEY")
+
+# evmUserModify is public-only, so use the Hyperliquid mainnet API.
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Configure the block type for HyperEVM transactions.
+result = exchange.use_big_blocks(True)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load the wallet that signs the action.
+const wallet = privateKeyToAccount("0x...");
+
+// evmUserModify is public-only, so use the default Hyperliquid transport.
+const transport = new HttpTransport();
+const client = new ExchangeClient({ transport, wallet });
+
+// Configure the block type for HyperEVM transactions.
+const result = await client.evmUserModify({ usingBigBlocks: true });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-modify-order.mdx
+++ b/reference/hyperliquid-exchange-modify-order.mdx
@@ -84,7 +84,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -96,15 +96,40 @@ exchange = Exchange(account, constants.MAINNET_API_URL)
 # Modify an existing order
 modify_result = exchange.modify_order(
     oid=77738308,
-    coin="BTC",
+    name="BTC",
     is_buy=True,
     sz=0.02,
     limit_px=51000,
     order_type={"limit": {"tif": "Gtc"}},
-    reduce_only=False
+    reduce_only=False,
 )
 
 print(modify_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+const transport = new HttpTransport(); // public Hyperliquid API
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Modify an existing order
+const modifyResult = await exchange.modify({
+  oid: 77738308,
+  order: {
+    a: 0,
+    b: true,
+    p: "51000",
+    s: "0.02",
+    r: false,
+    t: { limit: { tif: "Gtc" } },
+  },
+});
+
+console.log(modifyResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-multi-sig.mdx
+++ b/reference/hyperliquid-exchange-multi-sig.mdx
@@ -48,6 +48,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -57,6 +59,58 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+# pip install hyperliquid-python-sdk eth-account
+import time
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# The leader (outer signer) collects the inner signatures and submits the action.
+leader = eth_account.Account.from_key("0xLEADER_PRIVATE_KEY")
+exchange = Exchange(leader, constants.MAINNET_API_URL)
+
+multi_sig_user = "0xMULTI_SIG_ACCOUNT_ADDRESS"
+nonce = int(time.time() * 1000)
+
+# inner_action is the action the multi-sig account performs (for example, an order).
+inner_action = {"type": "scheduleCancel", "time": None}
+
+# signatures collected from each authorized signer of the multi-sig account.
+signatures = [
+    # sign_multi_sig_inner_action(...) output per signer
+]
+
+result = exchange.multi_sig(
+    multi_sig_user=multi_sig_user,
+    inner_action=inner_action,
+    signatures=signatures,
+    nonce=nonce,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+// npm install @nktkas/hyperliquid viem
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const multiSigUser = "0xMULTI_SIG_ACCOUNT_ADDRESS"; // the multi-sig account address
+const signers = [
+  privateKeyToAccount("0xLEADER_PRIVATE_KEY"), // leader — signs the wrapper
+  privateKeyToAccount("0xOTHER_SIGNER_PRIVATE_KEY"),
+] as const;
+
+const transport = new HttpTransport(); // public mainnet endpoint
+const client = new ExchangeClient({ transport, signers, multiSigUser });
+
+// The client wraps each action in a multiSig action automatically.
+const result = await client.order({ orders: [/* ... */], grouping: "na" });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-noop.mdx
+++ b/reference/hyperliquid-exchange-noop.mdx
@@ -46,6 +46,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -55,6 +57,40 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from eth_account.signers.local import LocalAccount
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import get_timestamp_ms
+
+# The noop endpoint is public-only, so use the Hyperliquid mainnet URL.
+wallet: LocalAccount = eth_account.Account.from_key("0x...")  # your private key
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# noop takes the nonce (current timestamp in milliseconds); the SDK signs the action for you.
+result = exchange.noop(get_timestamp_ms())
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // your private key (viem or ethers)
+
+// The noop endpoint is public-only, so use the default public transport.
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// noop takes the nonce (current timestamp in milliseconds); the SDK signs the action for you.
+const result = await client.noop({ nonce: Date.now() });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-perp-deploy.mdx
+++ b/reference/hyperliquid-exchange-perp-deploy.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,58 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from eth_account import Account
+
+# Signing is required: load the deployer wallet from its private key.
+wallet = Account.from_key("0x...")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# perpDeploy / registerAsset: register a new perp asset on a builder-deployed perp DEX.
+result = exchange.perp_deploy_register_asset(
+    dex="test",
+    max_gas=1000000,
+    coin="USDC",
+    sz_decimals=8,
+    oracle_px="1",
+    margin_table_id=1,
+    only_isolated=False,
+    schema=None,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Signing is required: load the deployer wallet from its private key.
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+const transport = new hl.HttpTransport(); // public mainnet API
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// perpDeploy / registerAsset: register a new perp asset on a builder-deployed perp DEX.
+const result = await client.perpDeploy({
+  registerAsset: {
+    maxGas: 1000000,
+    assetRequest: {
+      coin: "USDC",
+      szDecimals: 8,
+      oraclePx: "1",
+      marginTableId: 1,
+      onlyIsolated: false,
+    },
+    dex: "test",
+    schema: null,
+  },
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-place-order.mdx
+++ b/reference/hyperliquid-exchange-place-order.mdx
@@ -111,26 +111,53 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
 
-# Initialize with your private key
+# Initialize with your private key. The public mainnet API is used
+# because this signing endpoint is not served through Chainstack.
 account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
-# Place a limit buy order for BTC
+# Place a limit buy order for BTC.
 order_result = exchange.order(
-    coin="BTC",
-    is_buy=True, 
+    name="BTC",
+    is_buy=True,
     sz=0.01,
     limit_px=50000,
     order_type={"limit": {"tif": "Gtc"}},
-    reduce_only=False
+    reduce_only=False,
 )
 
 print(order_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// The default HttpTransport targets the public mainnet API because
+// this signing endpoint is not served through Chainstack.
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Place a limit buy order for asset index 0 (BTC perpetual).
+const result = await exchange.order({
+  orders: [{
+    a: 0,
+    b: true,
+    p: "50000",
+    s: "0.01",
+    r: false,
+    t: { limit: { tif: "Gtc" } },
+  }],
+  grouping: "na",
+});
+
+console.log(result);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-reserve-request-weight.mdx
+++ b/reference/hyperliquid-exchange-reserve-request-weight.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,47 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+# The hyperliquid-python-sdk does not expose a dedicated reserveRequestWeight
+# method, so build and sign the L1 action with the SDK signing primitives.
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import sign_l1_action, get_timestamp_ms
+
+wallet = Account.from_key("0x...")  # your API wallet private key
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+action = {"type": "reserveRequestWeight", "weight": 10}
+nonce = get_timestamp_ms()
+
+signature = sign_l1_action(
+    wallet,
+    action,
+    exchange.vault_address,
+    nonce,
+    exchange.expires_after,
+    exchange.base_url == constants.MAINNET_API_URL,
+)
+
+result = exchange._post_action(action, signature, nonce)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // your API wallet private key
+const transport = new HttpTransport(); // default public Hyperliquid API
+const exchange = new ExchangeClient({ transport, wallet });
+
+const result = await exchange.reserveRequestWeight({ weight: 10 });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-schedule-cancel.mdx
+++ b/reference/hyperliquid-exchange-schedule-cancel.mdx
@@ -104,6 +104,24 @@ remove_result = exchange.schedule_cancel(time=None)
 print(schedule_result)
 ```
 
+```typescript TypeScript
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Schedule cancel in 60 seconds
+const scheduleResult = await exchange.scheduleCancel({ time: Date.now() + 60_000 });
+
+// Remove scheduled cancel
+const removeResult = await exchange.scheduleCancel();
+
+console.log(scheduleResult);
+```
+
 </CodeGroup>
 
 ## Response example

--- a/reference/hyperliquid-exchange-send-asset.mdx
+++ b/reference/hyperliquid-exchange-send-asset.mdx
@@ -51,6 +51,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -60,6 +62,54 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load your wallet from a private key (keep it secret — never hardcode in production)
+wallet = eth_account.Account.from_key("0x...")
+
+# Public Hyperliquid API (this method is available on the official API only)
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Send a spot asset to another address.
+# sourceDex/destinationDex: "" for the default perp dex, "spot" for spot.
+result = exchange.send_asset(
+    destination="0x0000000000000000000000000000000000000001",
+    source_dex="spot",
+    destination_dex="spot",
+    token="USDC:0xeb62eee3685fc4c43992febcd9e75443",
+    amount=1,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load your wallet from a private key (keep it secret — never hardcode in production)
+const wallet = privateKeyToAccount("0x...");
+
+// Public Hyperliquid API (this method is available on the official API only)
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Send a spot asset to another address.
+// sourceDex/destinationDex: "" for the default perp dex, "spot" for spot.
+const result = await exchange.sendAsset({
+  destination: "0x0000000000000000000000000000000000000001",
+  sourceDex: "spot",
+  destinationDex: "spot",
+  token: "USDC:0xeb62eee3685fc4c43992febcd9e75443",
+  amount: "1",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-send-to-evm-with-data.mdx
+++ b/reference/hyperliquid-exchange-send-to-evm-with-data.mdx
@@ -50,6 +50,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -59,6 +61,85 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Public Hyperliquid mainnet API (default transport)
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// SDK signs the EIP-712 action and posts it to /exchange
+const result = await exchange.sendToEvmWithData({
+  token: "USDC",
+  amount: "1",
+  sourceDex: "spot",
+  destinationRecipient: "0x...",
+  addressEncoding: "hex",
+  destinationChainId: 42161,
+  gasLimit: 200000,
+  data: "0x",
+});
+
+console.log(result);
+```
+
+```python Python (hyperliquid-python-sdk)
+# Note: hyperliquid-python-sdk does not expose a sendToEvmWithData helper.
+# Build, sign, and post the action manually against the public mainnet API.
+import time
+import requests
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import sign_user_signed_action
+
+# Your wallet (e.g. from eth_account.Account)
+wallet = ...  # LocalAccount
+
+action = {
+    "type": "sendToEvmWithData",
+    "signatureChainId": "0xa4b1",
+    "hyperliquidChain": "Mainnet",
+    "token": "USDC",
+    "amount": "1",
+    "sourceDex": "spot",
+    "destinationRecipient": "0x...",
+    "addressEncoding": "hex",
+    "destinationChainId": 42161,
+    "gasLimit": 200000,
+    "data": "0x",
+    "nonce": int(time.time() * 1000),
+}
+
+# EIP-712 sign (payload_types must match the action fields)
+signature = sign_user_signed_action(
+    wallet,
+    action,
+    payload_types=[
+        {"name": "hyperliquidChain", "type": "string"},
+        {"name": "token", "type": "string"},
+        {"name": "amount", "type": "string"},
+        {"name": "sourceDex", "type": "string"},
+        {"name": "destinationRecipient", "type": "string"},
+        {"name": "addressEncoding", "type": "string"},
+        {"name": "destinationChainId", "type": "uint64"},
+        {"name": "gasLimit", "type": "uint64"},
+        {"name": "data", "type": "bytes"},
+        {"name": "nonce", "type": "uint64"},
+    ],
+    primary_type="HyperliquidTransaction:SendToEvmWithData",
+    is_mainnet=True,
+)
+
+resp = requests.post(
+    f"{constants.MAINNET_API_URL}/exchange",
+    json={"action": action, "nonce": action["nonce"], "signature": signature},
+)
+print(resp.json())
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-set-referrer.mdx
+++ b/reference/hyperliquid-exchange-set-referrer.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,40 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the wallet that sets the referral code (replace with your own private key)
+wallet = Account.from_key("0x...")
+
+# Public Hyperliquid mainnet endpoint (this method is public-only)
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Set the referral code for the wallet's account
+result = exchange.set_referrer("YOUR_CODE")
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load the wallet that sets the referral code (replace with your own private key)
+const wallet = privateKeyToAccount("0x...");
+
+// Public Hyperliquid mainnet endpoint (this method is public-only)
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ wallet, transport });
+
+// Set the referral code for the wallet's account
+const result = await exchange.setReferrer({ code: "YOUR_CODE" });
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-spot-deploy.mdx
+++ b/reference/hyperliquid-exchange-spot-deploy.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,53 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Public Hyperliquid mainnet — this method is not served by Chainstack
+wallet = eth_account.Account.from_key("0xYOUR_PRIVATE_KEY")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Step 1 of the spot deploy flow: register the token (registerToken2)
+result = exchange.spot_deploy_register_token(
+    token_name="USDC",
+    sz_decimals=8,
+    wei_decimals=8,
+    max_gas=1000000,
+    full_name="USD Coin",
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0xYOUR_PRIVATE_KEY"); // viem or ethers
+
+// Public Hyperliquid mainnet — this method is not served by Chainstack
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Step 1 of the spot deploy flow: register the token (registerToken2)
+const result = await client.spotDeploy({
+  registerToken2: {
+    spec: {
+      name: "USDC",
+      szDecimals: 8,
+      weiDecimals: 8,
+    },
+    maxGas: 1000000,
+    fullName: "USD Coin",
+  },
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-spot-perp-transfer.mdx
+++ b/reference/hyperliquid-exchange-spot-perp-transfer.mdx
@@ -98,7 +98,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python hyperliquid-python-sdk
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -108,18 +108,42 @@ account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Transfer 100 USDC from spot to perp
-to_perp = exchange.spot_perp_transfer(
+to_perp = exchange.usd_class_transfer(
     amount=100.0,
-    to_perp=True
+    to_perp=True,
 )
 
 # Transfer 50 USDC from perp to spot
-to_spot = exchange.spot_perp_transfer(
+to_spot = exchange.usd_class_transfer(
     amount=50.0,
-    to_perp=False
+    to_perp=False,
 )
 
 print(to_perp)
+```
+
+```typescript @nktkas/hyperliquid
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Transfer 100 USDC from spot to perp
+const toPerp = await exchange.usdClassTransfer({
+  amount: "100",
+  toPerp: true,
+});
+
+// Transfer 50 USDC from perp to spot
+const toSpot = await exchange.usdClassTransfer({
+  amount: "50",
+  toPerp: false,
+});
+
+console.log(toPerp);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-spot-send.mdx
+++ b/reference/hyperliquid-exchange-spot-send.mdx
@@ -109,7 +109,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -118,14 +118,33 @@ import eth_account
 account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
-# Send 100 PURR tokens to another address
+# Send 100 PURR tokens to another address (signs and posts a spotSend action)
 transfer_result = exchange.spot_transfer(
+    amount=100.0,
     destination="0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
-    token="PURR",
-    amount=100.0
+    token="PURR:0xc1fb593aeffbeb02f85e0308e9956a90",
 )
 
 print(transfer_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport(); // default public Hyperliquid API
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Send 100 PURR tokens to another address (signs and posts a spotSend action)
+const transferResult = await exchange.spotSend({
+  destination: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+  token: "PURR:0xc1fb593aeffbeb02f85e0308e9956a90",
+  amount: "100.0",
+});
+
+console.log(transferResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-sub-account-spot-transfer.mdx
+++ b/reference/hyperliquid-exchange-sub-account-spot-transfer.mdx
@@ -50,6 +50,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -59,6 +61,50 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Wallet that signs the action
+wallet = Account.from_key("YOUR_PRIVATE_KEY")
+
+# Public Hyperliquid mainnet API (this method is not served by Chainstack)
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Deposit spot tokens from the main account into the sub-account
+result = exchange.sub_account_spot_transfer(
+    sub_account_user="0xSUB_ACCOUNT_ADDRESS",
+    is_deposit=True,
+    token="USDC:0xeb62eee3685fc4c43992febcd9e75443",
+    amount=1,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Wallet that signs the action
+const wallet = privateKeyToAccount("YOUR_PRIVATE_KEY");
+
+// Public Hyperliquid mainnet API (this method is not served by Chainstack)
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Deposit spot tokens from the main account into the sub-account
+const result = await exchange.subAccountSpotTransfer({
+  subAccountUser: "0xSUB_ACCOUNT_ADDRESS",
+  isDeposit: true,
+  token: "USDC:0xeb62eee3685fc4c43992febcd9e75443",
+  amount: "1",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-sub-account-transfer.mdx
+++ b/reference/hyperliquid-exchange-sub-account-transfer.mdx
@@ -49,6 +49,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -58,6 +60,45 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the main account wallet that owns the sub-account
+wallet = Account.from_key("YOUR_PRIVATE_KEY")
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Deposit \$1 USDC into the sub-account (usd is in raw units: dollars * 1e6)
+result = exchange.sub_account_transfer(
+    sub_account_user="0x0000000000000000000000000000000000000000",
+    is_deposit=True,
+    usd=1 * 1_000_000,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Load the main account wallet that owns the sub-account
+const wallet = privateKeyToAccount("0x...");
+
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Deposit \$1 USDC into the sub-account (usd is in raw units: dollars * 1e6)
+const result = await exchange.subAccountTransfer({
+  subAccountUser: "0x0000000000000000000000000000000000000000",
+  isDeposit: true,
+  usd: 1 * 1e6,
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-token-delegate.mdx
+++ b/reference/hyperliquid-exchange-token-delegate.mdx
@@ -49,6 +49,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -58,6 +60,48 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python hyperliquid-python-sdk
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Wallet that signs the EIP-712 action.
+wallet = Account.from_key("0x...")
+
+# Public Hyperliquid mainnet endpoint (this method is public-only).
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# wei is the amount in token units * 1e8; is_undelegate=False delegates.
+result = exchange.token_delegate(
+    validator="0x...",
+    wei=1 * 10**8,
+    is_undelegate=False,
+)
+print(result)
+```
+
+```typescript @nktkas/hyperliquid
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Wallet that signs the EIP-712 action.
+const wallet = privateKeyToAccount("0x...");
+
+// Public Hyperliquid mainnet endpoint (this method is public-only).
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// wei is the amount in token units * 1e8; isUndelegate: false delegates.
+const result = await exchange.tokenDelegate({
+  validator: "0x...",
+  wei: 1 * 1e8,
+  isUndelegate: false,
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-twap-cancel.mdx
+++ b/reference/hyperliquid-exchange-twap-cancel.mdx
@@ -48,6 +48,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -57,6 +59,56 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Public Hyperliquid mainnet endpoint (default transport)
+const wallet = privateKeyToAccount("0x..."); // viem or ethers account
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Cancel an active TWAP order by asset ID (a) and TWAP order ID (t)
+const result = await client.twapCancel({
+  a: 0, // asset index
+  t: 1, // TWAP order ID to cancel
+});
+
+console.log(result);
+```
+
+```python Python (hyperliquid-python-sdk)
+# Note: the official hyperliquid-python-sdk does not expose a twapCancel
+# helper yet, so build and post the signed action directly.
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import sign_l1_action, get_timestamp_ms
+import eth_account
+
+# Public Hyperliquid mainnet endpoint
+wallet = eth_account.Account.from_key("0x...")  # your private key
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+timestamp = get_timestamp_ms()
+action = {
+    "type": "twapCancel",
+    "a": 0,  # asset index
+    "t": 1,  # TWAP order ID to cancel
+}
+signature = sign_l1_action(
+    wallet,
+    action,
+    None,  # vault_address
+    timestamp,
+    None,  # expires_after
+    exchange.base_url == constants.MAINNET_API_URL,
+)
+result = exchange._post_action(action, signature, timestamp)
+print(result)
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-twap-order.mdx
+++ b/reference/hyperliquid-exchange-twap-order.mdx
@@ -52,6 +52,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -61,6 +63,38 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```typescript @nktkas/hyperliquid
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // viem or ethers
+const transport = new hl.HttpTransport(); // public Hyperliquid mainnet
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Place a TWAP order (twapOrder)
+const data = await client.twapOrder({
+  twap: {
+    a: 0, // asset index
+    b: true, // is buy
+    s: "1", // total size
+    r: false, // reduce only
+    m: 10, // duration in minutes (5–1440)
+    t: true, // randomize slice timing
+  },
+});
+
+console.log(data);
+```
+
+```python hyperliquid-python-sdk
+# The official hyperliquid-python-sdk does not expose a twapOrder exchange
+# action (no Exchange.twap_order method as of this SDK version). Use the curl
+# request above, or the @nktkas/hyperliquid TypeScript SDK, to place a TWAP order.
+# The Python SDK can read TWAP slice fills via Info.user_twap_slice_fills(...).
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-update-isolated-margin.mdx
+++ b/reference/hyperliquid-exchange-update-isolated-margin.mdx
@@ -99,7 +99,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -108,27 +108,44 @@ import eth_account
 account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
-# Add 100 USDC to isolated BTC position
-add_result = exchange.update_isolated_margin(
-    coin="BTC",
-    is_buy=True,
-    amount=100.0  # In USDC
-)
+# Add 100 USDC to the isolated BTC position
+add_result = exchange.update_isolated_margin(amount=100.0, name="BTC")
 
-# Remove 50 USDC from isolated position
-remove_result = exchange.update_isolated_margin(
-    coin="BTC",
-    is_buy=True,
-    amount=-50.0  # Negative for removal
-)
-
-# Set position to specific leverage
-leverage_result = exchange.top_up_isolated_margin(
-    coin="BTC",
-    target_leverage=5.0
-)
+# Remove 50 USDC from the isolated BTC position (negative for removal)
+remove_result = exchange.update_isolated_margin(amount=-50.0, name="BTC")
 
 print(add_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Add 100 USDC to the isolated position (ntli is the float amount * 1e6)
+const addResult = await exchange.updateIsolatedMargin({
+  asset: 0,
+  isBuy: true,
+  ntli: 100 * 1e6,
+});
+
+// Remove 50 USDC from the isolated position (negative for removal)
+const removeResult = await exchange.updateIsolatedMargin({
+  asset: 0,
+  isBuy: true,
+  ntli: -50 * 1e6,
+});
+
+// Set the position to 5x leverage by topping up isolated margin
+const leverageResult = await exchange.topUpIsolatedOnlyMargin({
+  asset: 0,
+  leverage: "5.0",
+});
+
+console.log(addResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-update-leverage.mdx
+++ b/reference/hyperliquid-exchange-update-leverage.mdx
@@ -77,7 +77,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -88,19 +88,45 @@ exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Update cross leverage for BTC to 10x
 update_result = exchange.update_leverage(
-    coin="BTC",
+    leverage=10,
+    name="BTC",
     is_cross=True,
-    leverage=10
 )
 
 # Update isolated leverage for ETH to 5x
 update_isolated = exchange.update_leverage(
-    coin="ETH",
+    leverage=5,
+    name="ETH",
     is_cross=False,
-    leverage=5
 )
 
 print(update_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Update cross leverage for asset 0 (BTC) to 10x
+const updateResult = await exchange.updateLeverage({
+  asset: 0,
+  isCross: true,
+  leverage: 10,
+});
+
+// Update isolated leverage for asset 1 (ETH) to 5x
+const updateIsolated = await exchange.updateLeverage({
+  asset: 1,
+  isCross: false,
+  leverage: 5,
+});
+
+console.log(updateResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-usd-send.mdx
+++ b/reference/hyperliquid-exchange-usd-send.mdx
@@ -98,7 +98,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -109,11 +109,29 @@ exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Send 100.5 USDC to another address
 transfer_result = exchange.usd_transfer(
+    amount=100.5,
     destination="0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
-    amount=100.5
 )
 
 print(transfer_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Send 100.5 USDC to another address
+const transferResult = await exchange.usdSend({
+  destination: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+  amount: "100.5",
+});
+
+console.log(transferResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-exchange-user-dex-abstraction.mdx
+++ b/reference/hyperliquid-exchange-user-dex-abstraction.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,44 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the wallet that signs the action.
+wallet = eth_account.Account.from_key("YOUR_PRIVATE_KEY")
+
+# Public Hyperliquid API (this method is public-only).
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+result = exchange.user_dex_abstraction(
+    user=wallet.address,
+    enabled=True,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Wallet that signs the action (viem or ethers).
+const wallet = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
+
+// Public Hyperliquid API (this method is public-only).
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+const result = await client.userDexAbstraction({
+  user: wallet.address,
+  enabled: true,
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-user-set-abstraction.mdx
+++ b/reference/hyperliquid-exchange-user-set-abstraction.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,46 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# The wallet that signs the EIP-712 action
+wallet = Account.from_key("0x...")  # your private key
+
+# Public Hyperliquid mainnet API (userSetAbstraction is public-only)
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Set the account abstraction mode for the user
+result = exchange.user_set_abstraction(
+    user=wallet.address,
+    abstraction="unifiedAccount",  # "unifiedAccount" | "portfolioMargin" | "disabled"
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// The wallet that signs the EIP-712 action
+const wallet = privateKeyToAccount("0x..."); // your private key
+
+// Public Hyperliquid mainnet API (userSetAbstraction is public-only)
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Set the account abstraction mode for the user
+const result = await exchange.userSetAbstraction({
+  user: wallet.address,
+  abstraction: "unifiedAccount", // "dexAbstraction" | "unifiedAccount" | "portfolioMargin" | "disabled"
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-validator-l1-stream.mdx
+++ b/reference/hyperliquid-exchange-validator-l1-stream.mdx
@@ -47,6 +47,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -56,6 +58,48 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+# hyperliquid-python-sdk has no typed validatorL1Stream wrapper, so build and
+# sign the L1 action with the same primitives its typed methods use internally.
+import eth_account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import sign_l1_action, get_timestamp_ms
+
+wallet = eth_account.Account.from_key("0x...")  # your validator key
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+action = {"type": "validatorL1Stream", "riskFreeRate": "0.05"}
+nonce = get_timestamp_ms()
+signature = sign_l1_action(
+    wallet,
+    action,
+    None,  # vault_address
+    nonce,
+    None,  # expires_after
+    exchange.base_url == constants.MAINNET_API_URL,
+)
+
+result = exchange._post_action(action, signature, nonce)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+const wallet = privateKeyToAccount("0x..."); // your validator key
+const transport = new HttpTransport(); // public mainnet
+const exchange = new ExchangeClient({ transport, wallet });
+
+const result = await exchange.validatorL1Stream({
+  riskFreeRate: "0.05",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-vault-transfer.mdx
+++ b/reference/hyperliquid-exchange-vault-transfer.mdx
@@ -49,6 +49,8 @@ Returns an object with the action status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell cURL
 curl -X POST https://api.hyperliquid.xyz/exchange \
   -H "Content-Type: application/json" \
@@ -58,6 +60,50 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
     "signature": {...}
   }'
 ```
+
+```python Python (hyperliquid-python-sdk)
+from eth_account import Account
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils import constants
+
+# Load the wallet that signs the action
+wallet = Account.from_key("0xYOUR_PRIVATE_KEY")
+
+# Public Hyperliquid mainnet API
+exchange = Exchange(wallet, constants.MAINNET_API_URL)
+
+# Deposit into the vault. usd is the amount in raw USD units (float * 1e6),
+# so 10 USDC is 10 * 1_000_000. Set is_deposit=False to withdraw.
+result = exchange.vault_usd_transfer(
+    vault_address="0x1719884eb866cb12b2287399b15f7db5e7d775ea",
+    is_deposit=True,
+    usd=10 * 1_000_000,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Wallet that signs the action
+const wallet = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
+
+// Public Hyperliquid mainnet API (default transport)
+const transport = new hl.HttpTransport();
+const client = new hl.ExchangeClient({ transport, wallet });
+
+// Deposit into the vault. usd is the amount in raw USD units (float * 1e6),
+// so 10 USDC is 10 * 1e6. Set isDeposit: false to withdraw.
+const result = await client.vaultTransfer({
+  vaultAddress: "0x1719884eb866cb12b2287399b15f7db5e7d775ea",
+  isDeposit: true,
+  usd: 10 * 1e6,
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Use case
 

--- a/reference/hyperliquid-exchange-withdraw.mdx
+++ b/reference/hyperliquid-exchange-withdraw.mdx
@@ -105,7 +105,7 @@ curl -X POST https://api.hyperliquid.xyz/exchange \
   }'
 ```
 
-```python Python
+```python Python (hyperliquid-python-sdk)
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
 import eth_account
@@ -115,12 +115,31 @@ account = eth_account.Account.from_key("0x...")
 exchange = Exchange(account, constants.MAINNET_API_URL)
 
 # Withdraw 100.5 USDC to Arbitrum
-withdrawal_result = exchange.withdraw_usdc(
+withdrawal_result = exchange.withdraw_from_bridge(
+    amount=100.5,
     destination="0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
-    amount=100.5
 )
 
 print(withdrawal_result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Initialize with your private key
+const wallet = privateKeyToAccount("0x...");
+
+const transport = new HttpTransport();
+const exchange = new ExchangeClient({ transport, wallet });
+
+// Withdraw 100.5 USDC to Arbitrum
+const withdrawalResult = await exchange.withdraw3({
+  destination: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+  amount: "100.5",
+});
+
+console.log(withdrawalResult);
 ```
 
 </CodeGroup>

--- a/reference/hyperliquid-info-activeassetdata.mdx
+++ b/reference/hyperliquid-info-activeassetdata.mdx
@@ -41,9 +41,11 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 * `availableToTrade` (array) — Available amounts to trade [long, short]
 * `markPx` (string) — Current mark price
 
-## cURL example
+## Example request
 
-```bash
+<CodeGroup>
+
+```bash Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{
@@ -53,6 +55,48 @@ curl -X POST \
   }' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python hyperliquid-python-sdk
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk exposes activeAssetData as a websocket
+# subscription, so keep the websocket manager running (do not pass skip_ws=True).
+info = Info("YOUR_CHAINSTACK_ENDPOINT")
+
+
+def on_active_asset_data(message):
+    print(message)
+
+
+info.subscribe(
+    {
+        "type": "activeAssetData",
+        "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+        "coin": "BTC",
+    },
+    on_active_asset_data,
+)
+```
+
+```typescript @nktkas/hyperliquid
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const data = await info.activeAssetData({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+  coin: "BTC",
+});
+
+console.log(data);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-all-borrow-lend-reserve-states.mdx
+++ b/reference/hyperliquid-info-all-borrow-lend-reserve-states.mdx
@@ -35,12 +35,43 @@ The response is an array of tuples, where each tuple contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "allBorrowLendReserveStates"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# hyperliquid-python-sdk has no dedicated wrapper for this type yet,
+# so post the request directly through the generic Info.post method.
+reserve_states = info.post("/info", {"type": "allBorrowLendReserveStates"})
+
+print(reserve_states)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const client = new InfoClient({ transport });
+
+const reserveStates = await client.allBorrowLendReserveStates();
+
+console.log(reserveStates);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-all-perp-metas.mdx
+++ b/reference/hyperliquid-info-all-perp-metas.mdx
@@ -35,12 +35,42 @@ The response is an array of objects, one per perp DEX, each containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "allPerpMetas"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# skip_ws=True avoids opening a WebSocket connection for this REST call
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The SDK has no dedicated allPerpMetas helper, so post the request directly.
+all_perp_metas = info.post("/info", {"type": "allPerpMetas"})
+print(all_perp_metas)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// apiUrl points the transport at a custom server (your Chainstack endpoint)
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const allPerpMetas = await info.allPerpMetas();
+console.log(allPerpMetas);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-allmids.mdx
+++ b/reference/hyperliquid-info-allmids.mdx
@@ -39,6 +39,8 @@ The response may also include internal index keys like `"@142"` alongside human�
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -48,6 +50,32 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# allMids is a public-only method — use the official Hyperliquid API URL.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Posts {"type": "allMids", "dex": ""} to /info
+mids = info.all_mids()
+print(mids)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// allMids is a public-only method — the default transport targets the official Hyperliquid API.
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// Posts {"type": "allMids"} to /info
+const mids = await info.allMids();
+console.log(mids);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-borrow-lend-reserve-state.mdx
+++ b/reference/hyperliquid-info-borrow-lend-reserve-state.mdx
@@ -42,12 +42,41 @@ The response is an object containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "borrowLendReserveState", "token": 0}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The Python SDK has no dedicated borrowLendReserveState method,
+# so post the request type directly through the shared post() helper.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+reserve_state = info.post("/info", {"type": "borrowLendReserveState", "token": 0})
+print(reserve_state)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const reserveState = await info.borrowLendReserveState({ token: 0 });
+console.log(reserveState);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-borrow-lend-user-state.mdx
+++ b/reference/hyperliquid-info-borrow-lend-user-state.mdx
@@ -37,12 +37,49 @@ The response is an object containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "borrowLendUserState", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The Python SDK has no dedicated borrowLendUserState wrapper, so post the
+# request type directly through the Info client.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+response = info.post(
+    "/info",
+    {
+        "type": "borrowLendUserState",
+        "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+    },
+)
+print(response)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const response = await info.borrowLendUserState({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(response);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-candle-snapshot.mdx
+++ b/reference/hyperliquid-info-candle-snapshot.mdx
@@ -54,6 +54,8 @@ Only the most recent 5000 candles are available. Older data beyond this limit is
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -68,6 +70,38 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+candles = info.candles_snapshot(
+    name="BTC",
+    interval="1h",
+    startTime=1754300000000,
+    endTime=1754400000000,
+)
+print(candles)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const candles = await client.candleSnapshot({
+  coin: "BTC",
+  interval: "1h",
+  startTime: 1754300000000,
+  endTime: 1754400000000,
+});
+console.log(candles);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-clearinghousestate.mdx
+++ b/reference/hyperliquid-info-clearinghousestate.mdx
@@ -76,12 +76,45 @@ Both `crossMarginSummary` and `marginSummary` contain:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "clearinghouseState", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python hyperliquid-python-sdk
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# user_state posts {"type": "clearinghouseState", "user": address}.
+state = info.user_state("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(state)
+```
+
+```typescript @nktkas/hyperliquid
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({
+  apiUrl: "YOUR_CHAINSTACK_ENDPOINT",
+});
+const info = new InfoClient({ transport });
+
+// clearinghouseState posts {"type": "clearinghouseState", "user": address}.
+const state = await info.clearinghouseState({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(state);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-delegations.mdx
+++ b/reference/hyperliquid-info-delegations.mdx
@@ -41,12 +41,41 @@ Each delegation object in the array contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "delegations", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+delegations = info.user_staking_delegations("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(delegations)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const delegations = await info.delegations({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(delegations);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-delegator-history.mdx
+++ b/reference/hyperliquid-info-delegator-history.mdx
@@ -136,12 +136,36 @@ The `delegate` object within `delta` contains:
 
 ## Example request
 
+<CodeGroup>
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "delegatorHistory", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+history = info.delegator_history("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(history)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const history = await client.delegatorHistory({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(history);
+```
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-delegator-rewards.mdx
+++ b/reference/hyperliquid-info-delegator-rewards.mdx
@@ -136,12 +136,40 @@ Each reward event contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "delegatorRewards", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# delegatorRewards is public-only, so use the Hyperliquid mainnet API URL
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+rewards = info.user_staking_rewards("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(rewards)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+// delegatorRewards is public-only, so use the default public transport
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const rewards = await client.delegatorRewards({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(rewards);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-delegator-summary.mdx
+++ b/reference/hyperliquid-info-delegator-summary.mdx
@@ -64,12 +64,41 @@ The response is an object containing a summary of the user's delegation status:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "delegatorSummary", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+summary = info.user_staking_summary("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(summary)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const summary = await info.delegatorSummary({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(summary);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-exchangestatus.mdx
+++ b/reference/hyperliquid-info-exchangestatus.mdx
@@ -46,12 +46,41 @@ The `universe` array provides comprehensive information about all tradeable asse
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "exchangeStatus"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk has no dedicated exchangeStatus wrapper,
+# so post the request type directly through the generic Info.post method.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+status = info.post("/info", {"type": "exchangeStatus"})
+print(status)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const status = await info.exchangeStatus();
+console.log(status);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-extraagents.mdx
+++ b/reference/hyperliquid-info-extraagents.mdx
@@ -58,12 +58,41 @@ The response is an array of agent objects:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "extraAgents", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+agents = info.extra_agents(user="0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(agents)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const client = new InfoClient({ transport });
+
+const agents = await client.extraAgents({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(agents);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-frontendopenorders.mdx
+++ b/reference/hyperliquid-info-frontendopenorders.mdx
@@ -67,12 +67,41 @@ The response is an array of open order objects with enhanced frontend-specific i
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "frontendOpenOrders", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+orders = info.frontend_open_orders("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(orders)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const orders = await info.frontendOpenOrders({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(orders);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-funding-history.mdx
+++ b/reference/hyperliquid-info-funding-history.mdx
@@ -128,6 +128,8 @@ Each funding rate record contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -138,6 +140,33 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Retrieve funding history for BTC from a given start time.
+funding = info.funding_history(name="BTC", startTime=1681923833000)
+print(funding)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+// Retrieve funding history for BTC from a given start time.
+const funding = await client.fundingHistory({
+  coin: "BTC",
+  startTime: 1681923833000,
+});
+console.log(funding);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-gossip-root-ips.mdx
+++ b/reference/hyperliquid-info-gossip-root-ips.mdx
@@ -32,12 +32,35 @@ The response is an array of IP addresses (strings) representing recently availab
 
 ## Example request
 
+<CodeGroup>
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "gossipRootIps"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# The Python SDK has no dedicated gossipRootIps helper, so post the request directly.
+root_ips = info.post("/info", {"type": "gossipRootIps"})
+print(root_ips)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const rootIps = await client.gossipRootIps();
+console.log(rootIps);
+```
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-historical-orders.mdx
+++ b/reference/hyperliquid-info-historical-orders.mdx
@@ -138,12 +138,38 @@ The `status` field indicates the final state of each order:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "historicalOrders", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+orders = info.historical_orders("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(orders)
+```
+
+```typescript TypeScript
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const orders = await info.historicalOrders({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(orders);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-l2-book.mdx
+++ b/reference/hyperliquid-info-l2-book.mdx
@@ -111,12 +111,38 @@ Each price level contains the following fields:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "l2Book", "coin": "ETH"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# l2_snapshot posts {"type": "l2Book", "coin": "ETH"}
+book = info.l2_snapshot("ETH")
+print(book)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// l2Book posts {"type": "l2Book", "coin": "ETH"}
+const book = await info.l2Book({ coin: "ETH" });
+console.log(book);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-leadingvaults.mdx
+++ b/reference/hyperliquid-info-leadingvaults.mdx
@@ -78,12 +78,52 @@ The response is an array of vault objects managed by the specified vault leader:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "leadingVaults", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk Info class has no dedicated leadingVaults
+# helper, so use its generic post method, which targets the same /info
+# endpoint and {"type": "leadingVaults"} request body as the curl above.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+leading_vaults = info.post(
+    "/info",
+    {
+        "type": "leadingVaults",
+        "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+    },
+)
+
+print(leading_vaults)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const leadingVaults = await info.leadingVaults({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+
+console.log(leadingVaults);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-liquidatable.mdx
+++ b/reference/hyperliquid-info-liquidatable.mdx
@@ -60,12 +60,45 @@ The response is an object containing liquidation status and risk metrics:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "liquidatable", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The Python SDK has no dedicated liquidatable() helper, so post the
+# request directly. Info.post() is the same primitive every typed
+# method wraps.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+result = info.post(
+    "/info",
+    {"type": "liquidatable", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"},
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const result = await info.liquidatable();
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-margin-table.mdx
+++ b/reference/hyperliquid-info-margin-table.mdx
@@ -38,12 +38,41 @@ The response is an object containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "marginTable", "id": 1}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk has no named method for the marginTable type,
+# so post the request body directly through the shared Info.post primitive.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+margin_table = info.post("/info", {"type": "marginTable", "id": 1})
+print(margin_table)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const marginTable = await info.marginTable({ id: 1 });
+console.log(marginTable);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-max-builder-fee.mdx
+++ b/reference/hyperliquid-info-max-builder-fee.mdx
@@ -52,12 +52,53 @@ The response is a single integer representing the maximum builder fee:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "maxBuilderFee", "user": "0x47fc45cebfc47cef07a09a98405b6ebaef00ef75", "builder": "0x1922810825c90f4270048b96da7b1803cd8609ef"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk has no dedicated maxBuilderFee helper,
+# so call the info endpoint directly with the generic post method.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+response = info.post(
+    "/info",
+    {
+        "type": "maxBuilderFee",
+        "user": "0x47fc45cebfc47cef07a09a98405b6ebaef00ef75",
+        "builder": "0x1922810825c90f4270048b96da7b1803cd8609ef",
+    },
+)
+
+print(response)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const maxBuilderFee = await info.maxBuilderFee({
+  user: "0x47fc45cebfc47cef07a09a98405b6ebaef00ef75",
+  builder: "0x1922810825c90f4270048b96da7b1803cd8609ef",
+});
+
+console.log(maxBuilderFee);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-maxmarketorderntls.mdx
+++ b/reference/hyperliquid-info-maxmarketorderntls.mdx
@@ -55,12 +55,40 @@ The response is an array of objects containing market order limits for each asse
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "maxMarketOrderNtls"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The SDK has no dedicated helper for this type, so post it directly.
+result = info.post("/info", {"type": "maxMarketOrderNtls"})
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const result = await info.maxMarketOrderNtls();
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-meta-and-asset-ctxs.mdx
+++ b/reference/hyperliquid-info-meta-and-asset-ctxs.mdx
@@ -149,12 +149,38 @@ The second element is an array of market data objects, one for each asset in the
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "metaAndAssetCtxs"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Posts {"type": "metaAndAssetCtxs"} to /info
+meta_and_asset_ctxs = info.meta_and_asset_ctxs()
+print(meta_and_asset_ctxs)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// Posts {"type": "metaAndAssetCtxs"} to /info
+const metaAndAssetCtxs = await info.metaAndAssetCtxs();
+console.log(metaAndAssetCtxs);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-meta.mdx
+++ b/reference/hyperliquid-info-meta.mdx
@@ -54,12 +54,43 @@ An array of margin tier configurations, where each entry is a tuple containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "meta"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# Point the SDK at your Chainstack endpoint; skip_ws avoids opening a websocket.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# Posts {"type": "meta"} to /info.
+meta = info.meta()
+print(meta)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// apiUrl points the transport at your Chainstack endpoint.
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+// Posts {"type": "meta"} to /info.
+const meta = await info.meta();
+console.log(meta);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-openorders.mdx
+++ b/reference/hyperliquid-info-openorders.mdx
@@ -57,12 +57,41 @@ The response is an array of open order objects, each containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "openOrders", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+open_orders = info.open_orders("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(open_orders)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const openOrders = await info.openOrders({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(openOrders);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-order-status.mdx
+++ b/reference/hyperliquid-info-order-status.mdx
@@ -135,12 +135,44 @@ The `status` field in the order response can have the following values:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "orderStatus", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b", "oid": 127244980388}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Query order status by order id (oid)
+order_status = info.query_order_by_oid(
+    "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+    127244980388,
+)
+print(order_status)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// Query order status by order id (oid)
+const orderStatus = await info.orderStatus({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+  oid: 127244980388,
+});
+console.log(orderStatus);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-outcomemeta.mdx
+++ b/reference/hyperliquid-info-outcomemeta.mdx
@@ -65,12 +65,44 @@ See the full guide at [Trading HIP-4 outcome markets on Hyperliquid](/docs/hyper
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "outcomeMeta"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# This endpoint is public-only, so use the default Hyperliquid mainnet API.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# The SDK has no typed wrapper for "outcomeMeta", so post the request directly.
+# Every typed Info method is a thin wrapper over this same post(...) call.
+outcome_meta = info.post("/info", {"type": "outcomeMeta"})
+
+print(outcome_meta["outcomes"])
+print(outcome_meta["questions"])
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+// This endpoint is public-only, so use the default public HTTP transport.
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const data = await client.outcomeMeta();
+
+console.log(data.outcomes);
+console.log(data.questions);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-perp-annotation.mdx
+++ b/reference/hyperliquid-info-perp-annotation.mdx
@@ -38,12 +38,41 @@ Returns an annotation object when the deployer has set metadata, or `null` if no
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpAnnotation", "coin": "xyz:GOLD"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk Info class has no dedicated perpAnnotation
+# helper, so post the request type directly with the low-level post method.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+annotation = info.post("/info", {"type": "perpAnnotation", "coin": "xyz:GOLD"})
+print(annotation)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const annotation = await info.perpAnnotation({ coin: "xyz:GOLD" });
+console.log(annotation);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-perp-categories.mdx
+++ b/reference/hyperliquid-info-perp-categories.mdx
@@ -39,12 +39,41 @@ The official Hyperliquid UI only displays categories from a predefined set in lo
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpCategories"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk has no dedicated perpCategories method,
+# so post the request type directly with the generic post helper.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+categories = info.post("/info", {"type": "perpCategories"})
+print(categories)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const client = new hl.InfoClient({ transport });
+
+const categories = await client.perpCategories();
+console.log(categories);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-perp-dex-status.mdx
+++ b/reference/hyperliquid-info-perp-dex-status.mdx
@@ -35,12 +35,40 @@ The response is an object containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpDexStatus", "dex": "xyz"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The SDK has no dedicated perpDexStatus helper, so post the request directly.
+result = info.post("/info", {"type": "perpDexStatus", "dex": "xyz"})
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const result = await info.perpDexStatus({ dex: "xyz" });
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-perpdeployauctionstatus.mdx
+++ b/reference/hyperliquid-info-perpdeployauctionstatus.mdx
@@ -47,12 +47,39 @@ The response is an object containing auction timing and gas information:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpDeployAuctionStatus"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+status = info.query_perp_deploy_auction_status()
+print(status)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const status = await info.perpDeployAuctionStatus();
+console.log(status);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-perpdexs.mdx
+++ b/reference/hyperliquid-info-perpdexs.mdx
@@ -49,12 +49,39 @@ For non-default DEXs, each object contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpDexs"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+perp_dexs = info.perp_dexs()
+print(perp_dexs)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const perpDexs = await info.perpDexs();
+console.log(perpDexs);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-perps-at-open-interest-cap.mdx
+++ b/reference/hyperliquid-info-perps-at-open-interest-cap.mdx
@@ -63,12 +63,41 @@ The response is an array of perpetual contract symbols that have reached their o
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "perpsAtOpenInterestCap"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# The hyperliquid-python-sdk has no dedicated wrapper for this info type,
+# so post the request directly through the Info client.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+perps_at_cap = info.post("/info", {"type": "perpsAtOpenInterestCap"})
+print(perps_at_cap)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const perpsAtCap = await info.perpsAtOpenInterestCap();
+console.log(perpsAtCap);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-portfolio.mdx
+++ b/reference/hyperliquid-info-portfolio.mdx
@@ -133,12 +133,40 @@ Each time period contains the following performance data:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "portfolio", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# This method is public-only, so it uses the default Hyperliquid mainnet API.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+portfolio = info.portfolio("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(portfolio)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// This method is public-only, so the default transport targets the public Hyperliquid API.
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const portfolio = await info.portfolio({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(portfolio);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-predicted-fundings.mdx
+++ b/reference/hyperliquid-info-predicted-fundings.mdx
@@ -82,12 +82,37 @@ Each asset entry contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "predictedFundings"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# The SDK has no dedicated predictedFundings helper, so post the request directly.
+predicted_fundings = info.post("/info", {"type": "predictedFundings"})
+print(predicted_fundings)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const predictedFundings = await info.predictedFundings();
+console.log(predictedFundings);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-recent-trades.mdx
+++ b/reference/hyperliquid-info-recent-trades.mdx
@@ -119,12 +119,37 @@ Each trade object contains the following fields:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "recentTrades", "coin": "BTC"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# The SDK has no dedicated recentTrades wrapper, so post the request directly.
+trades = info.post("/info", {"type": "recentTrades", "coin": "BTC"})
+print(trades)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const trades = await info.recentTrades({ coin: "BTC" });
+console.log(trades);
+```
+
+</CodeGroup>
 
 ## Use cases
 

--- a/reference/hyperliquid-info-referral.mdx
+++ b/reference/hyperliquid-info-referral.mdx
@@ -146,12 +146,40 @@ Each entry in `referralStates` contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "referral", "user": "0x1442ad477ded1b0028b57621aa7b6f7eadb8f568"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# type: "referral"
+referral = info.query_referral_state("0x1442ad477ded1b0028b57621aa7b6f7eadb8f568")
+print(referral)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// type: "referral"
+const referral = await info.referral({
+  user: "0x1442ad477ded1b0028b57621aa7b6f7eadb8f568",
+});
+console.log(referral);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-spot-meta-and-asset-ctxs.mdx
+++ b/reference/hyperliquid-info-spot-meta-and-asset-ctxs.mdx
@@ -105,3 +105,44 @@ Each market context object contains:
 * EVM contract details enable cross-chain asset tracking and arbitrage
 * Daily volumes reset at UTC midnight
 * Some tokens may have null full names or EVM contracts if not applicable
+
+## Example request
+
+<CodeGroup>
+
+```shell Shell
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"type": "spotMetaAndAssetCtxs"}' \
+  https://api.hyperliquid.xyz/info
+```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# spotMetaAndAssetCtxs is a public Hyperliquid method, so use the public mainnet API
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# Posts {"type": "spotMetaAndAssetCtxs"} to /info
+meta, asset_ctxs = info.spot_meta_and_asset_ctxs()
+
+print(meta["tokens"][0])
+print(asset_ctxs[0])
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// spotMetaAndAssetCtxs is a public Hyperliquid method, so use the default public transport
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+// Posts { type: "spotMetaAndAssetCtxs" } to /info
+const [meta, assetCtxs] = await info.spotMetaAndAssetCtxs();
+
+console.log(meta.tokens[0]);
+console.log(assetCtxs[0]);
+```
+
+</CodeGroup>

--- a/reference/hyperliquid-info-spot-pair-deploy-auction-status.mdx
+++ b/reference/hyperliquid-info-spot-pair-deploy-auction-status.mdx
@@ -38,12 +38,41 @@ The response is an object containing:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "spotPairDeployAuctionStatus"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The Python SDK has no dedicated helper for this request type,
+# so post the request body directly through the inherited client.
+status = info.post("/info", {"type": "spotPairDeployAuctionStatus"})
+print(status)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const status = await info.spotPairDeployAuctionStatus();
+console.log(status);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-spotclearinghousestate.mdx
+++ b/reference/hyperliquid-info-spotclearinghousestate.mdx
@@ -52,12 +52,45 @@ For example, if `total` is "14.625485" and `hold` is "0.0", then the available b
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "spotClearinghouseState", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# skip_ws=True keeps this to a single info HTTP call
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# Posts {"type": "spotClearinghouseState", "user": address}
+spot_state = info.spot_user_state("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(spot_state)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// apiUrl points the transport at your custom server
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+// Posts {"type": "spotClearinghouseState", "user": "0x..."}
+const spotState = await info.spotClearinghouseState({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(spotState);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-spotdeploystate.mdx
+++ b/reference/hyperliquid-info-spotdeploystate.mdx
@@ -79,12 +79,45 @@ Current auction parameters:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "spotDeployState", "user": "0x0000000000000000000000000000000000000000"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# Posts {"type": "spotDeployState", "user": user} to /info
+state = info.query_spot_deploy_auction_status(
+    "0x0000000000000000000000000000000000000000"
+)
+print(state)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+// Posts {"type": "spotDeployState", "user": user} to the info endpoint
+const state = await info.spotDeployState({
+  user: "0x0000000000000000000000000000000000000000",
+});
+console.log(state);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-spotmeta.mdx
+++ b/reference/hyperliquid-info-spotmeta.mdx
@@ -55,12 +55,39 @@ An array of spot trading pairs:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "spotMeta"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+spot_meta = info.spot_meta()
+print(spot_meta)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const spotMeta = await info.spotMeta();
+console.log(spotMeta);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-subaccounts.mdx
+++ b/reference/hyperliquid-info-subaccounts.mdx
@@ -86,12 +86,41 @@ The response is an array of sub-account objects with detailed information about 
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "subAccounts", "user": "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+sub_accounts = info.query_sub_accounts("0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036")
+print(sub_accounts)
+```
+
+```typescript TypeScript
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const subAccounts = await info.subAccounts({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+});
+console.log(subAccounts);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-token-details.mdx
+++ b/reference/hyperliquid-info-token-details.mdx
@@ -10,6 +10,53 @@ You can only use this endpoint on the official Hyperliquid public API. It is not
 
 The `info` endpoint with `type: "tokenDetails"` retrieves comprehensive information about a specific token on the Hyperliquid exchange. This endpoint provides detailed supply metrics, pricing data, deployment information, and circulation details for in-depth token analysis and portfolio management.
 
+## Example request
+
+<CodeGroup>
+
+```shell cURL
+curl -X POST https://api.hyperliquid.xyz/info \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "tokenDetails",
+    "tokenId": "0x6d1e7cde53ba9467b783cb7c530ce054"
+  }'
+```
+
+```python hyperliquid-python-sdk
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# tokenDetails has no dedicated method in hyperliquid-python-sdk,
+# so post the request body directly through the underlying client.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+token_details = info.post(
+    "/info",
+    {
+        "type": "tokenDetails",
+        "tokenId": "0x6d1e7cde53ba9467b783cb7c530ce054",
+    },
+)
+
+print(token_details)
+```
+
+```typescript @nktkas/hyperliquid
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport();
+const client = new hl.InfoClient({ transport });
+
+const tokenDetails = await client.tokenDetails({
+  tokenId: "0x6d1e7cde53ba9467b783cb7c530ce054",
+});
+
+console.log(tokenDetails);
+```
+
+</CodeGroup>
+
 <Visibility for="humans">
 <Check>
 **Get your own node endpoint today**

--- a/reference/hyperliquid-info-user-abstraction.mdx
+++ b/reference/hyperliquid-info-user-abstraction.mdx
@@ -33,12 +33,41 @@ The response is a string representing the user's abstraction configuration (e.g.
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userAbstraction", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+abstraction = info.query_user_abstraction_state("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(abstraction)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const abstraction = await info.userAbstraction({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(abstraction);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-dex-abstraction.mdx
+++ b/reference/hyperliquid-info-user-dex-abstraction.mdx
@@ -33,12 +33,41 @@ The response is a string representing the user's DEX abstraction configuration, 
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userDexAbstraction", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+result = info.query_user_dex_abstraction_state("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const result = await info.userDexAbstraction({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-fills-by-time.mdx
+++ b/reference/hyperliquid-info-user-fills-by-time.mdx
@@ -96,12 +96,46 @@ Each fill object contains the following fields:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userFillsByTime", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b", "startTime": 1754380000000, "endTime": 1754380200000}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# userFillsByTime is available on the public Hyperliquid API only
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+fills = info.user_fills_by_time(
+    "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+    1754380000000,  # startTime (ms)
+    1754380200000,  # endTime (ms)
+)
+print(fills)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+// userFillsByTime is available on the public Hyperliquid API only
+const transport = new hl.HttpTransport();
+const info = new hl.InfoClient({ transport });
+
+const fills = await info.userFillsByTime({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+  startTime: 1754380000000, // ms
+  endTime: 1754380200000, // ms
+});
+console.log(fills);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-fills.mdx
+++ b/reference/hyperliquid-info-user-fills.mdx
@@ -81,12 +81,38 @@ Each fill object contains the following fields:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userFills", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+fills = info.user_fills("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(fills)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const fills = await info.userFills({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(fills);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-funding.mdx
+++ b/reference/hyperliquid-info-user-funding.mdx
@@ -111,6 +111,8 @@ Each funding event contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -122,6 +124,36 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+result = info.user_funding_history(
+    user="0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+    startTime=1681923833000,
+    endTime=1681924833000,
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const result = await info.userFunding({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+  startTime: 1681923833000,
+  endTime: 1681924833000,
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
+++ b/reference/hyperliquid-info-user-non-funding-ledger-updates.mdx
@@ -164,6 +164,8 @@ Each ledger update event contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
@@ -175,6 +177,38 @@ curl -X POST \
   }' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+updates = info.user_non_funding_ledger_updates(
+    user="0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+    startTime=1681923833000,
+    endTime=1681924833000,
+)
+
+print(updates)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const updates = await info.userNonFundingLedgerUpdates({
+  user: "0x2ba553d9f990a3b66b03b2dc0d030dfc1c061036",
+  startTime: 1681923833000,
+  endTime: 1681924833000,
+});
+
+console.log(updates);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-role.mdx
+++ b/reference/hyperliquid-info-user-role.mdx
@@ -94,12 +94,43 @@ The response varies based on the user's role type. All responses include a `role
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userRole", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# Pass your full Chainstack endpoint as the base URL.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+result = info.user_role(user="0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// apiUrl points the transport at your full Chainstack endpoint.
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const result = await info.userRole({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(result);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-user-to-multi-sig-signers.mdx
+++ b/reference/hyperliquid-info-user-to-multi-sig-signers.mdx
@@ -58,12 +58,41 @@ The response is an array of signer addresses associated with the user's multi-si
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userToMultiSigSigners", "user": "0x3710f20c8a8b2781D878105Fbd61CC0c20fE0411"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+signers = info.query_user_to_multi_sig_signers("0x3710f20c8a8b2781D878105Fbd61CC0c20fE0411")
+print(signers)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const signers = await info.userToMultiSigSigners({
+  user: "0x3710f20c8a8b2781D878105Fbd61CC0c20fE0411",
+});
+console.log(signers);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-user-twap-slice-fills.mdx
+++ b/reference/hyperliquid-info-user-twap-slice-fills.mdx
@@ -136,12 +136,40 @@ The `fill` object contains comprehensive execution information:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userTwapSliceFills", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# This method is available only on the public Hyperliquid API.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+fills = info.user_twap_slice_fills("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(fills)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+// This method is available only on the public Hyperliquid API.
+const transport = new hl.HttpTransport();
+const info = new hl.InfoClient({ transport });
+
+const fills = await info.userTwapSliceFills({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(fills);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-userfees.mdx
+++ b/reference/hyperliquid-info-userfees.mdx
@@ -104,12 +104,41 @@ The response is a comprehensive object containing detailed fee information, sche
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userFees", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python hyperliquid-python-sdk
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+user_fees = info.user_fees("0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(user_fees)
+```
+
+```typescript @nktkas/hyperliquid
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const client = new InfoClient({ transport });
+
+const userFees = await client.userFees({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(userFees);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-userratelimit.mdx
+++ b/reference/hyperliquid-info-userratelimit.mdx
@@ -85,12 +85,41 @@ The response is an object containing comprehensive rate limit information for th
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userRateLimit", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+rate_limit = info.user_rate_limit(user="0x31ca8395cf837de08b24da3f660e77761dfb974b")
+print(rate_limit)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const rateLimit = await info.userRateLimit({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(rateLimit);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-uservaultequities.mdx
+++ b/reference/hyperliquid-info-uservaultequities.mdx
@@ -57,12 +57,41 @@ Each vault equity object contains:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "userVaultEquities", "user": "0x2b804617c6f63c040377e95bb276811747006f4b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+equities = info.user_vault_equities("0x2b804617c6f63c040377e95bb276811747006f4b")
+print(equities)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const equities = await info.userVaultEquities({
+  user: "0x2b804617c6f63c040377e95bb276811747006f4b",
+});
+console.log(equities);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-validator-l1-votes.mdx
+++ b/reference/hyperliquid-info-validator-l1-votes.mdx
@@ -73,12 +73,39 @@ The response is an array of validator voting information, including their L1 gov
 
 ## Example request
 
+<CodeGroup>
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "validatorL1Votes"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# hyperliquid-python-sdk has no typed helper for this type, so post the
+# raw info request through the generic API.post method.
+votes = info.post("/info", {"type": "validatorL1Votes"})
+print(votes)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const votes = await info.validatorL1Votes();
+console.log(votes);
+```
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-vault-details.mdx
+++ b/reference/hyperliquid-info-vault-details.mdx
@@ -156,12 +156,48 @@ The `relationship` object describes vault hierarchies:
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "vaultDetails", "vaultAddress": "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"}' \
   https://api.hyperliquid.xyz/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+# This endpoint is public-only, so use the default Hyperliquid mainnet URL.
+info = Info(constants.MAINNET_API_URL, skip_ws=True)
+
+# The SDK has no dedicated vaultDetails helper, so post the request directly.
+# This sends the same {"type": "vaultDetails", ...} body as the curl above.
+result = info.post(
+    "/info",
+    {
+        "type": "vaultDetails",
+        "vaultAddress": "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",
+    },
+)
+print(result)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// This endpoint is public-only, so use the default public transport.
+const transport = new HttpTransport();
+const info = new InfoClient({ transport });
+
+const result = await info.vaultDetails({
+  vaultAddress: "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",
+});
+console.log(result);
+```
+
+</CodeGroup>
 
 ## Example response
 

--- a/reference/hyperliquid-info-vaultsummaries.mdx
+++ b/reference/hyperliquid-info-vaultsummaries.mdx
@@ -70,12 +70,42 @@ The response is an array of vault summary objects containing the following field
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "vaultSummaries"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The SDK has no dedicated vaultSummaries helper, so post the request type directly.
+vault_summaries = info.post("/info", {"type": "vaultSummaries"})
+
+print(vault_summaries)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const vaultSummaries = await info.vaultSummaries();
+
+console.log(vaultSummaries);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 

--- a/reference/hyperliquid-info-web-data2.mdx
+++ b/reference/hyperliquid-info-web-data2.mdx
@@ -64,12 +64,43 @@ The response is a large object with user‑centric aggregates for frontend use (
 
 ## Example request
 
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "webData2"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# In the official Python SDK, webData2 is a WebSocket subscription,
+# not an HTTP info method, so the WebSocket manager must stay enabled.
+info = Info("YOUR_CHAINSTACK_ENDPOINT")
+
+user = "0x31ca8395cf837de08b24da3f660e77761dfb974b"
+info.subscribe({"type": "webData2", "user": user}, print)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import * as hl from "@nktkas/hyperliquid";
+
+const transport = new hl.HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const client = new hl.InfoClient({ transport });
+
+const data = await client.webData2({
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+console.log(data);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Use case
 

--- a/reference/hyperliquid-info-web-data3.mdx
+++ b/reference/hyperliquid-info-web-data3.mdx
@@ -36,12 +36,54 @@ The response is an object containing:
 
 ## Example request
 
+The Hyperliquid SDKs do not expose a dedicated `webData3` info method, so the examples below post the request through each SDK's generic info request path.
+
+<CodeGroup>
+
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"type": "webData3", "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# Skip the WebSocket connection for a one-off request.
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# No typed webData3 method exists, so post the raw request to /info.
+response = info.post(
+    "/info",
+    {
+        "type": "webData3",
+        "user": "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+    },
+)
+
+print(response)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport } from "@nktkas/hyperliquid";
+
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+
+// No typed webData3 method exists, so send the raw request to the info endpoint.
+const response = await transport.request("info", {
+  type: "webData3",
+  user: "0x31ca8395cf837de08b24da3f660e77761dfb974b",
+});
+
+console.log(response);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 


### PR DESCRIPTION
## What

Adds **multi-language SDK code examples** to **185 of 189 Hyperliquid method pages**, grounded in the SDKs builders actually use (Discord-confirmed).

- **HyperCore (info + exchange):** Shell curl + **Python (`hyperliquid-python-sdk`)** + **TypeScript (`@nktkas/hyperliquid`)**.
- **HyperEVM (`eth_*`):** Shell curl + **web3.py + ethers.js + viem** (latest idioms, no version pins). WebSocket-subscription pages use each library's WebSocket transport.

## Endpoint handling (per your steer)

- **curl tab** keeps the **real public docs endpoint** (quick checks) — byte-identical, never changed.
- **Chainstack-served methods (Case A):** code uses the placeholder **`YOUR_CHAINSTACK_ENDPOINT`** + a `<Note>` telling agents to use their own endpoint from console.chainstack.com (the `<Note>` flows into the agent `.md`).
- **Hyperliquid-public-only methods (Case B):** code uses the public `api.hyperliquid.xyz` (SDK defaults), no stub, no note.

## Verification

- Orchestrated (185 author agents across two runs) + a sampling adversarial critic.
- Info/EVM examples **verified live** (read-only requests returned 200); exchange (signing) **signature-checked against SDK source** (never executed — no real orders).
- All curls byte-identical; broken-links clean; SDK method names cross-checked against the cloned SDK source. Also fixed several pre-existing buggy Python snippets (wrong kwargs / non-existent methods).

## Not in this PR (flagged for follow-up)

- **`eth-subscribe-syncing`** — WebSocket-only, needs dedicated WS-syncing examples (deferred).
- **`aligned-quote-token-info`, `batch-clearinghouse-states`** — methods **error on the live endpoint** (match the coverage audit's "not in any canonical source" flag) — likely stale; need review/removal.
- **`perp-dex-limits`** — method errors (likely a missing param) — needs a fix.
- **4 missing methods** (`approvedBuilders`, `perpConciseAnnotations`, `settledOutcome`, `userOutcome`) — new pages to create from the SOTA spec (separate).
