### PR TITLE
ci(llms-txt-sync): assign auto-sync PRs to akegaviar for notification

### DIFF
--- a/.github/workflows/llms-txt-sync.yml
+++ b/.github/workflows/llms-txt-sync.yml
@@ -84,9 +84,15 @@ jobs:
           # Create the PR if none is open; otherwise the force-push already updated it.
           if ! gh pr view "$BR" --json state --jq .state 2>/dev/null | grep -q OPEN; then
             gh pr create --base main --head "$BR" \
+              --assignee akegaviar \
               --title "chore: sync llms.txt" \
               --body "Automated regeneration of the nested llms.txt from docs.json (\`scripts/generate_llms_txt.py\`). Passed size/parse/page-count guards. Auto-merges once the Mintlify Deployment check passes."
           fi
+
+          # Ensure the PR is assigned (so the assignee is notified even if the PR
+          # already existed and was only refreshed by the force-push above).
+          gh pr edit "$BR" --add-assignee akegaviar \
+            || echo "::warning::Could not assign the PR to akegaviar."
 
           # Enable auto-merge. If the repo setting "Allow auto-merge" is off, this is a no-op
           # warning and the PR stays open for a manual one-click merge — the workflow still succeeds.


### PR DESCRIPTION
Follow-up to the HD-270 daily `llms.txt` auto-merge workflow.

**Problem:** the workflow opens its `auto/llms-txt-sync` PRs with no assignee, so they go unnoticed. Today's PR #464 (llms.txt drift from the new Hyperliquid pages) had to be spotted and merged manually.

**Change:** assign the PR to `akegaviar` on creation (`--assignee`) and on refresh (`--add-assignee`), so GitHub notifies on every auto-sync PR. Auto-merge (`--squash --auto`) is unchanged and still merges once the Mintlify Deployment check passes — assignment just guarantees a notification (and a clear owner for the rare case auto-merge is blocked, e.g. when Mintlify skips a build).

One-line-effective change inside the existing PR step; no schedule, guard, or generator changes.