### PR TITLE
docs(hyperliquid): sync methods table + tooling to current API and SDKs

### DIFF
--- a/docs/hyperliquid-debugging-signature-errors.mdx
+++ b/docs/hyperliquid-debugging-signature-errors.mdx
@@ -154,13 +154,13 @@ Hyperliquid L1 actions require signing with **chainId 1337**, but your wallet is
 
   ```typescript
   import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
-  import { PrivateKeySigner } from "@nktkas/hyperliquid/signing";
+  import { privateKeyToAccount } from "viem/accounts";
 
   // Agent wallet signs with chainId 1337 automatically
-  const agentSigner = new PrivateKeySigner({ privateKey: AGENT_PRIVATE_KEY });
+  const agentAccount = privateKeyToAccount(AGENT_PRIVATE_KEY);
   const client = new ExchangeClient({
     transport: new HttpTransport(),
-    wallet: agentSigner
+    wallet: agentAccount
   });
 
   // User's browser wallet only signs approveAgent (chainId 0x66eee)
@@ -220,7 +220,7 @@ For production applications, use this two-wallet pattern:
 
 ```typescript
 import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
-import { PrivateKeySigner } from "@nktkas/hyperliquid/signing";
+import { privateKeyToAccount } from "viem/accounts";
 
 // First: user approves agent via browser wallet (one-time)
 const agentAddress = await approveAgentWithBrowserWallet();
@@ -228,7 +228,7 @@ const agentAddress = await approveAgentWithBrowserWallet();
 // Then: agent handles all trading
 const agentClient = new ExchangeClient({
   transport: new HttpTransport(),
-  wallet: new PrivateKeySigner({ privateKey: agentPrivateKey })
+  wallet: privateKeyToAccount(agentPrivateKey)
 });
 
 // No chainId conflicts because browser wallet never signs L1 actions
@@ -240,7 +240,7 @@ Hyperliquid has two community TypeScript SDKs:
 
 | SDK | Maintainer | Features |
 |-----|------------|----------|
-| [@nktkas/hyperliquid](https://github.com/nktkas/hyperliquid) | nktkas | Full API coverage, PrivateKeySigner, viem/ethers support |
+| [@nktkas/hyperliquid](https://github.com/nktkas/hyperliquid) | nktkas | Full API coverage, viem/ethers wallet support |
 | [nomeida/hyperliquid](https://github.com/nomeida/hyperliquid) | nomeida | Simpler API, good for quick integrations |
 
 ### @nktkas/hyperliquid examples
@@ -256,7 +256,7 @@ npm install @nktkas/hyperliquid viem
 import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
 import { privateKeyToAccount } from "viem/accounts";
 
-const account = privateKeyToAccount("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+const account = privateKeyToAccount("0x..."); // your private key
 const client = new ExchangeClient({
   transport: new HttpTransport(),
   wallet: account
@@ -275,14 +275,14 @@ const result = await client.order({
 });
 ```
 
-```typescript With PrivateKeySigner (no viem dependency)
+```typescript With an ethers account
 import { ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
-import { PrivateKeySigner } from "@nktkas/hyperliquid/signing";
+import { Wallet } from "ethers";
 
-const signer = new PrivateKeySigner({ privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" });
+const wallet = new Wallet("0x..."); // your private key
 const client = new ExchangeClient({
   transport: new HttpTransport(),
-  wallet: signer
+  wallet
 });
 
 // Same API as with viem

--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -56,13 +56,16 @@ HyperEVM methods listed as `/evm` are also reachable on `/nanoreth`. See [Hyperl
 | perpDexStatus | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
 | spotPairDeployAuctionStatus | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
 | marginTable | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
-| alignedQuoteTokenInfo | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| gossipPriorityAuctionStatus | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| subAccounts2 | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| approvedBuilders | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| perpConciseAnnotations | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| settledOutcome | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
 | allMids | /info | HyperCore | Hyperliquid public RPC |
 | userFills | /info | HyperCore | Hyperliquid public RPC |
 | userFillsByTime | /info | HyperCore | Hyperliquid public RPC |
 | orderStatus | /info | HyperCore | Hyperliquid public RPC |
 | l2Book | /info | HyperCore | Hyperliquid public RPC |
-| batchClearinghouseStates | /info | HyperCore | Hyperliquid public RPC |
 | candleSnapshot | /info | HyperCore | Hyperliquid public RPC |
 | historicalOrders | /info | HyperCore | Hyperliquid public RPC |
 | userTwapSliceFills | /info | HyperCore | Hyperliquid public RPC |
@@ -81,6 +84,13 @@ HyperEVM methods listed as `/evm` are also reachable on `/nanoreth`. See [Hyperl
 | spotMetaAndAssetCtxs | /info | HyperCore | Hyperliquid public RPC |
 | outcomeMeta | /info | HyperCore | Hyperliquid public RPC |
 | tokenDetails | /info | HyperCore | Hyperliquid public RPC |
+| isVip | /info | HyperCore | Hyperliquid public RPC |
+| legalCheck | /info | HyperCore | Hyperliquid public RPC |
+| preTransferCheck | /info | HyperCore | Hyperliquid public RPC |
+| twapHistory | /info | HyperCore | Hyperliquid public RPC |
+| userBorrowLendInterest | /info | HyperCore | Hyperliquid public RPC |
+| userTwapSliceFillsByTime | /info | HyperCore | Hyperliquid public RPC |
+| validatorSummaries | /info | HyperCore | Hyperliquid public RPC |
 | order | /exchange | HyperCore | Hyperliquid public RPC |
 | cancel | /exchange | HyperCore | Hyperliquid public RPC |
 | cancelByCloid | /exchange | HyperCore | Hyperliquid public RPC |
@@ -121,6 +131,19 @@ HyperEVM methods listed as `/evm` are also reachable on `/nanoreth`. See [Hyperl
 | validatorL1Stream | /exchange | HyperCore | Hyperliquid public RPC |
 | noop | /exchange | HyperCore | Hyperliquid public RPC |
 | reserveRequestWeight | /exchange | HyperCore | Hyperliquid public RPC |
+| userOutcome | /exchange | HyperCore | Hyperliquid public RPC |
+| borrowLend | /exchange | HyperCore | Hyperliquid public RPC |
+| createVault | /exchange | HyperCore | Hyperliquid public RPC |
+| vaultModify | /exchange | HyperCore | Hyperliquid public RPC |
+| vaultDistribute | /exchange | HyperCore | Hyperliquid public RPC |
+| subAccountModify | /exchange | HyperCore | Hyperliquid public RPC |
+| setDisplayName | /exchange | HyperCore | Hyperliquid public RPC |
+| registerReferrer | /exchange | HyperCore | Hyperliquid public RPC |
+| finalizeEvmContract | /exchange | HyperCore | Hyperliquid public RPC |
+| gossipPriorityBid | /exchange | HyperCore | Hyperliquid public RPC |
+| linkStakingUser | /exchange | HyperCore | Hyperliquid public RPC |
+| stakingLinkDisableTradingUser | /exchange | HyperCore | Hyperliquid public RPC |
+| userPortfolioMargin | /exchange | HyperCore | Hyperliquid public RPC |
 | net_version | /evm | HyperEVM | <Icon icon="square-check" iconType="solid" /> |
 | web3_clientVersion | /evm | HyperEVM | <Icon icon="square-check" iconType="solid" /> |
 | eth_blockNumber | /evm | HyperEVM | <Icon icon="square-check" iconType="solid" /> |

--- a/docs/hyperliquid-tooling.mdx
+++ b/docs/hyperliquid-tooling.mdx
@@ -44,7 +44,7 @@ Use the SDK:
 <CodeGroup>
 ```typescript TypeScript
 import { InfoClient, ExchangeClient, HttpTransport } from "@nktkas/hyperliquid";
-import { PrivateKeySigner } from "@nktkas/hyperliquid/signing";
+import { privateKeyToAccount } from "viem/accounts";
 
 // Query market data (no authentication required)
 const info = new InfoClient({ transport: new HttpTransport() });
@@ -52,10 +52,10 @@ const meta = await info.meta();
 console.log(meta);
 
 // Trading operations (requires authentication)
-const signer = new PrivateKeySigner({ privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" });
+const wallet = privateKeyToAccount("0x..."); // viem or ethers account
 const exchange = new ExchangeClient({
   transport: new HttpTransport(),
-  wallet: signer
+  wallet
 });
 
 const result = await exchange.order({


### PR DESCRIPTION
Brings the Hyperliquid guide pages in line with this session's reference work and the current SDK APIs.

## `hyperliquid-methods.mdx` (availability table)
- **Adds the 25 methods** documented this session, with availability verified against **both** the Chainstack and public endpoints:
  - **Chainstack-served (✓):** `gossipPriorityAuctionStatus`, `subAccounts2`, `approvedBuilders`, `perpConciseAnnotations`, `settledOutcome`
  - **Hyperliquid public RPC:** 7 info (`isVip`, `legalCheck`, `preTransferCheck`, `twapHistory`, `userBorrowLendInterest`, `userTwapSliceFillsByTime`, `validatorSummaries`) + 13 exchange (`userOutcome`, `borrowLend`, `createVault`, `vaultModify`, `vaultDistribute`, `subAccountModify`, `setDisplayName`, `registerReferrer`, `finalizeEvmContract`, `gossipPriorityBid`, `linkStakingUser`, `stakingLinkDisableTradingUser`, `userPortfolioMargin`)
- **Removes 2 now-invalid rows:** `alignedQuoteTokenInfo` (was ✓, but Hyperliquid removed it — errors everywhere) and `batchClearinghouseStates` (was "public RPC", but returns `null` for every address). Their reference pages remain as deprecated tombstones.

## `hyperliquid-tooling.mdx` + `hyperliquid-debugging-signature-errors.mdx`
- The TypeScript examples imported `PrivateKeySigner` from `@nktkas/hyperliquid/signing`, which **nktkas removed in Feb 2026** — so they no longer compile. Replaced with the current `privateKeyToAccount` (viem) pattern, matching the nktkas README and the SDK examples shipped in #462/#463/#465.
- Reframed the "no viem dependency" example as an **ethers account** (`new Wallet(...)`), since that's the real no-viem alternative now.
- Dropped the stale "PrivateKeySigner" mention from the SDK feature table; swapped the hardcoded anvil test key for `"0x..."` placeholders.

Local `mint broken-links` passes.