### PR TITLE
docs(hyperliquid): fix 4 flagged HL method pages (syncing WS, perp-dex-limits, 2 deprecations)

### DIFF
--- a/openapi/hyperliquid_node_api/hypercore_info/info_aligned_quote_token_info.json
+++ b/openapi/hyperliquid_node_api/hypercore_info/info_aligned_quote_token_info.json
@@ -18,6 +18,7 @@
         ],
         "summary": "info (alignedQuoteTokenInfo)",
         "operationId": "infoAlignedQuoteTokenInfo",
+        "deprecated": true,
         "requestBody": {
           "required": true,
           "content": {

--- a/openapi/hyperliquid_node_api/hypercore_info/info_batch_clearinghouse_states.json
+++ b/openapi/hyperliquid_node_api/hypercore_info/info_batch_clearinghouse_states.json
@@ -18,6 +18,7 @@
         ],
         "summary": "info (batchClearinghouseStates)",
         "operationId": "infoBatchClearinghouseStates",
+        "deprecated": true,
         "requestBody": {
           "required": true,
           "content": {

--- a/openapi/hyperliquid_node_api/hypercore_info/info_perp_dex_limits.json
+++ b/openapi/hyperliquid_node_api/hypercore_info/info_perp_dex_limits.json
@@ -35,6 +35,7 @@
                   },
                   "dex": {
                     "type": "string",
+                    "minLength": 1,
                     "description": "Name of the builder-deployed perp DEX. The empty string is not allowed.",
                     "default": "xyz"
                   }
@@ -73,6 +74,8 @@
                       "description": "Array of [coin, oiCap] tuples giving the open interest cap per asset.",
                       "items": {
                         "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
                         "items": {
                           "type": "string"
                         }

--- a/openapi/hyperliquid_node_api/hypercore_info/info_perp_dex_limits.json
+++ b/openapi/hyperliquid_node_api/hypercore_info/info_perp_dex_limits.json
@@ -32,10 +32,16 @@
                     "enum": [
                       "perpDexLimits"
                     ]
+                  },
+                  "dex": {
+                    "type": "string",
+                    "description": "Name of the builder-deployed perp DEX. The empty string is not allowed.",
+                    "default": "xyz"
                   }
                 },
                 "required": [
-                  "type"
+                  "type",
+                  "dex"
                 ]
               }
             }
@@ -47,7 +53,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "totalOiCap": {
+                      "type": "string",
+                      "description": "Total open interest cap across the DEX."
+                    },
+                    "oiSzCapPerPerp": {
+                      "type": "string",
+                      "description": "Open interest size cap per perpetual."
+                    },
+                    "maxTransferNtl": {
+                      "type": "string",
+                      "description": "Maximum transfer notional amount."
+                    },
+                    "coinToOiCap": {
+                      "type": "array",
+                      "description": "Array of [coin, oiCap] tuples giving the open interest cap per asset.",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/reference/hyperliquid-evm-eth-subscribe-syncing.mdx
+++ b/reference/hyperliquid-evm-eth-subscribe-syncing.mdx
@@ -372,6 +372,88 @@ const monitor = new NodeHealthMonitor('wss://hyperliquid-mainnet.core.chainstack
 monitor.connect();
 ```
 
+## Example request
+
+`eth_subscribe("syncing")` runs over a WebSocket connection. After subscribing, the node sends a notification with the current state and then another on every change: `false` when fully synced, or an object with `startingBlock`, `currentBlock`, and `highestBlock` while syncing. The Shell tab uses `wscat` for a quick check; the Python, JavaScript, and TypeScript tabs use the WebSocket transport of each library.
+
+<CodeGroup>
+
+```shell wscat
+$ wscat -c wss://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/evm
+# Wait for the connection to be established
+
+Connected (press CTRL+C to quit)
+
+> {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["syncing"]}
+< {"jsonrpc":"2.0","id":1,"result":"0x4f9f6872aa4c474b686cf23e352b725c"}
+
+# A notification is sent immediately with the current state, then on every change.
+# When the node is fully synced:
+< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x4f9f6872aa4c474b686cf23e352b725c","result":false}}
+
+# When the node is syncing:
+< {"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x4f9f6872aa4c474b686cf23e352b725c","result":{"startingBlock":"0x0","currentBlock":"0x1234","highestBlock":"0x5678"}}}
+```
+
+```python web3.py
+import asyncio
+from web3 import AsyncWeb3, WebSocketProvider
+
+
+async def main():
+    async with AsyncWeb3(WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT")) as w3:
+        subscription_id = await w3.eth.subscribe("syncing")
+        print(f"Subscribed with ID: {subscription_id}")
+
+        async for message in w3.socket.process_subscriptions():
+            # result is False when synced, or a progress object while syncing
+            print(f"Sync status: {message['result']}")
+
+
+asyncio.run(main())
+```
+
+```javascript ethers.js
+import { WebSocketProvider } from "ethers";
+
+const provider = new WebSocketProvider("YOUR_CHAINSTACK_ENDPOINT");
+
+// ethers has no high-level "syncing" event, so listen on the underlying
+// WebSocket and send the eth_subscribe request directly.
+provider.websocket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data.toString());
+  if (message.method === "eth_subscription") {
+    // result is false when synced, or a progress object while syncing
+    console.log("Sync status:", message.params.result);
+  }
+});
+
+await provider.send("eth_subscribe", ["syncing"]);
+```
+
+```typescript viem
+import { createPublicClient, webSocket } from "viem";
+
+const client = createPublicClient({
+  transport: webSocket("YOUR_CHAINSTACK_ENDPOINT"),
+});
+
+// viem has no high-level syncing action, so use the transport's low-level subscribe.
+const { unsubscribe } = await client.transport.subscribe({
+  params: ["syncing"],
+  onData: (data) => {
+    // data.result is false when synced, or a progress object while syncing
+    console.log("Sync status:", data.result);
+  },
+});
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
+
 ## Use cases
 
 The `eth_subscribe("syncing")` method is essential for applications that need to:

--- a/reference/hyperliquid-info-aligned-quote-token-info.mdx
+++ b/reference/hyperliquid-info-aligned-quote-token-info.mdx
@@ -4,13 +4,13 @@ openapi: /openapi/hyperliquid_node_api/hypercore_info/info_aligned_quote_token_i
 description: "The info endpoint with type: \"alignedQuoteTokenInfo\" retrieves supply, rate, and pending payment information for an aligned quote token."
 ---
 
-<Info>
-This method is available on Chainstack. Not all Hyperliquid methods are available on Chainstack, as the open-source node implementation does not support them yet — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
-</Info>
+<Warning>
+**Removed by Hyperliquid (~June 2026).** The Hyperliquid API no longer recognizes the `alignedQuoteTokenInfo` request type — requests fail to deserialize — and the method has been dropped from the official SDKs. There is no direct replacement. For the aligned quote asset mechanism, see [Aligned quote assets](https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/aligned-quote-assets) in the Hyperliquid docs; for spot token metadata, see [tokenDetails](/reference/hyperliquid-info-token-details). This page is kept for reference.
+</Warning>
 
-The `info` endpoint with `type: "alignedQuoteTokenInfo"` retrieves supply, rate, and pending payment information for an aligned quote token. Aligned quote tokens are HIP-1 spot tokens that deployers have registered as collateral for HIP-3 perpetual DEXes through the CoreWriter contract on HyperEVM.
+The `info` endpoint with `type: "alignedQuoteTokenInfo"` returned supply, rate, and pending payment information for an aligned quote token. Aligned quote tokens are HIP-1 spot tokens that deployers had registered as collateral for HIP-3 perpetual DEXes through the CoreWriter contract on HyperEVM.
 
-Returns `null` if the token has not been registered as an aligned quote asset.
+It returned `null` if the token had not been registered as an aligned quote asset.
 
 <Visibility for="humans">
 <Check>

--- a/reference/hyperliquid-info-batch-clearinghouse-states.mdx
+++ b/reference/hyperliquid-info-batch-clearinghouse-states.mdx
@@ -4,11 +4,11 @@ openapi: /openapi/hyperliquid_node_api/hypercore_info/info_batch_clearinghouse_s
 description: "The info endpoint with type: \"batchClearinghouseStates\" retrieves perpetuals account summaries for multiple users in one call. On Hyperliquid info."
 ---
 
-<Info>
-You can only use this endpoint on the official Hyperliquid public API. It is not available through Chainstack, as the open-source node implementation does not support it yet. See [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
-</Info>
+<Warning>
+**Not available.** This batch method is not served by the public Hyperliquid API — requests return `null` for every address — and it is not available through Chainstack. To fetch perpetuals account state for multiple users, call [clearinghouseState](/reference/hyperliquid-info-clearinghousestate) once per address. Some third-party providers offer their own batch aggregators built on per-user calls. This page is kept for reference.
+</Warning>
 
-The `info` endpoint with `type: "batchClearinghouseStates"` retrieves perpetuals account summaries for multiple users in one call. Use this to efficiently fetch positions, margin usage, and account values across many addresses.
+The `info` endpoint with `type: "batchClearinghouseStates"` was intended to retrieve perpetuals account summaries for multiple users in one call — positions, margin usage, and account values across many addresses.
 
 <Visibility for="humans">
 <Check>

--- a/reference/hyperliquid-info-perp-dex-limits.mdx
+++ b/reference/hyperliquid-info-perp-dex-limits.mdx
@@ -8,7 +8,7 @@ description: "Reference for the perpDexLimits JSON-RPC method on the Hyperliquid
 This method is available on Chainstack. Not all Hyperliquid methods are available on Chainstack, as the open-source node implementation does not support them yet — see [Hyperliquid methods](/docs/hyperliquid-methods) for the full availability breakdown.
 </Info>
 
-The `info` endpoint with `type: "perpDexLimits"` retrieves the configuration limits for perpetual DEXes on Hyperliquid, including maximum number of assets and other deployment constraints.
+The `info` endpoint with `type: "perpDexLimits"` retrieves the market limits for a builder-deployed perpetual DEX on Hyperliquid — the total open interest cap, the per-perpetual open interest size cap, the maximum transfer notional, and the per-asset open interest caps.
 
 <Visibility for="humans">
 <Check>
@@ -25,30 +25,75 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 ### Request body
 
 * `type` (string, required) — The request type. Must be `"perpDexLimits"`.
+* `dex` (string, required) — The name of the builder-deployed perp DEX, for example `"xyz"`. The empty string is not allowed. Use [perpDexs](/reference/hyperliquid-info-perpdexs) to list deployed perp DEX names.
 
 ## Response
 
-The response contains the perp DEX deployment limits and configuration constraints.
+Returns a perp DEX limits object, or `null` if the DEX has no configured limits.
+
+* `totalOiCap` (string) — Total open interest cap across the DEX.
+* `oiSzCapPerPerp` (string) — Open interest size cap per perpetual.
+* `maxTransferNtl` (string) — Maximum transfer notional amount.
+* `coinToOiCap` (array) — Array of `[coin, oiCap]` tuples giving the open interest cap per asset.
 
 ## Example request
+
+<CodeGroup>
 
 ```shell Shell
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"type": "perpDexLimits"}' \
+  -d '{"type": "perpDexLimits", "dex": "xyz"}' \
   https://hyperliquid-mainnet.core.chainstack.com/4f8d8f4040bdacd1577bff8058438274/info
 ```
+
+```python Python (hyperliquid-python-sdk)
+from hyperliquid.info import Info
+
+# skip_ws=True avoids opening a WebSocket connection for this REST call
+info = Info("YOUR_CHAINSTACK_ENDPOINT", skip_ws=True)
+
+# The SDK has no dedicated perpDexLimits helper, so post the request directly.
+perp_dex_limits = info.post("/info", {"type": "perpDexLimits", "dex": "xyz"})
+print(perp_dex_limits)
+```
+
+```typescript TypeScript (@nktkas/hyperliquid)
+import { HttpTransport, InfoClient } from "@nktkas/hyperliquid";
+
+// apiUrl points the transport at a custom server (your Chainstack endpoint)
+const transport = new HttpTransport({ apiUrl: "YOUR_CHAINSTACK_ENDPOINT" });
+const info = new InfoClient({ transport });
+
+const perpDexLimits = await info.perpDexLimits({ dex: "xyz" });
+console.log(perpDexLimits);
+```
+
+</CodeGroup>
+
+<Note>
+**Use your own endpoint in your code.** The code examples use a placeholder Chainstack endpoint (YOUR_CHAINSTACK_ENDPOINT) — replace it with your own Hyperliquid node endpoint from the [Chainstack console](https://console.chainstack.com/). The curl above uses a shared public endpoint for quick checks only; do not use it in production.
+</Note>
 
 ## Example response
 
 ```json
-null
+{
+  "totalOiCap": "7000000000.0",
+  "oiSzCapPerPerp": "20000000000.0",
+  "maxTransferNtl": "3000000000.0",
+  "coinToOiCap": [
+    ["xyz:AAPL", "100000000.0"],
+    ["xyz:ALUMINIUM", "25000000.0"],
+    ["xyz:AMD", "100000000.0"]
+  ]
+}
 ```
 
 ## Use case
 
 The `info` endpoint with `type: "perpDexLimits"` is useful for:
 
-* Checking deployment constraints before deploying a new perp DEX
-* Understanding the maximum number of assets allowed per DEX
-* Building deployment tools that validate against current limits
+* Checking the open interest caps of a builder-deployed perp DEX before opening positions
+* Monitoring per-asset open interest caps on a perp DEX
+* Building risk and deployment tools that validate against current market limits


### PR DESCRIPTION
Follow-up to the SDK-examples pass (#461): the 4 pages that were flagged/reverted during that run, each handled per-page.

## Changes

**1. `perp-dex-limits` — fixed (was erroring)**
The method requires a `dex` param that the page omitted, so the documented curl returned *"Failed to deserialize the JSON body"*. Added the required `dex` (builder-deployed perp DEX name, e.g. `"xyz"`) to the curl and the OpenAPI spec, rewrote the intro/params/response to the real shape (open-interest caps), and added Python (`hyperliquid-python-sdk`) + TypeScript (`@nktkas/hyperliquid`) examples.
Verified live: curl, Python SDK, and nktkas all return identical data (`totalOiCap 7000000000.0`, 94 coins). Endpoint/host/key unchanged — only the request *body* gained the required param.

**2. `eth-subscribe-syncing` — added WebSocket examples**
Added the `## Example request` `<CodeGroup>` (wscat + web3.py + ethers + viem), matching the other `eth_subscribe` pages. ethers/viem have no high-level syncing helper, so those tabs use the underlying-socket / low-level transport subscribe. All four transports verified against the live endpoint (each subscribed and received the `result:false` notification).

**3. `aligned-quote-token-info` — deprecated in place**
Hyperliquid removed this info method (~Jun 2026; dropped in nktkas [#154](https://github.com/nktkas/hyperliquid/pull/154) "to align with the Hyperliquid API"). The live API no longer recognizes the type (every request fails to deserialize). No replacement exists. Replaced the misleading "available on Chainstack" note with a `<Warning>` pointing to the aligned-quote-assets concept + `tokenDetails`.

**4. `batch-clearinghouse-states` — deprecated in place**
Never an official public method (0 commits in nktkas or the official Python SDK across full history; absent from the official docs). The public API deserializes it but returns `null` for every address. Replaced the note with a `<Warning>` pointing to `clearinghouseState` (per-user).

## Why deprecate (not delete) the two dead methods
Both URLs still get traffic — `batch-clearinghouse-states` ~242 views/30d (207 from agents), `aligned-quote-token-info` ~19/30d (mostly agents). Deleting them 404s those hits and loses SEO; deprecating keeps the URL and converts every agent read from "here's a dead method" into correct guidance.

## Verification
- Endpoints/keys untouched (perp-dex-limits curl change is body-only).
- All examples run live (Python + nktkas + curl for perp-dex-limits; 4 WS transports for syncing).
- MDX tags balanced, internal links resolve, spec JSON valid, no `type:null`.