### PR TITLE
docs(solana): refresh top trading-bot recipes (pump.fun→PumpSwap, Jupiter, Raydium)

### DIFF
--- a/docs/solana-creating-a-pumpfun-bot.mdx
+++ b/docs/solana-creating-a-pumpfun-bot.mdx
@@ -8,10 +8,10 @@ description: Build a fully coded Python bot that interacts directly with pump.fu
 </Frame>
 **TLDR**
 
-* This Python-based Solana bot monitors the pump.fun on-chain program to detect new tokens, automatically buys them, and optionally sells them soon after.
+* This Python-based Solana bot monitors the pump.fun on-chain program to detect new tokens, automatically buys them, and optionally sells them soon after. The same bot also supports [letsbonk.fun](https://letsbonk.fun) via a config switch.
 * It decodes transaction data using the pump.fun Anchor IDL, fetching token details like mint addresses and bonding curves.
-* Scripts for listening, buying, and selling combine into a main “trade” engine with optional flags (e.g., continuous trading or filtering by creator/token name).
-* Learning examples provide reference scripts on Anchor discriminators, price fetching, and subscribing to Solana websockets.
+* You configure one or more bot instances as `.yaml` files in the `bots/` directory (strategy, slippage, priority fees, exit rules) and run them with `pump_bot`.
+* Learning examples provide reference scripts on Anchor discriminators, price fetching, and subscribing to Solana websockets via `logsSubscribe`, `blockSubscribe`, and Geyser.
 
 The pump.fun project is generating millions of USD in fees and in the volume as evidenced by [pump.fun DefiLlama project page](https://defillama.com/protocol/pump#information).
 
@@ -41,103 +41,99 @@ It's very useful to know that the pump.fun program and all the associated accoun
 
 The other thing important to know is that the tokens created with pump.fun are 6 decimal tokens, which is different from the default Solana 9 decimal SPL tokens.
 
-The bot subscribes over WebSocket to a Solana mainnet RPC node and extracts all the newly minted coins created by the pump.fun main program ID: [6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P](https://solscan.io/account/6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P)
+The bot subscribes over WebSocket to a Solana mainnet RPC node and extracts all the newly minted coins created by the pump.fun main program ID [6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P](https://solscan.io/account/6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P). It can listen with `logsSubscribe` (supported by every provider), `blockSubscribe`, or a Geyser stream for the lowest latency.
 
-Once a new coin is minted, the bot buys the coin and then sells it — the behavior is dictated by a few flags. See the implementation and the additional details for a full description.
+Once a new coin is minted, the bot buys it and then exits according to your configured strategy. When a token's bonding curve completes, its liquidity graduates to PumpSwap—pump.fun's own AMM. You set the behavior per bot instance in a `.yaml` config file; see [Configure and run the bot](#configure-and-run-the-bot).
 
 ## Implementation
 
-The core of the bot consists of three components:
+The bot is installed and run with [uv](https://github.com/astral-sh/uv). Your secrets—RPC HTTP and WebSocket endpoints, the wallet private key, and optional Geyser credentials—go in a `.env` file, and each bot instance is a `.yaml` file in the `bots/` directory. The core logic has two paths: a listener that detects new tokens, and the buy/sell execution.
 
-* Listener script
-* Buy script
-* Sell script
+### Listener
 
-All of the three scripts are put together in the main `trade.py` implementation.
-
-### Listener script
-
-To be able to construct a buy transaction (and later on a sell transaction), the bot needs the global constants and the coin related variables.
-
-The global pump.fun and Solana system program & account addresses, as well things like RPC endpoints, slippage etc are set in the `config.py` file.
-
-The coin related variables that are necessary for constructing transactions are:
+To construct a buy (and later a sell) transaction, the bot needs the global program and account addresses plus the new token's variables:
 
 * `mint` — the created token address
-* `bondingCurve` — the bonding curve account created for the newly minted token; this is the account that defines the token price
-* `associatedBondingCurve` — the associated account that's holding the tokens that you buy and sell per the bonding curve token price information; the mechanism here is the default Solana one, which is the same thing as how you need an associated token account as a user to hold a token
+* `bondingCurve` — the bonding curve account for the new token; this account defines the token price
+* `associatedBondingCurve` — the associated token account that holds the tokens bought and sold against the bonding curve
 
-To get the three addresses all once (`mint`, `bondingCurve`, and `associatedBondingCurve`), the bot uses the [blockSubscribe | Solana](/reference/blocksubscribe-solana) method over WebSocket with full transaction details, filters out the transactions are 1) only related to the main pump.fun executable program `6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P` and 2) that only match the `create` instruction.
+The bot can obtain these addresses three ways, fastest last:
 
-Then from the those transactions, the bot extracts the required addresses.
+* **`logsSubscribe`** — subscribes to the pump.fun program logs and derives the `associatedBondingCurve` on the fly (it is a PDA of the `bondingCurve`, the token program, and the `mint`). This works on every provider and is the default path.
+* **`blockSubscribe`** — subscribes to full blocks filtered to the pump.fun program's `create` instruction and extracts the addresses. Reliable on Chainstack, but not every provider supports it.
+* **Geyser** — a gRPC stream for the lowest latency. See the [Geyser implementation guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) and [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
 
 <Note>
-  While `blockSubscribe` works for this use case, it has known stability issues with busy programs. For production bots and better performance, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883). See our [Geyser implementation guide](/docs/solana-listening-to-pumpfun-token-mint-using-geyser) and learn more about [Geyser](/docs/yellowstone-grpc-geyser-plugin).
+  Earlier versions of the bot relied on `blockSubscribe`, which has stability issues with busy programs and isn't available on every plan. The bot now defaults to `logsSubscribe` (deriving the associated bonding curve locally) and supports Geyser for production. See [Solana: Listening to pump.fun token mint using only logsSubscribe](/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe).
 </Note>
 
-### Buy script
+### Buy and sell
 
-The buy script takes the global pump.fun program & accounts and the system ones from `config.py` and the coin specific ones from the listener script.
-
-Then using the `mint` address and the end user address (from your private key), the bot creates an associated token account to be able to hold the tokens.
-
-Then the bot fetches the token price from the `bondingCurve` account.
-
-And then the bot does the purchase.
+Using the `mint` and your wallet address (from the private key in `.env`), the bot creates an associated token account to hold the token, fetches the price from the `bondingCurve` account, and submits the buy. The sell path is the reverse and simpler—it fetches the price and submits a sell.
 
 A couple of notes:
 
-* Here and in all other scripts, the [Anchor instruction discriminators](https://book.anchor-lang.com/anchor_bts/discriminator.html) are precalculated. See `learning-examples/calculate_discriminator.py`
-* There's a default 15 second cooldown period between getting the new token details and proceeding with creating an associated token account for it and the actual purchase. This cooldown is for the things to stabilize a bit, otherwise you might get errors. The Solana is so fast and the way we are retrieving the new token details (using the `blockSubscribe` method) is also up there in the speed league, so when it comes to doing the actual *write* transactions, not all of the data that we already have may have fully propagated across the cluster, so you might get an error as a result. Feel free to experiment with this cooldown setting.
+* The [Anchor instruction discriminators](https://book.anchor-lang.com/anchor_bts/discriminator.html) are precalculated. See `learning-examples/calculate_discriminator.py`.
+* `extreme_fast_mode` (in the bot config) skips the bonding-curve stabilization wait and the RPC price check and buys a fixed token amount directly—faster, but less precise. With it off, the bot waits and price-checks first so the new token's data has propagated across the cluster.
 
-### Sell script
+<Warning>
+pump.fun ships breaking on-chain program upgrades—for example, the [2026-04-28 fee-recipient change](https://github.com/pump-fun/pump-public-docs/blob/main/docs/BREAKING_FEE_RECIPIENT.md) altered the buy/sell account lists. When the program changes, account lists and IDLs must be updated, so always cross-check against a recent successful transaction and pull the latest from the repository before running.
+</Warning>
 
-The sell script is basically the buy script but in reverse and cropped and simpler, because it does not need to use the listener script, nor does it need to create an associated token account.
+## Configure and run the bot
 
-All the sell script does is fetch the price and execute a sell instruction.
+### Install
 
-### Trade script
+```shell
+git clone https://github.com/chainstacklabs/pump-fun-bot.git
+cd pump-fun-bot
+uv sync
+source .venv/bin/activate
+uv pip install -e .
+```
 
-The main script that you run the bot with is `trade.py`. This is the script that puts together the listener script, the buy script, and the sell script.
+### Configure
 
-### Logging
+Copy `.env.example` to `.env` and add your Solana RPC endpoints and wallet private key. Then edit or copy a `.yaml` template in `bots/`—each file is a separate bot instance. Key settings:
 
-The `trades` directory keeps the tab on your listens and trades:
+* `platform` — `"pump_fun"` (default) or `"lets_bonk"` to trade on [letsbonk.fun](https://letsbonk.fun) instead
+* `trade.buy_amount`, `trade.buy_slippage`, `trade.sell_slippage` — position size and slippage tolerance
+* `trade.exit_strategy` — `"time_based"`, `"tp_sl"` (take-profit/stop-loss), or `"manual"`
+* `trade.extreme_fast_mode` — skip the price check and buy a fixed token amount for speed
+* `priority_fees` — `enable_fixed` with a `fixed_amount`, or `enable_dynamic` (estimates via `getRecentPrioritizationFees`); see [Solana: priority fees for faster transactions](/docs/solana-how-to-priority-fees-faster-transactions)
+* `filters` — restrict trading to tokens matching a name/symbol or created by a specific address
+* `geyser` — endpoint and auth token for the Geyser listener
 
-* Each token that pops up as part of your listener script is saved as a token address txt file
-* The `trades.log` is an appendable file that adds each of your trades (buy/sell), along with the token address and a time stamp.
+### Run
+
+```shell
+# Run as the installed package
+pump_bot
+
+# Or run directly
+uv run src/bot_runner.py
+```
+
+Each enabled bot in `bots/` runs as its own instance, so you can run several strategies at once.
+
+<Note>
+This bot is for learning, not production. Also by Chainstack: [pumpfun-cli](https://github.com/chainstacklabs/pumpfun-cli) (a terminal client for trading, launching, and managing tokens, with smart routing between the bonding curve and PumpSwap) and [pumpclaw](https://github.com/chainstacklabs/pumpclaw) (an agent skill that lets AI assistants like Claude Code and Cursor operate pumpfun-cli).
+</Note>
 
 ## Learning examples
 
-There are numerous scripts and other data in the `learning-examples` directory that should help you understand how the bot is constructed and how to interact with Solana in general, so be sure to check it out.
+The `learning-examples` directory has many scripts for understanding how the bot works and how to interact with Solana. Highlights:
 
-Examples:
+* `listen-new-tokens/listen_logsubscribe_abc.py` — snipes new tokens using only `logsSubscribe`, deriving the associated bonding curve on the fly (no extra `getTransaction` call)
+* `listen-new-tokens/compare_listeners.py` — runs the listener methods side by side to see which detects new tokens first
+* `bonding-curve-progress/get_bonding_curve_status.py` — checks whether a token's bonding curve is still active or has completed
+* `listen-migrations/listen_logsubscribe.py` — detects graduations to PumpSwap; see [Listening to pump.fun migrations to PumpSwap](/docs/solana-listening-to-pumpfun-migrations-to-raydium)
+* `compute_associated_bonding_curve.py` — derives the associated bonding curve PDA for a token
+* `calculate_discriminator.py` — calculates Anchor instruction discriminators from the IDL in `idl/`
+* `pumpswap/` — manual buy and sell examples against the PumpSwap AMM
+* `manual_buy.py` / `manual_sell.py` — manual buy and sell with parameters you provide
 
-* `blockSubscribe_extract_transactions.py` — connects over WebSocket, subscribes with [blockSubscribe | Solana](/reference/blocksubscribe-solana), and dumps all the extracted transactions in raw form to the `learning-examples/blockSubscribe-transactions` directory
-* `calculate_discriminator.py` — calculates the unique discriminator as part of the [Anchor framework](https://book.anchor-lang.com/anchor_bts/discriminator.html) for the pump.fun instructions. The instructions themselves can be taken from the `idl/pump_fun_idl.json` file
-* `fetch_price.py` — a full implementation of doing a `getAccountInfo` call to a token's bonding curve address and then decoding the response
-* `decode_from_blockSubscribe.py` — decodes the raw transactions extracted with the `blockSubscribe` method
-* `decode_from_getAccountInfo.py` — decodes the raw response from the `getAccountInfo` call to a token's bonding curve address; this is how you fetch the token price
-* `listen_create_from_blocksubscribe.py` — this is basically `blockSubscribe_extract_transactions.py` but with all the additional parsing to keep printing the newly minted token data to you
-* `listen_new_direct.py` — uses [logsSubscribe | Solana](/reference/logssubscribe-solana) to print the parsed token data from the pump.fun program logs; this is here as an example but it is not used in our bot as the logs do not emit the `associatedBondingCurve` address
-* `listen_new_portal.py` — just an example of getting the newly minted token data stream from a third-party API like pumpportal; not used in our bot
-* `manual_buy.py` — a manual buy script; you provide all the necessary parameters
-* `manual_sell.py` — a manual sell script; you provide all the necessary parameters
-
-## Fun flags
-
-You can run the `trade.py` script, which is the bot itself, with a few flags:
-
-* `--yolo` — keeps the bot running in continuous mode; the bot buys a token, sells the token 20 seconds later, and then buys a new one
-* `--match` — trades the tokens with names or symbols matching this string you provide
-* `--bro` — only buys and sells the tokens created by a certain user address
-* `--marry` — makes the script buy a token and never sell
-
-You can also combine the flags, for example running:
-
-`python trade.py --match doge --bro 7YmjpX4sPPw9pq6P2hrq9LehAi6QjELPWZYKXRrLaLCB --marry`
-
-will only buy the tokens that have `doge` in the name or description, created by the user `7YmjpX4sPPw9pq6P2hrq9LehAi6QjELPWZYKXRrLaLCB` and never sell the tokens.
+The IDLs in `idl/` are vendored from [pump-fun/pump-public-docs](https://github.com/pump-fun/pump-public-docs); refresh them from there when the program changes.
 
 <CardGroup>
   <Card title="Ake">

--- a/docs/solana-creating-a-pumpfun-bot.mdx
+++ b/docs/solana-creating-a-pumpfun-bot.mdx
@@ -117,7 +117,7 @@ uv run src/bot_runner.py
 Each enabled bot in `bots/` runs as its own instance, so you can run several strategies at once.
 
 <Note>
-This bot is for learning, not production. Also by Chainstack: [pumpfun-cli](https://github.com/chainstacklabs/pumpfun-cli) (a terminal client for trading, launching, and managing tokens, with smart routing between the bonding curve and PumpSwap) and [pumpclaw](https://github.com/chainstacklabs/pumpclaw) (an agent skill that lets AI assistants like Claude Code and Cursor operate pumpfun-cli).
+This bot is for learning, not production. Also by Chainstack: [pumpfun-cli](https://github.com/chainstacklabs/pumpfun-cli) (a terminal client for trading, launching, and managing tokens, with smart routing between the bonding curve and PumpSwap) and [pumpclaw](https://github.com/chainstacklabs/pumpclaw) (an agent skill that lets AI assistants like Claude Code and Codex operate pumpfun-cli).
 </Note>
 
 ## Learning examples

--- a/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
+++ b/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
@@ -60,7 +60,7 @@ Do not pass program IDs (Jupiter, Raydium, pump.fun, etc.) to this method. Progr
 </Warning>
 
 <CodeGroup>
-  ```solidity solidity
+  ```shell Shell
   curl --request POST \
        --url YOUR_SOLANA_ENDPOINT \
        --header 'accept: application/json' \
@@ -218,7 +218,7 @@ SOLANA_RPC="YOUR_HTTPS_CHAINSTACK_URL"
 Once the `.env` file is set up, you can load environment variables in your TypeScript code (e.g., `main.ts`), import the `dotenv` package, and load the environment variables at the beginning of your script:
 
 <CodeGroup>
-  ```tsx tsx
+  ```typescript TypeScript
   import "dotenv/config";
   ```
 </CodeGroup>
@@ -228,7 +228,7 @@ This will load the environment variables from the `.env` file into the `process.
 **Access environment variables**: You can now access the environment variables in your code like this:
 
 <CodeGroup>
-  ```tsx tsx
+  ```typescript TypeScript
   const rpcUrl = process.env.SOLANA_RPC;
   ```
 </CodeGroup>
@@ -249,7 +249,7 @@ Now that we have set up the project, installed the required packages, and config
 2. Paste the following code into the `main.ts` file:
 
 <CodeGroup>
-  ```solidity solidity
+  ```typescript TypeScript
   import { Connection, PublicKey } from '@solana/web3.js';
   import 'dotenv/config';
 

--- a/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
+++ b/docs/solana-how-to-perform-token-swaps-using-the-raydium-sdk.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Solana: How to perform token swaps using the Raydium SDK"
-description: "Perform Solana token swaps with Raydium SDK and Chainstack. Learn TypeScript implementation, pool configuration, transaction handling, and SOL to USDC swaps."
+title: "Solana: How to perform token swaps using Raydium"
+description: "Swap tokens on Solana with Raydium's Trade API and Chainstack in TypeScript — get a quote, set priority fees, then build, sign, and send a SOL to USDC swap with versioned transactions."
 ---
 
 <Frame>
@@ -8,22 +8,21 @@ description: "Perform Solana token swaps with Raydium SDK and Chainstack. Learn 
 </Frame>
 
 **TLDR:**
-* Using the Raydium SDK on Solana allows you to swap tokens efficiently while leveraging OpenBook’s order book for ample liquidity.
-* This TypeScript project sets up the Solana Connection (with your own node endpoint), loads trimmed pool data, and constructs a transaction for a token pair (e.g., SOL → USDC).
-* Configuration lives in `swapConfig.ts` for easy adjustments (e.g., token amounts, slippage, versioned transaction usage).
-* You can simulate swaps first or execute them immediately, with built-in transaction logging and debugging.
+* Raydium is a leading Solana AMM. Its hosted **Trade API** quotes and builds a swap for you, routing across Raydium's pool types (AMM v4, CPMM, CLMM) so you don't manage pool data yourself.
+* The flow: fetch a priority fee, get a quote, build the transaction, then sign it with `@solana/web3.js` and send it through your own Solana node.
+* This guide swaps SOL → USDC in TypeScript using a Chainstack Solana node for the broadcast.
+
+<Warning>
+The old Raydium SDK v1 (`@raydium-io/raydium-sdk`) is end-of-life — its repository was archived in June 2025 and it never supported CPMM or CLMM pools. For new code, use the current [Trade API](https://docs.raydium.io/raydium/build/developer-guides/overview) shown here (simplest for a basic swap), or the [`@raydium-io/raydium-sdk-v2`](https://github.com/raydium-io/raydium-sdk-V2) library for on-chain control. The canonical examples are in [raydium-sdk-V2-demo](https://github.com/raydium-io/raydium-sdk-V2-demo).
+</Warning>
 
 ## Main article
 
-The Solana blockchain is at the forefront of DeFi, known for its remarkable speed and cost-efficiency. This has positioned Solana as a highly sought-after platform for users and developers interested in DeFi activities.
+The Solana blockchain is at the forefront of DeFi, known for its speed and cost-efficiency. Central to this ecosystem is Raydium, an automated market maker (AMM) that provides deep liquidity across several pool types — legacy AMM v4, constant-product CPMM, and concentrated-liquidity CLMM.
 
-Central to this ecosystem's appeal is Raydium, an automated market maker (AMM) that integrates seamlessly with OpenBook's central order book, enabling quick and cost-effective token transactions. Raydium's integration with Solana facilitates immediate swaps with minimal slippage and maintains liquidity at optimal levels.
-
-In this guide, we'll walk you through using the Raydium SDK and Solana Chainstack nodes to swap tokens in TypeScript.
+You don't need to know which pool a pair trades in. Raydium's **Trade API** computes the best route across all of them, returns a quote, and builds a ready-to-sign transaction. This guide walks through a SOL → USDC swap in TypeScript, signing and broadcasting through a Chainstack Solana node.
 
 ## Prerequisites
-
-Before diving into the token-swapping process using the Raydium SDK on Solana, ensuring you have everything needed for a smooth experience is key. Here's a quick rundown of what you'll need beforehand and how to set everything up:
 
 ### Deploy a Chainstack Solana node
 
@@ -35,280 +34,104 @@ Deploy a [Solana RPC endpoint on Chainstack](https://chainstack.com/build-better
   <Card title="View node access and credentials" href="/docs/manage-your-node#view-node-access-and-credentials" icon="angle-right" horizontal />
 </CardGroup>
 
-### Prerequisites
+### Local setup
 
-* **Node.js**: Make sure you have [Node.js](https://nodejs.org/en/download/current) (version 18 or above) installed on your machine. Node.js is essential for running the scripts and managing the dependencies of the Raydium SDK.
-* **Yarn**: Yarn is a fast, reliable, secure dependency management tool. It is used to install the necessary dependencies for this project. After installing Node.js, install Yarn by running **`npm install --global yarn`** in your terminal.
-* **Solana wallet**: A Solana wallet with some SOL is necessary to cover the swap’s transaction fees.
+* [Node.js](https://nodejs.org/en/download/current) 18 or above (for the global `fetch` used below)
+* A Solana wallet with some SOL to cover the swap and fees
 
-## Setting up the GitHub repository
-
-This project is organized into various scripts, including utility functions and configuration settings, all stored within a GitHub repository. To begin exploring the project, you can clone the repository onto your local machine. This step guarantees you have all the necessary files and scripts.
-
-<Info>
-  Explore the Github repository: [Raydium SDK Swap Example](https://github.com/chainstacklabs/raydium-sdk-swap-example-typescript)
-</Info>
-
-First, open your terminal and run the following command to clone the repository:
+Install the dependencies:
 
 <CodeGroup>
   ```shell Shell
-  git clone https://github.com/chainstacklabs/raydium-sdk-swap-example-typescript.git
+  npm install @solana/web3.js bs58
   ```
 </CodeGroup>
 
-After cloning, hop onto the project’s directory with:
+## Implementation
+
+The Trade API exposes two hosts: `https://api-v3.raydium.io` for general data (including the priority-fee endpoint) and `https://transaction-v1.raydium.io` for the swap compute and build endpoints. The flow is fetch fee → quote → build → sign → send.
+
+```typescript raydium_swap.ts
+import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js'
+import bs58 from 'bs58'
+
+// Your Chainstack Solana node and wallet
+const RPC_ENDPOINT = 'YOUR_CHAINSTACK_SOLANA_NODE'
+const PRIVATE_KEY = 'YOUR_PRIVATE_KEY' // base58-encoded
+
+const SWAP_HOST = 'https://transaction-v1.raydium.io'
+const BASE_HOST = 'https://api-v3.raydium.io'
+
+const INPUT_MINT = 'So11111111111111111111111111111111111111112'  // SOL
+const OUTPUT_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' // USDC
+const AMOUNT = 1_000_000   // 0.001 SOL, in lamports
+const SLIPPAGE_BPS = 50    // 0.5%
+const TX_VERSION = 'V0'
+
+async function swap() {
+  const connection = new Connection(RPC_ENDPOINT, 'confirmed')
+  const wallet = Keypair.fromSecretKey(bs58.decode(PRIVATE_KEY))
+
+  // 1) Priority fee tiers from Raydium (vh / h / m).
+  const { data: fee } = await (await fetch(`${BASE_HOST}/main/auto-fee`)).json()
+  const computeUnitPriceMicroLamports = String(fee.default.h) // 'h' = high tier
+
+  // 2) Quote — Raydium routes across its pool types for you.
+  const swapResponse = await (
+    await fetch(
+      `${SWAP_HOST}/compute/swap-base-in?inputMint=${INPUT_MINT}&outputMint=${OUTPUT_MINT}` +
+        `&amount=${AMOUNT}&slippageBps=${SLIPPAGE_BPS}&txVersion=${TX_VERSION}`,
+    )
+  ).json()
+  console.log(`Quote: ${AMOUNT} -> ${swapResponse.data.outputAmount} (out)`)
+
+  // 3) Build the swap transaction. wrapSol because the input is native SOL.
+  const { data: txs } = await (
+    await fetch(`${SWAP_HOST}/transaction/swap-base-in`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        computeUnitPriceMicroLamports,
+        swapResponse,
+        txVersion: TX_VERSION,
+        wallet: wallet.publicKey.toBase58(),
+        wrapSol: true,
+        unwrapSol: false,
+      }),
+    })
+  ).json()
+
+  // 4) Deserialize, sign, and send each returned transaction through your node.
+  for (const { transaction } of txs) {
+    const tx = VersionedTransaction.deserialize(Buffer.from(transaction, 'base64'))
+    tx.sign([wallet])
+    const sig = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: true })
+    console.log(`Sent: https://solscan.io/tx/${sig}`)
+  }
+}
+
+swap()
+```
+
+Run it with a TypeScript runner such as [`tsx`](https://www.npmjs.com/package/tsx):
 
 <CodeGroup>
   ```shell Shell
-  cd raydium-sdk-swap-example-typescript
+  npx tsx raydium_swap.ts
   ```
 </CodeGroup>
 
-Next, install the project dependencies. These dependencies are libraries and tools you need to have the project run correctly. In this tutorial we use Yarn, a fast and reliable package manager, to handle these installations. Run the following command to install the necessary dependencies:
-
-<CodeGroup>
-  ```shell Shell
-  yarn
-  ```
-</CodeGroup>
-
-## Project structure and environment setup
-
-The heart of this project lies within the `src` directory, which holds all the executable scripts and necessary configurations for token swapping. Additionally, you'll need a `.env` file in the project's root directory. This file is crucial as it holds sensitive information that enables the project to interact with the Solana blockchain and perform operations securely.
-
-### Configuring environment variables
-
-To set up your environment variables, you'll need to create a `.env` file at the root of your project. This file should include your Solana RPC URL and your wallet's private key. These variables are essential for connecting to the Solana network and executing transactions. Follow these steps:
-
-1. Create a new file named `.env` in the root directory of the project.
-
-2. Open the `.env` file in a text editor and add the following lines, replacing `YOUR_CHAINSTACK_SOLANA_NODE` and `YOUR_PRIVATE_KEY` with your actual Solana RPC URL and wallet's private key:
-
-   <CodeGroup>
-     ```shell Shell
-     RPC_URL=YOUR_CHAINSTACK_SOLANA_NODE
-     WALLET_PRIVATE_KEY=YOUR_PRIVATE_KEY
-     ```
-   </CodeGroup>
-Alternatively, the project has a `.env.example` file, which you can rename to `.env` , and update with your details accordingly.
-
-### Trim Raydium's mainnet.json
-
-Raydium's mainnet.json file that has metadata on all the liquidity pools is the file that we need but it's huge — almost 500 MB. This is the file that the project would first need to download and then load into memory to perform the swap. That alone takes minutes, so use a trimmed version that only has the metadata pertaining to your swap and not the entirety of all the available pools.
-
-Here's how to get the trimmed mainnet.json version used in the project:
-
-1. In the project root, run:
-   <CodeGroup>
-     ```shell Shell
-     wget https://api.raydium.io/v2/sdk/liquidity/mainnet.json
-     ```
-   </CodeGroup>
-2. Set the tokenA and tokenB in `src/swapConfig.ts`.
-3. Run the script that takes the token pair from `src/swapConfig.ts`, looks for the respective liquidity pair in `mainnet.json` and produces `trimmed_mainnet.json`, which contains only the data pertaining to the tokens that you need.
-
-Now you can move further to perform the swap.
-
-## Explore the code
-
-The project's source code is divided into three TypeScript files, each with its distinct purpose within the Raydium SDK swapping process. Let's dive into what each file contributes to the project:
-
-### The `RaydiumSwap.ts` file
-
-`RaydiumSwap.ts` defines the `RaydiumSwap` class that encapsulates the functionality for performing token swaps using Raydium on the Solana blockchain.
-
-This file includes functions to:
-
-* Load the Raydium SDK.
-* Connect to the Solana blockchain using the RPC URL from the environment variables you have set.
-* Construct and send swap transactions using the Raydium SDK.
-* Handle errors and transaction confirmations.
-
-Here is an overview of its components:
-
-#### Constructor
-
-* Initializes the Solana `Connection` with a commitment level to `confirmed` for transaction finality.
-* Creates a `Wallet` instance using a provided private key to sign transactions and interact with the blockchain.
-
-#### `loadPoolKeys`
-
-This asynchronous method fetches the liquidity pool information from a given JSON configuration file and stores it within the class. This information is crucial as it includes the details of the various liquidity pools available on Raydium, which are needed to perform swaps.
-
-#### `findPoolInfoForTokens`
-
-This method searches for and returns the liquidity pool information for a specified token pair, facilitating the swap between them. It relies on the data loaded by `loadPoolKeys`.
-
-#### `getSwapTransaction`
-
-* An asynchronous method that builds a swap transaction based on the input parameters, such as the token to receive, the amount to swap, and the liquidity pool to use. Depending on the `useVersionedTransaction` flag, it can create either a legacy `Transaction` or a `VersionedTransaction`.
-* It first calculates the minimum amount out and amount in for the swap, considering the slippage and pool liquidity.
-* After calculating the swap amounts, it creates a transaction instruction using `Liquidity.makeSwapInstructionSimple`.
-
-#### `sendLegacyTransaction` and `sendVersionedTransaction`
-
-These asynchronous methods are responsible for sending the respective types of transactions to the network. They also manage transaction configurations, skipping preflight checks and setting maximum retry limits.
-
-#### `simulateLegacyTransaction` and `simulateVersionedTransaction`
-
-These asynchronous methods allow for the simulation of the respective types of transactions. This can be useful for testing to ensure the transaction will likely succeed before sending it to the blockchain.
-
-#### `calcAmountOut`
-
-An asynchronous method that performs the swap calculations, determining the expected and minimum amount out, execution price, and associated fees based on the current state of the liquidity pool.
-
-#### Exporting the class
-
-At the end of the file, the `RaydiumSwap` class is exported, making it available for import in other application parts.
-
-This file is key for abstracting the complexities of swap operations. The Raydium SDK communicates directly with the Solana blockchain, preparing and executing transactions that swap tokens within the specified liquidity pools.
-
-### The`index.ts` file
-
-`index.ts` is the entry point script that combines the functionality implemented in `RaydiumSwap.ts` and the configuration specified in `swapConfig.ts` to perform or simulate a token swap. Below is the functionality provided by each segment of the script:
-
-#### Swap initialization
-
-An instance of `RaydiumSwap` is created to establish a connection to the Solana blockchain and prepare the wallet for transaction signing.
-
-#### Pool key loading
-
-It invokes `loadPoolKeys` from the `RaydiumSwap` instance to retrieve the necessary information from Raydium's liquidity pools.
-
-#### Pool information retrieval
-
-The script locates the specific liquidity pool required for the token swap using the `findPoolInfoForTokens` method, which uses the token addresses from the `swapConfig`.
-
-#### Transaction preparation
-
-A transaction for the swap is built using the `getSwapTransaction` method, passing in parameters such as the destination token address, the amount to swap, the retrieved pool information, and additional configuration like the maximum lamports for transaction fees and whether to use a versioned transaction.
-
-#### Execution or simulation
-
-Based on the `swapConfig`, the script executes the swap on the blockchain or simulates it to forecast the outcome without sending the transaction.
-
-#### Transaction handling
-
-* If executing the swap, it sends the transaction through the appropriate method (`sendVersionedTransaction` or `sendLegacyTransaction`). It logs the transaction ID, which can be used to track the transaction on a Solana blockchain explorer like Solscan.
-* If simulating, it simulates the corresponding method (`simulateVersionedTransaction` or `simulateLegacyTransaction`) and logs the results, which can help debug or test before live execution.
-
-#### Swap invocation
-
-Finally, the `swap` function is called to initiate the swap process.
-
-This script is a high-level workflow that dictates the swap process from start to finish, abstracting the lower-level details and ensuring that the user-facing process is streamlined and straightforward.
-
-### The `swapConfig.ts` file
-
-The `swapConfig.ts` file holds the configuration settings for a token swap using the Raydium SDK on the Solana blockchain. This is where you set the parameters used throughout the swap process. Let’s detail the contents and role of each configuration option.
-
-This configuration file exports an object `swapConfig` containing key-value pairs that define the parameters of the swap operation:
-
-#### `executeSwap`
-
-A boolean that determines whether to send the transaction (`true`) or to simulate it (`false`). This is useful for testing the swap process without committing real funds.
-
-#### `useVersionedTransaction`
-
-A boolean indicating whether to use Solana's `VersionedTransaction` format. This new transaction format can include additional metadata and is meant to be more future-proof.
-
-#### `tokenAAmount`
-
-The amount of the source token (in this case, SOL) that you wish to swap. The value `0.01` indicates that the swap will attempt to exchange 0.01 SOL.
-
-#### `tokenAAddress`
-
-The address of the source token, which is the token you are giving up in the swap, is set to the mint address of SOL, the native currency of the Solana blockchain.
-
-#### `tokenBAddress`
-
-The address of the destination token is the token you want to receive. In this example, the mint address corresponds to USDC.
-
-#### `maxLamports`
-
-The maximum number of lamports (the smallest unit of SOL) that you are willing to spend on transaction fees.
-
-#### `direction`
-
-Indicates the fixed side of the swap—`in` means that the `tokenAAmount` is the exact amount you will send, while `out` means it's the exact amount you wish to receive.
-
-#### `maxRetries`
-
-The number of retries allowed.
-
-#### `liquidityFile`
-
-The URL to a JSON file containing information about the available liquidity pools on Raydium. This is essential for the `RaydiumSwap` class to load pool keys and find the right pool for the swap.
-
-## How to use the project
-
-To use this program for swapping tokens on the Solana blockchain with the Raydium SDK, follow these steps:
-
-### Configuration
-
-1. Open `src/swapConfig.ts` in your favorite code editor.
-
-2. Modify the `swapConfig` object to set up your desired swap parameters:
-
-   * `executeSwap`: Set this to `false` if you wish to simulate the transaction before executing or `true` to execute the swap immediately. It’s set on the simulation by default.
-   * `useVersionedTransaction`: Determine whether to use a versioned transaction (`true`) or a legacy transaction (`false`). Versioned transactions are the new standard and are recommended.
-   * `tokenAAmount`: Specify the amount of the source token you wish to swap. For example, `0.01` if you're swapping 0.01 SOL.
-   * `tokenAAddress`: Enter the source token's mint address. By default, it's set to SOL's mint address.
-   * `tokenBAddress`: Enter the mint address of the destination token. The default is set to USDC's mint address.
-   * `maxLamports`: Define the maximum fee you will pay for the transaction, which is measured in lamports.
-   * `direction`: Choose `'in'` to fix the amount of the source token or `'out'` to fix the amount of the destination token.
-   * `liquidityFile`: This should point to the Raydium liquidity pool information file. It's preset to the Raydium liquidity pools.
-
-### Execution
-
-With your swap configuration set:
-
-1. Navigate to your terminal.
-
-2. Ensure you're in the root directory of the cloned repository.
-
-3. Run the swap script using Yarn:
-
-   <CodeGroup>
-     ```shell Shell
-     yarn swap
-     ```
-   </CodeGroup>
-
-### Process flow
-
-When you run `yarn swap`, the program will:
-
-* Load the necessary pool keys from Raydium's API based on your liquidity file URL.
-
-* Use the token addresses from `swapConfig` to identify the appropriate liquidity pool.
-
-* Create a transaction with the specified parameters, ready to swap the defined `tokenAAmount` of `tokenAAddress` for `tokenBAddress`.
-
-* Depending on your `executeSwap` configuration, the program will either:
-
-  * Simulate the transaction and output the results in the console for review.
-  * Execute the swap transaction on the Solana blockchain and provide a transaction ID for tracking.
-
-### Transaction tracking
-
-If you execute the swap, you can track the transaction on a Solana blockchain explorer using the provided transaction ID. For example:
-
-<CodeGroup>
-  ```shell Shell
-  https://solscan.io/tx/YOUR_TRANSACTION_ID
-  ```
-</CodeGroup>
-
-<Info>
-  You can see an example of a swap completed with this program on [Solscan](https://solscan.io/tx/5QNkWNrjxjuZaGPKHwTD7topj7jzgqdCLpyXY8q8vAQE1e3VmWZAmymwo8sS5h8NXfLByEWbFS7FdnzDQZLwqHxG).
-</Info>
+### How it works
+
+* **Priority fee.** `GET /main/auto-fee` returns suggested compute-unit prices in three tiers — `vh` (very high), `h` (high), and `m` (medium). Pass the chosen tier as `computeUnitPriceMicroLamports` in the build request; Raydium adds the compute-budget instructions for you.
+* **Quote.** `GET /compute/swap-base-in` takes the input/output mints, the input `amount` (in the input token's smallest unit), and `slippageBps`. `swap-base-in` means you fix the input amount; use `swap-base-out` to fix the output amount instead. Raydium returns the best route and the expected `outputAmount`.
+* **Build.** `POST /transaction/swap-base-in` returns one or more base64 transactions. Set `wrapSol: true` when the input is native SOL (it wraps to WSOL) and `unwrapSol: true` when the output is SOL. For SPL-to-SPL swaps, pass your input/output token account addresses.
+* **Versioned transactions.** With `txVersion: 'V0'`, Raydium returns `VersionedTransaction`s; deserialize, sign, and broadcast each through your node. The build can return more than one transaction (for example, when an account needs to be created first), so loop over all of them.
+
+<Note>
+For on-chain control instead of the hosted API — building the swap locally, managing pool state, or working with a specific pool — use [`@raydium-io/raydium-sdk-v2`](https://github.com/raydium-io/raydium-sdk-V2) and its `raydium.cpmm.swap` / `raydium.liquidity.swap` modules. See the [raydium-sdk-V2-demo](https://github.com/raydium-io/raydium-sdk-V2-demo) `src/api/swap.ts` (API path) and `src/cpmm/swap.ts` (on-chain path).
+</Note>
 
 ## Conclusion
 
-In this guide, we navigated the process of executing token swaps on Solana with the Raydium SDK. From setting up the environment to understanding the codebase, we covered the essentials needed to jumpstart your DeFi activities on one of the fastest blockchains.
-
-We walked through the cloning of the repository, installing dependencies, and dissecting the purpose of each TypeScript file, giving you the clarity to configure and execute swaps with ease. The `swapConfig.ts` empowers you to fine-tune swap parameters, while `RaydiumSwap.ts` and `index.ts` facilitate the execution and simulation of swaps, complete with transaction tracking capabilities.
-
-By the end of this tutorial, you've gained the ability to conduct token swaps confidently, making the most of Solana's rapid and cost-effective ecosystem. This foundation sets you up for continued growth and exploration in the vibrant landscape of decentralized finance.
+Raydium's Trade API gets you a working Solana swap with minimal code: it handles routing and pool selection, and hands you a transaction to sign and send through your own node. From here you can fix the output amount with `swap-base-out`, swap arbitrary SPL pairs by supplying token accounts, or drop down to `@raydium-io/raydium-sdk-v2` when you need on-chain control. Pair it with a Chainstack Solana node for reliable, low-latency broadcasting.

--- a/docs/solana-how-to-priority-fees-faster-transactions.mdx
+++ b/docs/solana-how-to-priority-fees-faster-transactions.mdx
@@ -29,7 +29,7 @@ The higher the compute units required for a transaction, the more fees will be p
 
 This project aims to provide a practical demonstration of how to implement priority fees in Solana transactions. The code showcases a simple Solana transaction that transfers SOL from one account to another with the addition of a priority fee.
 
-By leveraging the Compute Budget Program's `setComputeUnitLimit` and `setComputeUnitPrice` functions, the example shows how to modify the compute unit limit for the transaction and set a specific compute unit price, effectively attaching a priority fee.
+The example uses the Compute Budget Program's `setComputeUnitPrice` to set a compute unit price, which attaches the priority fee. In production, pair it with `setComputeUnitLimit` to cap the compute units — the priority fee is `compute_unit_price × compute_unit_limit`, so an accurate limit (ideally sized from a transaction simulation) both improves landing and avoids overpaying.
 
 ## Prerequisites
 
@@ -47,7 +47,7 @@ Deploy a [reliable Solana RPC endpoint](https://chainstack.com/build-better-with
 
 ### Set up your environment
 
-* **Node.js**: Make sure your machine has Node.js (version 18 or higher) installed. Node.js is a prerequisite for running the scripts and managing the dependencies of the Raydium SDK.
+* **Node.js**: Make sure your machine has Node.js (version 18 or higher) installed. Node.js is a prerequisite for running the scripts and managing the project's dependencies.
 * **npm**: The Node Package Manager (npm) is the default package manager for Node.js projects. It will be used to install the necessary dependencies for this project. npm comes pre-installed with Node.js, so you don't need to install it separately.
 * **Solana wallet**: You'll need a Solana wallet with SOL.
 
@@ -171,7 +171,7 @@ PRIVATE_KEY="YOUR_PRIVATE_KEY"
 Once the `.env` file is set up, you can load environment variables in your TypeScript code (e.g., `main.ts`), import the `dotenv` package, and load the environment variables at the beginning of your script:
 
 <CodeGroup>
-  ```tsx tsx
+  ```typescript TypeScript
   import "dotenv/config";
   ```
 </CodeGroup>
@@ -181,7 +181,7 @@ This will load the environment variables from the `.env` file into the `process.
 **Access environment variables**: You can now access the environment variables in your code like this:
 
 <CodeGroup>
-  ```tsx tsx
+  ```typescript TypeScript
   const rpcUrl = process.env.SOLANA_RPC;
   const wsUrl = process.env.SOLANA_WSS;
   const privateKey = process.env.PRIVATE_KEY;
@@ -321,7 +321,7 @@ After familiarizing ourselves with the code, it's time to execute a Solana trans
 You can adjust the recipient, the priority fee rate, and the transfer amount by modifying these lines:
 
 <CodeGroup>
-  ```jsx jsx
+  ```typescript TypeScript
   // Config priority fee and amount to transfer
   const PRIORITY_RATE = 25000; // Adjust the priority fee rate in micro-lamports here
 
@@ -343,7 +343,7 @@ To execute the script after setting up your desired parameters, run the followin
 This will initiate the transaction with the applied priority fee, logging the process to the console. The output will resemble the following:
 
 <CodeGroup>
-  ```jsx jsx
+  ```shell Shell
   $ ts-node main.ts
 
 Connected to Solana RPC at https://solana-mainnet.core.chainstack.

--- a/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
+++ b/docs/solana-listening-to-pumpfun-migrations-to-raydium.mdx
@@ -1,13 +1,17 @@
 ---
-title: "Solana: Listening to pump.fun migrations to Raydium"
-description: Track pump.fun token migrations to Raydium liquidity pools in real time using Solana WebSocket subscriptions and log parsing through Chainstack nodes.
+title: "Solana: Listening to pump.fun migrations to PumpSwap"
+description: Track pump.fun token graduations to the PumpSwap AMM (formerly Raydium) in real time using Solana WebSocket subscriptions and on-chain event parsing through Chainstack nodes.
 ---
 
 **TLDR:**
-* pump.fun tokens start on a bonding curve and later migrate to Raydium for traditional AMM trading.
-* Use the `check_boding_curve_status.py` script to see if a token’s curve is still active or completed.
-* Use the `listen_to_raydium_migration.py` script to track live migration events by decoding relevant on-chain transactions.
-* These tools help you adapt trading strategies when tokens move from pump.fun’s bonding curve to Raydium liquidity pools.
+* pump.fun tokens start on a bonding curve and, once it completes, **graduate to PumpSwap** — pump.fun's own AMM (program `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`).
+* Before March 2025, graduated tokens migrated to Raydium. pump.fun launched PumpSwap on Mar 20, 2025, and graduations have gone there ever since — Raydium is now a rare legacy path.
+* Use `get_bonding_curve_status.py` to check whether a token's curve is still active or completed.
+* Use `listen_logsubscribe.py` (logsSubscribe on the migration program) or `listen_programsubscribe.py` (programSubscribe on the PumpSwap program) to track live graduations.
+
+<Warning>
+This guide previously covered migration to **Raydium**. On **March 20, 2025** pump.fun launched its own AMM, [PumpSwap](https://x.com/pumpdotfun/status/1902762309950292010), and graduated tokens now migrate to PumpSwap instead of Raydium. The bonding-curve mechanics and the migration program are the same; only the destination AMM changed. The old Raydium listener is kept in the repository as `listen_blocksubscribe_old_raydium.py` for reference.
+</Warning>
 
 ## Main article
 
@@ -15,14 +19,16 @@ For the full pump.fun bot, see [Solana: Creating a trading and sniping pump.fun 
 
 See also [Solana: Listening to pump.fun token mint using only logsSubscribe](/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe).
 
-This article is an add-on for two scripts:
+This article is an add-on for these scripts in the [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot):
 
 <CardGroup>
   <Card title="get_bonding_curve_status.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/bonding-curve-progress/get_bonding_curve_status.py" icon="angle-right" horizontal />
   <Card title="listen_logsubscribe.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/listen-migrations/listen_logsubscribe.py" icon="angle-right" horizontal />
+  <Card title="listen_programsubscribe.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/listen-migrations/listen_programsubscribe.py" icon="angle-right" horizontal />
+  <Card title="compare_migration_listeners.py" href="https://github.com/chainstacklabs/pump-fun-bot/blob/main/learning-examples/listen-migrations/compare_migration_listeners.py" icon="angle-right" horizontal />
 </CardGroup>
 
-This guide shows you how to track the lifecycle of pump.fun tokens from their initial bonding curve state through migration to Raydium using Python scripts.
+This guide shows you how to track the lifecycle of pump.fun tokens from their initial bonding curve state through graduation to PumpSwap using Python scripts.
 
 ## Prerequisites
 
@@ -40,34 +46,42 @@ This guide shows you how to track the lifecycle of pump.fun tokens from their in
 
 * Clone the [pump-fun-bot GitHub repository](https://github.com/chainstacklabs/pump-fun-bot/)
 * Install the requirements `pip install -r requirements.txt`
-* Provide the node HTTP and WebSocket endpoints in `config.py`
+* Provide the node HTTP and WebSocket endpoints in your `.env` file
 
-## Understanding pump.fun token migration
+## Understanding pump.fun token graduation
 
-Tokens on pump.fun start trading against a bonding curve—a mathematical formula that determines the token's price based on supply and demand. However, once certain conditions are met, the token "graduates" and migrates its liquidity to Raydium DEX.
+Tokens on pump.fun start trading against a bonding curve—a mathematical formula that determines the token's price based on supply and demand. Once the curve's `complete` flag flips to true, the token "graduates" and its liquidity migrates to an AMM.
 
-A token migrates to Raydium when:
+A token graduates when:
 
 1. The bonding curve reaches completion status (tracked by the `complete` flag in the curve's state)
-2. The token has accumulated sufficient liquidity and trading volume
+2. The accumulated SOL in the curve reaches the graduation threshold
 3. The migration transaction is executed by the protocol
 
-After migration, trading moves from the bonding curve mechanism to Raydium's traditional AMM (Automated Market Maker) model. This transition is significant because:
+**Where the liquidity goes:** since March 20, 2025, graduated tokens migrate to **PumpSwap** (also called Pump AMM), pump.fun's native AMM, program `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`. Migration is now handled by a permissionless `migrate` instruction that creates a PumpSwap pool and burns the LP tokens (locking the liquidity). Before PumpSwap launched, graduations went to Raydium; that path is effectively retired.
+
+After graduation, trading moves from the bonding curve to PumpSwap's constant-product AMM:
 
 * Trading mechanics change from bonding curve to AMM
-* Liquidity becomes more flexible and can be added/removed by users
-* The token becomes accessible to the broader Raydium ecosystem
+* Liquidity is held in a PumpSwap pool
+* The token becomes tradable through the PumpSwap program and any aggregator that routes to it
 
 ## Monitoring tools
 
-This guide covers two essential scripts for tracking this migration process:
+This guide covers the scripts for tracking graduation:
 
-1. `get_bonding_curve_status.py` — checks if a token is still on the bonding curve or ready for migration
-2. `listen_logsubscribe.py` — monitors real-time migrations to Raydium
+1. `get_bonding_curve_status.py` — checks whether a token is still on the bonding curve or has completed and graduated
+2. `listen_logsubscribe.py` — monitors real-time graduations by listening to the migration program's events
+3. `listen_programsubscribe.py` — monitors real-time graduations by watching for new PumpSwap pool accounts
+4. `compare_migration_listeners.py` — runs both listeners side by side to compare detection latency
 
 ### Checking bonding curve status
 
-The `get_bonding_curve_status.py` script lets you check if a token's bonding curve is still active or has completed and is ready for Raydium migration.
+The `get_bonding_curve_status.py` script lets you check whether a token's bonding curve is still active or has completed and graduated. It derives the bonding curve address from the token mint and makes a [getAccountInfo | Solana](/reference/solana-getaccountinfo) call to read the curve state from the pump.fun program (`6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P`).
+
+<Note>
+The bonding curve account layout has evolved. The current state includes a `creator` field (and an `is_mayhem_mode` flag), so make sure your decoder matches the latest account struct in the repository's `get_bonding_curve_status.py`. The `complete` flag itself is unchanged.
+</Note>
 
 #### Usage
 
@@ -77,96 +91,87 @@ The `get_bonding_curve_status.py` script lets you check if a token's bonding cur
   ```
 </CodeGroup>
 
-Replace `TOKEN_ADDRESS` with the Solana address of the token you want to check. The script derives the associated bonding curve address from the token address that you provide and then makes a [getAccountInfo | Solana](/reference/solana-getaccountinfo) call to the bonding curve.
+Replace `TOKEN_ADDRESS` with the Solana address of the token you want to check.
 
 #### Example output
 
-For an active bonding curve:
+For a completed (graduated) bonding curve:
 
 ```
-Token Status:
+Token status:
 --------------------------------------------------
-Token Mint:              TokenAddressHere...
-Associated Bonding Curve: BondingCurveAddressHere...
-Bump Seed:               255
+Token mint:              TokenAddressHere...
+Bonding curve:           BondingCurveAddressHere...
+Bump seed:               255
 --------------------------------------------------
 
-Bonding Curve Status:
+Bonding curve status:
 --------------------------------------------------
-Completion Status: Not Completed
+Creator:             CreatorAddressHere...
+Completed:           ✅ Migrated
 --------------------------------------------------
+
+Note: This bonding curve has completed and liquidity has migrated to PumpSwap.
 ```
 
-For a completed bonding curve:
+### Monitoring graduations in real time
 
-<CodeGroup>
-  ```shell Shell
-  Token Status:
-  --------------------------------------------------
-  Token Mint:              TokenAddressHere...
-  Associated Bonding Curve: BondingCurveAddressHere...
-  Bump Seed:               255
-  --------------------------------------------------
+There are two reliable ways to detect a graduation, and the repository ships a script for each.
 
-  Bonding Curve Status:
-  --------------------------------------------------
-  Completion Status: Completed
+**Option 1 — listen to the migration program (logsSubscribe).** The migration wrapper program [39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg](https://solscan.io/account/39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg) emits a `Migrate` event when a token graduates. `listen_logsubscribe.py` subscribes with [logsSubscribe | Solana](/reference/logssubscribe-solana), parses the event, and prints the migration signature, the token mint, and the new PumpSwap pool address. The event carries the `baseMint`, `quoteMint`, decimals, and the base/quote amounts deposited into the pool.
 
-  Note: This bonding curve has completed and liquidity has been migrated to Raydium.
-  --------------------------------------------------
-  ```
-</CodeGroup>
+<Warning>
+`logsSubscribe` skips transactions with truncated logs (no `Program data` field), so a small number of migrations can be missed. To cover those, follow up with a `getTransaction` call or run the programSubscribe listener below in parallel.
+</Warning>
 
-### Monitoring Raydium migrations
+**Option 2 — watch for new PumpSwap pools (programSubscribe).** `listen_programsubscribe.py` subscribes to the PumpSwap program `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA` and detects new pool (market) accounts as they are created, filtering by the pool account discriminator and length. This catches every new pool, but consumes a high volume of WebSocket messages.
 
-The `listen_logsubscribe.py` script uses WebSocket subscriptions to monitor real-time migrations of tokens from pump.fun to Raydium DEX.
-
-The pump.fun migration account is [39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg](https://solscan.io/account/39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg).
-
-This is the account that—on the token bonding curve completion status—adds the token to a Raydium's AMM pool with the token's liquidity. This essentially constitutes token migration from pump.fun to Raydium.
-
-Our script uses the [blockSubscribe | Solana](/reference/blocksubscribe-solana) method over WebSocket by listening to all the transactions involving the migration account `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg`, then decodes the transactions using the Raydium IDL `raydium_amm_idl.json` that's also in our [pump-fun-bot repository](https://github.com/chainstacklabs/pump-fun-bot) . After decoding the data, it prints what we actually need—the address of the pump.fun token that migrated and the new liquidity pool address for this token on Raydium.
-
-<Note>
-  **Important for production:** The `blockSubscribe` method can experience stability issues with high-traffic programs like Raydium, including connection errors and data skipping. For production monitoring of Raydium migrations, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883) for more reliable streaming. Learn more about [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
-</Note>
+Run `compare_migration_listeners.py` to run both at once and measure which detects a given graduation first across your RPC providers.
 
 #### Usage
 
 <CodeGroup>
   ```shell Shell
+  # Listen via the migration program's events
   python listen_logsubscribe.py
+
+  # Or watch for new PumpSwap pool accounts
+  python listen_programsubscribe.py
   ```
 </CodeGroup>
 
 #### Example output
 
-When a migration occurs:
+When a graduation occurs:
 
 <CodeGroup>
   ```shell Shell
-  Found initialize2 instruction!
+  Migrate detected!
 
   Signature: 5KtPn3...
-  Token Address: TokenAddressHere...
-  Liquidity Address: LiquidityPoolAddressHere...
+  Token (base mint): TokenAddressHere...
+  PumpSwap pool:     PoolAddressHere...
   ==================================================
   ```
 </CodeGroup>
+
+<Note>
+  **Important for production:** `logsSubscribe` and `programSubscribe` can experience stability issues and dropped messages with high-traffic programs, including connection errors and data skipping. For production monitoring, consider using [Geyser as recommended by the Solana team](https://github.com/anza-xyz/agave/issues/3879#issuecomment-2519700883) for more reliable streaming. Learn more about [Yellowstone Geyser](/docs/yellowstone-grpc-geyser-plugin).
+</Note>
 
 ## Use cases
 
 These monitoring tools are particularly useful for:
 
-* Traders who need to adjust their strategies when trading moves to Raydium
+* Traders who need to adjust their strategies when trading moves to PumpSwap
 * Arbitrage bots that operate differently on bonding curves vs AMMs
-* Market makers looking to provide liquidity as soon as tokens migrate
-* Sniping successful tokens on Raydium early
+* Market makers looking to provide liquidity as soon as tokens graduate
+* Sniping successful tokens on PumpSwap early
 * Analytics tools tracking the pump.fun ecosystem
 
 ## Conclusion
 
-Understanding and monitoring the token migration process from pump.fun to Raydium is crucial for trading strategies. These tools help you stay informed about the state and location of token liquidity, allowing you to adapt your trading approach accordingly.
+Understanding and monitoring the token graduation process from pump.fun to PumpSwap is crucial for trading strategies. These tools help you stay informed about the state and location of token liquidity, allowing you to adapt your trading approach accordingly.
 
 For the complete trading bot implementation, see [Creating a pump.fun trading bot](/docs/solana-creating-a-pumpfun-bot).
 

--- a/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-only-logssubscribe.mdx
@@ -135,23 +135,15 @@ Because we rely on logs only, we do not need extra calls like `getTransaction`. 
 
 ## Compare performance
 
-You can run:
+The repository's `listen-new-tokens/` directory has a listener for each method — `listen_logsubscribe.py` (logs only), `listen_blocksubscribe.py`, and `listen_geyser.py` — plus `compare_listeners.py`, which runs them side by side and reports which detects a new token first:
 
 <CodeGroup>
   ```shell Shell
-  python listen_create_from_blocksubscribe.py
+  uv run learning-examples/listen-new-tokens/compare_listeners.py
   ```
 </CodeGroup>
 
-alongside:
-
-<CodeGroup>
-  ```shell Shell
-  python listen_new_direct_full_details.py
-  ```
-</CodeGroup>
-
-to see which one delivers the event data faster in your environment.
+Use it to see which method delivers the event data faster in your environment.
 
 ## Next steps
 
@@ -164,7 +156,7 @@ See also:
 
 <CardGroup>
   <Card title="Solana: Creating a trading and sniping pump.fun bot" href="/docs/solana-creating-a-pumpfun-bot" icon="angle-right" horizontal />
-  <Card title="Solana: Listening to pump.fun migrations to Raydium" href="/docs/solana-listening-to-pumpfun-migrations-to-raydium" icon="angle-right" horizontal />
+  <Card title="Solana: Listening to pump.fun migrations to PumpSwap" href="/docs/solana-listening-to-pumpfun-migrations-to-raydium" icon="angle-right" horizontal />
 </CardGroup>
 
 

--- a/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
+++ b/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
@@ -9,6 +9,10 @@ description: Calculate and apply optimal priority fees for Jupiter swap transact
 * Adding this priority fee to the raw Jupiter transaction data (plus the base fee of 5000 lamports) helps ensure faster block inclusion under congestion.
 * The entire flow uses both Jupiter endpoints (quote + swap) and a private Solana RPC (e.g., Chainstack) for the final transaction broadcast, giving you more control over performance and reliability.
 
+<Warning>
+Jupiter retired the old `quote-api.jup.ag/v6` endpoints on October 1, 2025. This guide uses the current Swap API at `https://api.jup.ag/swap/v1`. The keyless `https://lite-api.jup.ag/swap/v1` works for low request rates; `api.jup.ag` takes an `X-API-Key` header for higher tiers (get a key at [portal.jup.ag](https://portal.jup.ag)). Jupiter also offers a newer consolidated [Swap API v2](https://dev.jup.ag); the v1 flow below is verified end to end.
+</Warning>
+
 ## Main article
 
 With its cumulative volume in [USD billions](https://defillama.com/protocol/jupiter-aggregator#information), Jupiter is one of the top DEX aggregators on Solana.
@@ -59,39 +63,94 @@ Here's how it's going to work:
 
 ## Implementation
 
-Now let's implement our flow as outlined above.
+The flow is: estimate a priority fee from recent on-chain data, get a quote from Jupiter, build the swap transaction with that fee, then sign and send it through your own Solana node. Jupiter doesn't have an official Python SDK, so we call its REST API directly and sign with `solders`.
 
-Have a look at the [Jupiter swap API](https://developers.jup.ag/docs/swap), and you will see that there are a few endpoints. The two that we need are:
+Install the dependencies:
 
-* quote — to get the quote for the trade
-* swap — to prepare the swap transaction
+<CodeGroup>
+  ```shell Shell
+  pip install requests solders solana
+  ```
+</CodeGroup>
 
-For everything else we are using our own Solana node.
+The complete script:
 
-Relying on your own unique Solana node endpoint, however, is always the smartest and most reliable way of doing things. This already puts you ahead of the competition, since you are the only one using it, you can try different ones in different locations or having a load balanced one, and so on.
+```python jupiter_swap.py
+import base64
+import statistics
 
-We get the quote from Jupiter.
+import requests
+from solders.keypair import Keypair
+from solders.transaction import VersionedTransaction
+from solana.rpc.api import Client
+from solana.rpc.types import TxOpts
 
-We get the priority fee from the chain and our calculations:
+# Your Chainstack Solana node and wallet
+RPC_ENDPOINT = "YOUR_CHAINSTACK_SOLANA_NODE"
+PRIVATE_KEY = "YOUR_PRIVATE_KEY"  # base58-encoded
 
-* Query the chain with `getRecentPrioritizationFees` the Chainstack Solana node
-* Get the priority fee data over the last 150 blocks
-* We then take the 150 fee data and calculate the median
-* Then we multiply the median by whatever number we think will get us the priority slot in the queuer. For example, setting the multiplier to `1.1` will get us a 10% bump over the median; `3` will 3x the median, and so on.
-* Then we build the transaction with the `/swap` Jupiter endpoint with our priority fee.
-* And then we send the transaction through the Chainstack Solana node.
+# Jupiter Swap API. lite-api.jup.ag is keyless (low rate); api.jup.ag takes an
+# X-API-Key header for higher tiers — get a key at https://portal.jup.ag
+JUPITER = "https://api.jup.ag/swap/v1"
 
-A word on why base the priority fee on the median and not just the highest fee over the past 150 blocks. In the tests that I did, I found that there can be random astronomical priority fees on the chain, and relying on these "flukes" can jeopardize your finances in no time. Feel free to play around and find a better strategy, I'm sure there's one. Just be careful.
+INPUT_MINT = "So11111111111111111111111111111111111111112"   # SOL
+OUTPUT_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"  # USDC
+AMOUNT = 1_000_000          # 0.001 SOL, in lamports
+SLIPPAGE_BPS = 50           # 0.5%
+PRIORITY_MULTIPLIER = 1.1   # bump over the median fee
 
-Check the full code in the [GitHub repo](https://github.com/chainstacklabs/jupiter-swaps-priority-fees-python):
+wallet = Keypair.from_base58_string(PRIVATE_KEY)
 
-* PRIVATE\_KEY - your private key, of course.
-* RPC\_ENDPOINT — your Chainstack Solana node endpoint.
-* INPUT\_MINT — the token going in for your swap.
-* OUTPUT\_MINT — the token that you get as a result of the swap.
-* AMOUNT — the amount of the INPUT\_MINT token in lamports.
-* AUTO\_MULTIPLIER — multiply the median of fees to get yourself a priority. Setting to `1` will keep the median unchanged and use that as the priority fee.
-* SLIPPAGE\_BPS — slippage tolerance
+# 1) Estimate the priority fee from recent blocks. Use the median, not the max:
+#    occasional astronomical fees on-chain can drain your wallet if you chase them.
+resp = requests.post(RPC_ENDPOINT, json={
+    "jsonrpc": "2.0", "id": 1, "method": "getRecentPrioritizationFees",
+    "params": [[INPUT_MINT]],  # account-aware: fees for the accounts your tx touches
+}).json()
+fees = [x["prioritizationFee"] for x in resp["result"]]
+median_fee = int(statistics.median(fees)) if fees else 0
+max_lamports = int(median_fee * PRIORITY_MULTIPLIER) or 1_000
+print(f"Median priority fee: {median_fee} microlamports/CU")
+
+# 2) Get a quote from Jupiter.
+quote = requests.get(f"{JUPITER}/quote", params={
+    "inputMint": INPUT_MINT, "outputMint": OUTPUT_MINT,
+    "amount": AMOUNT, "slippageBps": SLIPPAGE_BPS,
+}).json()
+print(f"Quote: {AMOUNT} -> {quote['outAmount']} (out)")
+
+# 3) Build the swap transaction with the priority fee and a dynamic compute-unit limit.
+swap = requests.post(f"{JUPITER}/swap", json={
+    "quoteResponse": quote,
+    "userPublicKey": str(wallet.pubkey()),
+    "dynamicComputeUnitLimit": True,
+    "prioritizationFeeLamports": {
+        "priorityLevelWithMaxLamports": {
+            "maxLamports": max_lamports,
+            "priorityLevel": "veryHigh",
+        }
+    },
+}).json()
+
+# 4) Sign the returned versioned transaction and send it through your node.
+raw = VersionedTransaction.from_bytes(base64.b64decode(swap["swapTransaction"]))
+signed = VersionedTransaction(raw.message, [wallet])
+
+client = Client(RPC_ENDPOINT)
+sig = client.send_raw_transaction(bytes(signed), opts=TxOpts(skip_preflight=True)).value
+print(f"Sent: https://solscan.io/tx/{sig}")
+```
+
+A few notes on the current Jupiter API:
+
+* **Priority fee shape.** `prioritizationFeeLamports.priorityLevelWithMaxLamports` lets Jupiter pick a fee at the chosen `priorityLevel` (`medium`, `high`, or `veryHigh`) capped at `maxLamports`. Here we cap it at the median-derived value so we never overpay during a fee spike.
+* **`dynamicComputeUnitLimit: true`** makes Jupiter simulate the swap and set an accurate compute-unit limit, which both improves landing and avoids overpaying (the priority fee is `compute_unit_price × compute_unit_limit`).
+* **Versioned transactions.** Jupiter returns a base64 `VersionedTransaction`; sign it with `solders` and broadcast the raw bytes through your node.
+* **Why the median.** Fees over the recent window can include random astronomical outliers — basing your fee on the max can drain your wallet. The median (optionally bumped by `PRIORITY_MULTIPLIER`) is a safer baseline. Tune it for your needs.
+
+<Note>
+The companion repository [jupiter-swaps-priority-fees-python](https://github.com/chainstacklabs/jupiter-swaps-priority-fees-python) has the full project. The base fee on Solana is a fixed 5000 lamports per signature; the priority fee above is added on top.
+</Note>
 
 ## Conclusion
 


### PR DESCRIPTION
## Why

The Mintlify analytics show the Solana trading-bot recipes are among the most AI-crawled pages (ChatGPT is ~63% of views). A verify pass found several of the top ones teaching **dead or deprecated APIs** — so ChatGPT has been serving broken/outdated code. Each fix is grounded in the current `chainstacklabs/pump-fun-bot` repo, live web sources, and (where code changed) **execution-verified**.

## Pages (by AI views/30d)

| Page | Fix |
|---|---|
| pumpfun→raydium migrations (1,549) | **Rewrite:** pump.fun graduates to **PumpSwap**, not Raydium, since 2025-03-20. Corrected detection (`migrate` event / new PumpSwap pool), fixed a `blockSubscribe`→`logsSubscribe` error. |
| creating-a-pumpfun-bot (1,379) | **Rewrite:** repo was restructured (uv, `.env`+`bots/*.yaml`, `pump_bot`, logsSubscribe default, PumpSwap, letsbonk.fun). Replaced the obsolete `trade.py`/`--yolo`/`config.py` model. |
| jupiter priority-fees python (1,190) | **Rewrite + verified:** `quote-api.jup.ag/v6` was retired 2025-10-01. New verified Python example on `api.jup.ag/swap/v1` (quote→build→sign). |
| priority-fees-faster-tx (1,186) | Fix mislabeled fences (tsx/jsx→ts/shell), correct CU-limit overclaim + best-practice note; ComputeBudget code current. |
| pumpfun-mint logsSubscribe (1,070) | Fix stale script names → current repo scripts + `compare_listeners.py`; Raydium→PumpSwap card title. |
| getRecentPrioritizationFees (1,044) | Fix mislabeled fences (solidity/tsx→shell/ts); content already current. |
| raydium-sdk swaps (904) | **Rewrite + verified:** `@raydium-io/raydium-sdk` v1 is EOL (archived Jun 2025). New TypeScript example on Raydium's current **Trade API**. |

## Verification

- **Jupiter:** ran quote → swap-build → deserialize → local sign against the live API (no broadcast, no funds).
- **Raydium:** ran auto-fee → quote → build against the live Trade API; the TS example compiles clean (`tsc`, ESM).
- **pump.fun facts:** triple-confirmed (repo + 8 web sources + live on-chain: PumpSwap `pAMMBay…` executable, migration wrapper active 2026-06-25).
- All 7 pages: `mintlify broken-links` clean; no unescaped `$`; URL slugs preserved.

## Follow-up (out of scope — separate repos)

Two companion code repos are also broken and should be updated separately: `chainstacklabs/jupiter-swaps-priority-fees-python` (still calls v6) and `chainstacklabs/raydium-sdk-swap-example-typescript` (v1). The docs pages are now self-contained with verified inline code regardless.