### PR TITLE
docs: GEO upgrade — Ethereum, Solana, TON, TRON getting-started pages

### DIFF
--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -33,13 +33,15 @@ Point the CLI at your Chainstack node:
 solana config set --url YOUR_CHAINSTACK_ENDPOINT
 ```
 
-<Warning>
-When you set the HTTPS endpoint with `solana config set`, the CLI derives a WebSocket endpoint by swapping the protocol — but the port stays the same, which is usually wrong for Chainstack. Set the WebSocket explicitly:
+<Note>
+This is only needed on **Trader Nodes**, whose WebSocket endpoint is on a different host than the HTTPS one — the WSS host carries a `ws-` prefix (`nd-….p2pify.com` for HTTPS, `ws-nd-….p2pify.com` for WSS). Because `solana config set` derives the WebSocket URL by swapping only the protocol, set it explicitly on a Trader Node:
 
 ```bash
 solana config set --ws YOUR_CHAINSTACK_WSS_ENDPOINT
 ```
-</Warning>
+
+On **Global Nodes**, HTTPS and WebSocket share the same host (for example, `solana-mainnet.core.chainstack.com`), so the derived WebSocket URL is correct and no `--ws` flag is needed.
+</Note>
 
 Example:
 

--- a/openapi/tron_node_api/jsonrpc_eth_chainid.json
+++ b/openapi/tron_node_api/jsonrpc_eth_chainid.json
@@ -91,7 +91,7 @@
                     },
                     "result": {
                       "type": "string",
-                      "description": "Chain ID as hexadecimal string (TRON mainnet: 0x2b6653dc, testnet: 0x94a9059e)",
+                      "description": "Chain ID as hexadecimal string (TRON mainnet: 0x2b6653dc, Nile testnet: 0xcd8690dc)",
                       "example": "0x2b6653dc"
                     }
                   }

--- a/reference/ethereum-getting-started.mdx
+++ b/reference/ethereum-getting-started.mdx
@@ -75,7 +75,7 @@ The `txpool_*` and `admin_*` namespaces are listed for completeness but are not 
 
 With a Chainstack Ethereum endpoint you can:
 
-- Query chain state — balances, blocks, logs, receipts, storage, proofs, and gas — through the standard `eth_*` JSON-RPC interface, compatible with web3.js, ethers, viem, and web3.py.
+- Query chain state — balances, blocks, logs, receipts, storage, proofs, and gas — through the standard `eth_*` JSON-RPC interface, compatible with ethers, viem, and web3.py.
 - Deploy and call Solidity contracts with Hardhat, Foundry, Remix, and Ape, using `eth_call`, `eth_estimateGas`, and `eth_sendRawTransaction`.
 - Debug and trace transactions with `debug_traceTransaction`, `trace_block`, `trace_replayTransaction`, and the `erigon_*` namespace on archive nodes.
 - Stream real-time data over WebSocket with `eth_subscribe` for `newHeads`, `logs`, `newPendingTransactions`, and `syncing`.
@@ -104,7 +104,7 @@ Now you are ready to connect to the Ethereum blockchain and use the Ethereum API
 
 You can call the API directly over HTTP and WebSocket, or use a maintained library:
 
-- JavaScript and TypeScript — [web3.js](https://github.com/web3/web3.js), [ethers.js](https://github.com/ethers-io/ethers.js), and [viem](https://github.com/wevm/viem).
+- JavaScript and TypeScript — [ethers.js](https://github.com/ethers-io/ethers.js) and [viem](https://github.com/wevm/viem).
 - Python — [web3.py](https://github.com/ethereum/web3.py).
 - .NET — [Nethereum](https://github.com/Nethereum/Nethereum).
 
@@ -146,7 +146,7 @@ Yes. Connect over WebSocket and use `eth_subscribe` to stream `newHeads`, `logs`
 
 ### Which SDKs work with the Ethereum API?
 
-Any standard Ethereum library works against a Chainstack endpoint: web3.js, ethers.js, and viem for JavaScript and TypeScript, web3.py for Python, and Nethereum for .NET. For contracts, use Foundry, Hardhat, Ape, or Scaffold-ETH 2. See [Ethereum tooling](/docs/ethereum-tooling).
+Any standard Ethereum library works against a Chainstack endpoint: ethers.js and viem for JavaScript and TypeScript, web3.py for Python, and Nethereum for .NET. For contracts, use Foundry, Hardhat, Ape, or Scaffold-ETH 2. See [Ethereum tooling](/docs/ethereum-tooling).
 
 ### Does Chainstack serve the Beacon Chain (consensus layer) API?
 

--- a/reference/ethereum-getting-started.mdx
+++ b/reference/ethereum-getting-started.mdx
@@ -1,13 +1,25 @@
 ---
 title: "Ethereum API reference: JSON-RPC and Beacon quickstart"
-description: "Use the Ethereum JSON-RPC and Beacon Chain APIs on Chainstack to deploy nodes, send transactions, and query the execution and consensus layers."
+description: "Use the Ethereum JSON-RPC and Beacon Chain APIs on Chainstack to deploy nodes, send transactions, and query the execution and consensus layers. Chain ID 1, proof of stake, 100 methods served, archive and debug & trace on mainnet and testnets."
 ---
 
-## What is the Ethereum protocol?
+The Ethereum API gives developers programmatic access to the canonical EVM blockchain across both of its layers: the execution layer over JSON-RPC for accounts, contracts, logs, and transactions, and the consensus layer over the Beacon Chain REST API for validators, attestations, and finality. Chainstack serves both through a single Ethereum node endpoint.
 
-Ethereum, launched in 2015, is a decentralized and open-source blockchain network that provides a platform for developers to build decentralized applications for diverse purposes. Ethereum relies on a proof-of-stake (PoS) consensus mechanism, and one of Ethereum's most critical features is its smart contract functionality, which empowers developers to create self-executing programs, automating the enforcement of contractual terms and conditions.
+## Ethereum API at a glance
 
-Find useful Ethereum tools in the [Ethereum tooling](https://docs.chainstack.com/docs/ethereum-tooling) section.
+| Property | Value |
+| --- | --- |
+| Chain | Ethereum — Layer 1, proof-of-stake consensus |
+| Mainnet chain ID | `1` |
+| Testnet chain IDs | Sepolia `11155111`, Hoodi `560048` |
+| Block time | ~12 seconds |
+| Execution layer | JSON-RPC — `eth`, `net`, `web3`, `debug`, `trace`, `erigon` namespaces |
+| Consensus layer | Beacon Chain REST API — `/eth/v1/beacon`, `/eth/v1/validator`, `/eth/v1/node` |
+| Methods served by Chainstack | 100 — 69 execution-layer JSON-RPC methods + 31 Beacon Chain endpoints |
+| Real-time data | WebSocket `eth_subscribe` (newHeads, logs, newPendingTransactions, syncing) |
+| Debug & trace | `debug_*`, `trace_*`, and `erigon_*` namespaces |
+| Networks | Mainnet, Sepolia, and Hoodi, with full and archive nodes |
+| Request units | 1 RU per full request, 2 RUs per archive request |
 
 <Visibility for="humans">
 <Check>
@@ -19,38 +31,138 @@ Find useful Ethereum tools in the [Ethereum tooling](https://docs.chainstack.com
 </Check>
 </Visibility>
 
-## What is the Ethereum API?
+## What is Ethereum
 
-The Ethereum API allows developers to communicate with the Ethereum blockchain to build applications.
+Ethereum, launched in 2015, is a decentralized, open-source blockchain network that provides a platform for developers to build decentralized applications for diverse purposes. Ethereum runs on a proof-of-stake (PoS) consensus mechanism, and one of its most critical features is smart contract functionality, which lets developers create self-executing programs that automate the enforcement of contractual terms and conditions.
 
-Chainstack Ethereum nodes provide execution layer API and consensus layer API (aka Beacon Chain API).
+Ethereum is the reference implementation of the Ethereum Virtual Machine (EVM), the execution environment that dozens of other chains — Base, BNB Smart Chain, Polygon, Arbitrum, Optimism, and more — adopt for compatibility. Tooling, contract bytecode, and JSON-RPC calls that work against Ethereum carry over to the wider EVM ecosystem with minimal changes.
 
-An application must connect to an Ethereum RPC node to read data from and send transactions to the Ethereum blockchain.
+A modern Ethereum node runs two clients that share consensus and produce blocks together:
 
-When communicating with an Ethereum RPC node, the Ethereum client implements a JSON-RPC specification, a communication protocol allowing one to make remote calls and execute them as if they were made locally.
+- Execution layer — processes transactions, runs the EVM, and holds account and contract state. It exposes the JSON-RPC interface that applications use to read state and send transactions.
+- Consensus layer — runs proof-of-stake validation through the Beacon Chain, tracking validators, attestations, and finality. It exposes a REST API for validator duties and chain-finality data.
+
+## What is the Ethereum API
+
+The Ethereum API lets developers build decentralized applications, analytics tools, wallets, and indexers. To read data from and send transactions to the Ethereum blockchain, an application connects to an Ethereum node endpoint, then calls the layer it needs:
+
+- The execution layer implements the JSON-RPC specification, a communication protocol that lets you make remote calls and execute them as if they were local. This is where you query balances, blocks, logs, and receipts, call and deploy smart contracts, and submit signed transactions.
+- The consensus layer exposes the Beacon Chain REST API for validator state, committees, sync committees, rewards, and finality checkpoints.
+
+A Chainstack Ethereum node serves both, so a single endpoint covers execution-layer JSON-RPC, Beacon Chain queries, and WebSocket subscriptions for real-time data.
+
+## Methods
+
+Chainstack serves 100 Ethereum methods across the execution and consensus layers:
+
+| Layer | Namespace or path | Methods served | Notes |
+| --- | --- | --- | --- |
+| Execution | `eth_*` | 39 | Accounts, blocks, logs, gas, contract calls, transactions, subscriptions |
+| Execution | `debug_*` | 9 | Transaction and block tracing |
+| Execution | `trace_*` | 8 | OpenEthereum-style tracing and replays |
+| Execution | `erigon_*` | 8 | Erigon-specific block, header, and log queries |
+| Execution | `net_*` | 3 | Network listening status and peer count |
+| Execution | `web3_*` | 2 | Client version and Keccak-256 hashing |
+| Consensus | Beacon Chain REST | 31 | Validators, committees, rewards, finality, events |
+
+For the complete, per-method availability matrix, see [Ethereum methods](/docs/ethereum-methods).
+
+<Note>
+The `txpool_*` and `admin_*` namespaces are listed for completeness but are not served on Chainstack Ethereum nodes. See [Ethereum methods](/docs/ethereum-methods) for the full availability matrix.
+</Note>
+
+### What you can build
+
+With a Chainstack Ethereum endpoint you can:
+
+- Query chain state — balances, blocks, logs, receipts, storage, proofs, and gas — through the standard `eth_*` JSON-RPC interface, compatible with web3.js, ethers, viem, and web3.py.
+- Deploy and call Solidity contracts with Hardhat, Foundry, Remix, and Ape, using `eth_call`, `eth_estimateGas`, and `eth_sendRawTransaction`.
+- Debug and trace transactions with `debug_traceTransaction`, `trace_block`, `trace_replayTransaction`, and the `erigon_*` namespace on archive nodes.
+- Stream real-time data over WebSocket with `eth_subscribe` for `newHeads`, `logs`, `newPendingTransactions`, and `syncing`.
+- Read consensus-layer state — validators, committees, sync committees, rewards, and finality checkpoints — through the Beacon Chain REST API.
+- Index historical state at any block height — balances, contract storage, and traces — against an archive node.
 
 ## How to start using the Ethereum API
 
-You need access to an Ethereum RPC node to use the Ethereum API.
-
-Follow these steps to sign up on Chainstack, deploy an Ethereum RPC node, and find your endpoint credentials:
+You need access to an Ethereum node endpoint to use the Ethereum API. Follow these steps to sign up, deploy a node, and find your credentials:
 
 <Steps>
   <Step>
     [Sign up with Chainstack](https://console.chainstack.com/user/account/create).
   </Step>
   <Step>
-    [Deploy a node](https://docs.chainstack.com/docs/manage-your-networks).
+    [Deploy a node](/docs/manage-your-networks).
   </Step>
   <Step>
-    [View node access and credentials](https://docs.chainstack.com/docs/manage-your-node#view-node-access-and-credentials).
+    [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
   </Step>
 </Steps>
 
-Now, you can connect to the Ethereum blockchain and use the Ethereum API to build.
+Now you are ready to connect to the Ethereum blockchain and use the Ethereum API to build.
 
-<Info>
-  **See also**
+## SDKs and tooling
 
-  [Build better with Ethereum](https://chainstack.com/build-better-with-ethereum/)
-</Info>
+You can call the API directly over HTTP and WebSocket, or use a maintained library:
+
+- JavaScript and TypeScript — [web3.js](https://github.com/web3/web3.js), [ethers.js](https://github.com/ethers-io/ethers.js), and [viem](https://github.com/wevm/viem).
+- Python — [web3.py](https://github.com/ethereum/web3.py).
+- .NET — [Nethereum](https://github.com/Nethereum/Nethereum).
+
+For smart contract development, point [Foundry](https://github.com/foundry-rs/foundry), [Hardhat](https://github.com/NomicFoundation/hardhat), [Ape](https://github.com/ApeWorX/ape), or Scaffold-ETH 2 at your Chainstack endpoint. Point any library or framework at your node URL and add a chain ID. See [Ethereum tooling](/docs/ethereum-tooling) for wallet, IDE, library, and framework setup.
+
+## Networks
+
+Chainstack supports Ethereum mainnet and the Sepolia and Hoodi testnets, with full and archive node modes, WebSocket connections, and debug & trace APIs.
+
+| Feature | Mainnet | Sepolia | Hoodi |
+| --- | --- | --- | --- |
+| Chain ID | `1` | `11155111` | `560048` |
+| Full nodes | Yes | Yes | — |
+| Archive nodes | Yes | Yes | Yes |
+| WebSocket | Yes | Yes | Yes |
+| Debug & trace APIs | Yes | Yes | Yes |
+
+<Note>
+A full node keeps recent state — the latest 128 blocks — while an archive node holds all historical state from genesis. Use an archive node for historical balances, contract storage at past blocks, and `trace_*` replays. See [Networks](/docs/protocols-networks) for the full deployment matrix.
+</Note>
+
+## Frequently asked questions
+
+### What is the Ethereum chain ID?
+
+Ethereum mainnet is chain ID `1`. The Chainstack-supported testnets are Sepolia (`11155111`) and Hoodi (`560048`). Set the chain ID in your wallet, SDK, or framework config alongside your Chainstack RPC endpoint.
+
+### What is the difference between a full node and an archive node?
+
+A full node keeps recent state — the latest 128 blocks on Ethereum — which covers most live application reads and transaction submission. An archive node retains all historical state from genesis, so you can query balances and contract storage at any past block and run `trace_*` replays. Chainstack offers both modes on mainnet and Sepolia, and archive on Hoodi.
+
+### Does Ethereum support debug and trace methods?
+
+Yes. Chainstack Ethereum nodes serve the `debug_*`, `trace_*`, and `erigon_*` namespaces — including `debug_traceTransaction`, `trace_block`, `trace_replayTransaction`, and `trace_filter` — for transaction tracing and smart contract debugging. Debug and trace are available on mainnet, Sepolia, and Hoodi.
+
+### Does Chainstack support WebSocket subscriptions on Ethereum?
+
+Yes. Connect over WebSocket and use `eth_subscribe` to stream `newHeads`, `logs`, `newPendingTransactions`, and `syncing` events in real time. Use `eth_unsubscribe` to cancel a subscription.
+
+### Which SDKs work with the Ethereum API?
+
+Any standard Ethereum library works against a Chainstack endpoint: web3.js, ethers.js, and viem for JavaScript and TypeScript, web3.py for Python, and Nethereum for .NET. For contracts, use Foundry, Hardhat, Ape, or Scaffold-ETH 2. See [Ethereum tooling](/docs/ethereum-tooling).
+
+### Does Chainstack serve the Beacon Chain (consensus layer) API?
+
+Yes. Chainstack Ethereum nodes expose 31 Beacon Chain REST endpoints alongside execution-layer JSON-RPC, covering validators, committees, sync committees, rewards, finality checkpoints, and the events stream. See [Ethereum methods](/docs/ethereum-methods) for the full list.
+
+### How are Ethereum requests priced?
+
+Pricing is 1 request unit (RU) per full request and 2 RUs per archive request. For which EVM methods bill as full versus archive, see [Request units — EVM methods affected by block age](/docs/request-units#evm-methods-affected-by-block-age).
+
+## Related Ethereum resources
+
+- [Ethereum methods](/docs/ethereum-methods) — complete per-method availability reference
+- [Ethereum tooling](/docs/ethereum-tooling) — wallets, IDEs, libraries, and frameworks
+- [Ethereum Trader Nodes with Warp transactions](/docs/ethereum-trader-nodes) — low-latency transaction propagation
+- [Ethereum logs tutorial series: logs and filters](/docs/ethereum-logs-tutorial-series-logs-and-filters) — query and filter event logs
+- [Ethereum: how to analyze pending blocks](/docs/ethereum-how-to-analyze-pending-blocks) — inspect the mempool and pending state
+- [Ethereum Dencun: rundown with examples](/docs/ethereum-dencun-rundown-with-examples) — blobs and the Dencun upgrade
+- [Debug and trace](/reference/ethereum-debug-trace-rpc-methods) — tracing method reference and examples
+- [Subscriptions](/reference/ethereum-web3js-subscriptions-methods) — WebSocket subscription method reference

--- a/reference/getting-started-ton.mdx
+++ b/reference/getting-started-ton.mdx
@@ -1,13 +1,23 @@
 ---
 title: "TON API reference: The Open Network JSON-RPC quickstart"
-description: "Use the TON API on Chainstack to query The Open Network, send transactions, work with jettons and NFTs, and build apps on the high-throughput layer-1."
+description: "Use the TON API on Chainstack to query The Open Network, send transactions, work with jettons and NFTs, and build apps on the high-throughput layer-1. 62 methods across HTTP API v2 and v3, archive on mainnet and testnet, no EVM chain ID."
 ---
 
-## What is the TON protocol
+The TON API gives developers programmatic access to The Open Network, a non-EVM layer-1 blockchain. Chainstack serves it through two HTTP API surfaces on a single endpoint — the v2 node API (which also accepts JSON-RPC) and the v3 indexer — so one node covers real-time reads, transaction sending, jettons, NFTs, and smart contract calls.
 
-TON (The Open Network) is a fully decentralized layer-1 blockchain designed for fast transactions and scalability. It was originally designed by Telegram and later developed by the open TON Community. TON uses a unique sharding mechanism to achieve high throughput and low latency.
+## TON API at a glance
 
-TON employs a Proof-of-Stake consensus mechanism where validators stake TON coins to participate in block production and validation. The network is designed to support millions of transactions per second through its dynamic sharding system.
+| Property | Value |
+| --- | --- |
+| Chain | TON (The Open Network) — non-EVM layer-1, Proof-of-Stake |
+| Address model | Workchains — masterchain (`-1`) and basechain (`0`) |
+| EVM chain ID | None — TON is not EVM-compatible |
+| API surfaces | HTTP API v2 (node API, also runs JSON-RPC) and HTTP API v3 (indexer) |
+| Methods served by Chainstack | 62 — 28 on v2 and 34 on v3 |
+| Low-level protocol | ADNL on dedicated nodes |
+| Networks | Mainnet and testnet |
+| Node mode | Archive (all data available on every node) |
+| Request units | 1 RU per full request, 2 RUs per archive request |
 
 <Visibility for="humans">
 <Check>
@@ -19,22 +29,22 @@ TON employs a Proof-of-Stake consensus mechanism where validators stake TON coin
 </Check>
 </Visibility>
 
+## What is the TON protocol
+
+TON (The Open Network) is a fully decentralized layer-1 blockchain designed for fast transactions and scalability. It was originally designed by Telegram and later developed by the open TON Community. TON uses a unique sharding mechanism to achieve high throughput and low latency.
+
+TON employs a Proof-of-Stake consensus mechanism where validators stake TON coins to participate in block production and validation. Unlike EVM chains, TON has no single chain ID — it organizes state into workchains: the masterchain (workchain `-1`) coordinates the network and stores consensus data, and the basechain (workchain `0`) carries most user accounts and smart contracts.
+
 ## What is the TON API
 
-<Check>
-  ### Both TON API v2 and v3 are supported
+The TON API lets developers build decentralized applications on TON. It provides methods to read blockchain data, send transactions, and interact with smart contracts, jettons, and NFTs. To communicate with the TON blockchain, an application connects to a managed Chainstack TON node.
 
-  Chainstack supports both v2 and v3 APIs:
+Chainstack exposes two API surfaces on the same endpoint, and both serve the same data:
 
-  * TON API v2 — node API that can also run JSON-RPC methods.
-  * TON API v3 — an indexer.
-</Check>
+- TON API v2 — the node API. It serves real-time requests directly off a node and also accepts JSON-RPC through the `/jsonRPC` envelope.
+- TON API v3 — the indexer. It serves processed, indexed data through REST endpoints, which suits complex queries and stable historical reads.
 
-<Info>
-  ### TON billing: full vs archive
-
-  v2 and v3 are priced the same, and all data is available. Most TON requests are billed as full (1 request unit); requests that read historical data are archive (2 request units) — `getTransactions` and `getTransactionsStd` are always archive, and block/seqno methods are archive when the requested block is 128 or more seqno behind the tip. See [Request units — TON method scope](/docs/request-units#ton-method-scope) for the full method list.
-</Info>
+The interactive examples on each TON method page are REST, but every Chainstack TON endpoint also accepts JSON-RPC, and each page has a JSON-RPC curl counterpart.
 
 <Check>
   ### ADNL protocol support on dedicated nodes
@@ -42,19 +52,44 @@ TON employs a Proof-of-Stake consensus mechanism where validators stake TON coin
   TON dedicated nodes on Chainstack support the [ADNL protocol](https://docs.ton.org/v3/documentation/network/protocols/adnl/overview) for secure, low-level network communication. This enables advanced use cases requiring direct interaction with the TON network layer.
 </Check>
 
-The TON API allows developers to interact with the TON blockchain to build decentralized applications. It provides methods to read data from the blockchain, send transactions, and interact with smart contracts.
+For help deciding between the two surfaces, see [choosing v2 or v3](/docs/ton-choosing-v2-or-v3).
 
-To communicate with the TON blockchain, an application must connect to a TON node. Chainstack provides managed TON nodes that developers can use to access the network.
+## TON API surface
 
-When communicating with a TON node, clients use HTTP requests to interact with the API, which follows RESTful & JSON-RPC principles for most operations.
+The two surfaces differ in how they serve data, not in what data they cover.
 
-Note that interactive examples are REST on each of the TOP API reference pages, but the Chainstack TON endpoints also support JSON-RPC calls. Each of the pages has a JSON-RPC curl example counterpart
+| API surface | Type | Serves off | Best for | Served by |
+| --- | --- | --- | --- | --- |
+| TON API v2 | Node API + JSON-RPC | A node | Real-time reads, transaction sending | Chainstack |
+| TON API v3 | Indexer | An indexer | Processed data, complex and historical queries | Chainstack |
+| ADNL | Low-level network protocol | A dedicated node | Direct TON network-layer interaction | Chainstack (dedicated nodes) |
+
+## Methods
+
+Chainstack serves 62 TON methods across the two HTTP API surfaces, all on the same endpoint:
+
+| API surface | Prefix | Methods | Availability |
+| --- | --- | --- | --- |
+| TON API v2 | `/v2/` | 28 | All served by Chainstack |
+| TON API v3 | `/v3/` | 34 | All served by Chainstack |
+
+For the complete, per-method reference, see [TON methods](/docs/ton-methods). Both surfaces are priced the same — see [TON billing](#how-is-ton-usage-billed-on-chainstack) below.
+
+### What you can build
+
+With a Chainstack TON endpoint you can:
+
+- Read account state and balances with `/v2/getAddressInformation`, `/v2/getWalletInformation`, and the v3 `/v3/account` and `/v3/wallet` endpoints.
+- Send transactions by submitting a serialized message with `/v2/sendBoc` or `/v2/sendBocReturnHash`, and estimate fees first with `/v2/estimateFee`.
+- Read blocks and the masterchain with `/v2/getMasterchainInfo`, `/v2/lookupBlock`, and the v3 `/v3/blocks` endpoint.
+- Work with jettons (TON fungible tokens) through `/v3/jetton/masters`, `/v3/jetton/wallets`, and `/v3/jetton/transfers`.
+- Work with NFTs through `/v3/nft/collections`, `/v3/nft/items`, and `/v3/nft/transfers`.
+- Call smart contract get-methods with `/v2/runGetMethod` or `/v3/runGetMethod`.
+- Trace and analyze activity with the v3 indexer — `/v3/traces`, `/v3/actions`, and `/v3/events`.
 
 ## How to start using the TON API
 
-To use the TON API, you need access to a TON node.
-
-Follow these steps to sign up on Chainstack, deploy a TON node, and find your endpoint credentials:
+To use the TON API, you need access to a TON node. Follow these steps to sign up on Chainstack, deploy a TON node, and find your endpoint credentials:
 
 <Steps>
 <Step>
@@ -69,3 +104,71 @@ Follow these steps to sign up on Chainstack, deploy a TON node, and find your en
 </Steps>
 
 Now you are ready to connect to the TON blockchain and use the TON API to build your decentralized applications.
+
+## SDKs and tooling
+
+You can call the TON API directly over HTTP, or use a maintained SDK in your language. Point any SDK at your Chainstack endpoint:
+
+- JavaScript — [TonWeb](https://github.com/toncenter/tonweb) (`npm install tonweb`) and [Ton.js](https://github.com/ton-org/ton) (`npm install ton`).
+- Python — [TONsdk](https://github.com/tonfactory/tonsdk), [PyTONLib](https://github.com/toncenter/pytonlib), and [Pytoniq](https://github.com/yungwine/pytoniq).
+- Go — [TonUtils](https://github.com/xssnick/tonutils-go) and [tongo](https://github.com/tonkeeper/tongo).
+- Rust — [Tonlib-rs](https://github.com/ston-fi/tonlib-rs).
+- .NET — [TonSdk.NET](https://github.com/continuation-team/TonSdk.NET).
+
+For smart contract development, use [Blueprint](https://github.com/ton-org/blueprint) (`npm create ton@latest`) with FunC and the Sandbox local test environment. See [TON tooling](/docs/ton-tooling) for setup snippets across every SDK, supported wallets, and IDEs.
+
+## Networks
+
+Chainstack supports both TON mainnet and testnet. TON nodes run in archive mode, so all historical data is available on every node, and both surfaces are served on each.
+
+| Feature | Mainnet | Testnet |
+| --- | --- | --- |
+| TON API v2 | Yes | Yes |
+| TON API v3 | Yes | Yes |
+| Archive data | Yes | Yes |
+| Faucet | N/A | [Chainstack faucet](https://faucet.chainstack.com) |
+
+<Note>
+TON has no debug and trace namespace and no EVM-style WebSocket subscriptions. For analyzing activity, use the v3 indexer endpoints — `/v3/traces`, `/v3/actions`, and `/v3/events`.
+</Note>
+
+## Frequently asked questions
+
+### What is the difference between TON API v2 and v3?
+
+v2 is the node API: it serves real-time requests directly off a node and also accepts JSON-RPC. v3 is the indexer: it serves processed, structured data through REST, which suits complex queries and stable historical reads. Both are priced the same and expose the same data on Chainstack. Use v2 for the freshest data and v3 for cleaned, indexed data. See [choosing v2 or v3](/docs/ton-choosing-v2-or-v3).
+
+### Does TON have an EVM chain ID?
+
+No. TON is not EVM-compatible, so it has no numeric chain ID. Instead, TON organizes state into workchains — the masterchain (`-1`) and the basechain (`0`) — and addresses accounts and contracts by workchain.
+
+### How many TON methods does Chainstack support?
+
+62, all served directly on Chainstack nodes: 28 on the v2 node API and 34 on the v3 indexer. See the [TON methods reference](/docs/ton-methods) for the full per-method list.
+
+### How do I send a transaction on TON?
+
+Serialize your message as a bag of cells (BOC) and submit it with `/v2/sendBoc`, or use `/v2/sendBocReturnHash` to get the transaction hash back. Most SDKs build and sign the BOC for you.
+
+### What are jettons on TON?
+
+Jettons are TON's fungible token standard (TEP-74), the equivalent of ERC-20 on EVM chains. Read jetton data through the v3 indexer with `/v3/jetton/masters`, `/v3/jetton/wallets`, `/v3/jetton/transfers`, and `/v3/jetton/burns`. See [how to develop jettons](/docs/ton-how-to-develop-fungible-tokens-jettons) and [how to interact with jettons](/docs/ton-how-to-interact-with-jettons).
+
+### How is TON usage billed on Chainstack?
+
+By request unit. Most TON requests are full (1 RU). Archive requests (2 RUs) apply to history reads — `getTransactions` and `getTransactionsStd` are always archive, and block/seqno methods are archive when the requested block is 128 or more seqno behind the tip. v2 and v3 are priced the same. See [request units — TON method scope](/docs/request-units#ton-method-scope).
+
+### Does Chainstack support the ADNL protocol?
+
+Yes, on dedicated nodes. ADNL is TON's low-level network protocol for secure, direct interaction with the network layer. The HTTP API v2 and v3 surfaces cover most use cases; ADNL is for advanced, low-level needs. See [TON tooling](/docs/ton-tooling).
+
+## Related TON resources
+
+- [TON methods](/docs/ton-methods) — complete per-method API reference
+- [TON: choosing v2 or v3](/docs/ton-choosing-v2-or-v3) — pick the right API surface
+- [TON tooling](/docs/ton-tooling) — SDKs, wallets, IDEs, and Blueprint setup
+- [TON: wallet initialization with TonWeb](/docs/ton-wallet-initialization-with-tonweb) — deploy a wallet contract end to end
+- [TON: how to develop fungible tokens (jettons)](/docs/ton-how-to-develop-fungible-tokens-jettons) — build jetton minter and wallet contracts
+- [TON: how to customize fungible tokens (jettons)](/docs/ton-how-to-customize-fungible-tokens-jettons) — extend jettons with capped supply and mint price
+- [TON: how to interact with jettons](/docs/ton-how-to-interact-with-jettons) — read jetton metadata, balances, and history
+- [TON: how to develop non-fungible tokens (NFT)](/docs/ton-how-to-develop-non-fungible-tokens) — build NFT item and collection contracts

--- a/reference/solana-getting-started.mdx
+++ b/reference/solana-getting-started.mdx
@@ -1,15 +1,24 @@
 ---
 title: "Solana API reference: JSON-RPC and WebSocket quickstart"
-description: "Use the Solana JSON-RPC and WebSocket APIs on Chainstack to query accounts, send transactions, and build apps on the high-throughput PoH chain."
+description: "Use the Solana JSON-RPC and WebSocket APIs on Chainstack to query accounts, send transactions, and build apps on the high-throughput PoH chain. 67 methods, mainnet and devnet, archive, WebSocket subscriptions, and Yellowstone gRPC Geyser."
 ---
 
-## What is the Solana protocol
+The Solana API gives developers programmatic access to the Solana blockchain over JSON-RPC and WebSocket. Chainstack serves it across mainnet and devnet, with archive data, real-time subscriptions, and the Yellowstone gRPC Geyser plugin for low-latency streaming. Solana is not EVM — it has no chain ID. Instead, you point your application at a cluster (mainnet or devnet) through a node endpoint.
 
-Solana is a permissionless network protocol with the parallel smart contract processing functionality. For consensus, Solana uses a combination of proof-of-stake to secure the network and the proof-of-history mechanism to synchronize the network state.
+## Solana API at a glance
 
-Validators on the network stake SOL to get the right to confirm blocks in assigned time slots.
-
-To get an assigned time slot, validator nodes use the sequence of hashed events that each of them maintains, which is called proof of history.
+| Property | Value |
+| --- | --- |
+| Chain | Solana — Layer 1, proof-of-history plus proof-of-stake |
+| Network model | Clusters, not chain IDs — mainnet and devnet |
+| Slot interval | ~400 ms scheduled slots; blocks are produced only when a slot succeeds |
+| API protocols | JSON-RPC over HTTPS and WebSocket subscriptions over WSS |
+| Methods served by Chainstack | 67 — 51 HTTP JSON-RPC methods and 16 WebSocket subscription methods |
+| Real-time streaming | WebSocket `*Subscribe` methods, plus the Yellowstone gRPC Geyser add-on |
+| Geyser gRPC | Yellowstone gRPC Geyser, mainnet only, paid add-on from the Growth plan |
+| Networks | Mainnet and devnet, full and archive nodes |
+| Transaction sending | `sendTransaction` forwarded over QUIC to the current and next leaders |
+| Request units | 1 RU per full request, 2 RUs per archive request |
 
 <Visibility for="humans">
 <Check>
@@ -21,27 +30,49 @@ To get an assigned time slot, validator nodes use the sequence of hashed events 
 </Check>
 </Visibility>
 
+## What is the Solana protocol
+
+Solana is a permissionless network protocol with parallel smart contract processing. For consensus, Solana uses a combination of proof-of-stake to secure the network and the proof-of-history mechanism to synchronize the network state.
+
+Validators on the network stake SOL to get the right to confirm blocks in assigned time slots. To get an assigned time slot, validator nodes use the sequence of hashed events that each of them maintains, which is called proof of history.
+
+Solana measures time in slots — scheduled intervals of roughly 400 ms each, designated for validators to attempt block production. Not every slot produces a block, so slot numbers and block heights diverge over time. See [Solana: Understanding block time](/docs/solana-understanding-block-time) for how this affects confirmation latency.
+
 ## What is the Solana API
 
-The Solana API allows developers to communicate with the Solana blockchain to build applications.
+The Solana API allows developers to communicate with the Solana blockchain to build applications. To read data from and send transactions to the Solana blockchain, an application must connect to a Solana RPC node.
 
-To read data from and send transactions to the Solana blockchain, an application must connect to a Solana RPC node.
-
-When communicating with a Solana RPC node, the Solana client implements a JSON-RPC specification, a communication protocol allowing one to make remote calls and execute them as if they were made locally.
+When communicating with a Solana RPC node, the Solana client implements a JSON-RPC specification — a communication protocol that lets one make remote calls and execute them as if they were made locally. For real-time data, the same node exposes WebSocket subscriptions, and Chainstack offers the Yellowstone gRPC Geyser plugin for the lowest-latency streaming.
 
 <Info>
 Chainstack Solana nodes include Jito ShredStream by default, providing faster slot reception and improved reliability. This is especially beneficial when using the [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin).
 </Info>
 
-## Method limits
+## Solana API surface
 
-See [Limits](/docs/limits).
+Chainstack serves 67 Solana methods across two protocols on the same node — JSON-RPC over HTTPS for queries and transactions, and WebSocket subscriptions over WSS for real-time updates.
+
+| API surface | Protocol | Methods | What it covers |
+| --- | --- | --- | --- |
+| Solana JSON-RPC | HTTPS | 51 | Account and token reads, block and slot queries, transaction lookups, network and validator info, sending and simulating transactions |
+| WebSocket subscriptions | WSS | 16 | 8 subscribe and 8 unsubscribe methods — `accountSubscribe`, `blockSubscribe`, `logsSubscribe`, `programSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`, `slotsUpdatesSubscribe` |
+
+For the complete, per-method availability matrix, including per-method rate limits and archive support, see [Solana methods](/docs/solana-methods).
+
+### What you can build
+
+With a Chainstack Solana endpoint you can:
+
+- Read account and program state — fetch one account with `getAccountInfo`, batch with `getMultipleAccounts`, and scan a program's accounts with `getProgramAccounts` using `dataSize` or `memcmp` filters.
+- Query SPL token data — balances, supply, and largest holders through `getTokenAccountBalance`, `getTokenAccountsByOwner`, `getTokenSupply`, and `getTokenLargestAccounts`.
+- Read blocks, slots, and history — `getBlock`, `getSlot`, `getBlockTime`, and `getLatestBlockhash`, with archive nodes and `getSignaturesForAddress` for transaction history.
+- Send and simulate transactions — submit with `sendTransaction` (forwarded over QUIC to the current and next leaders), preflight with `simulateTransaction`, and estimate cost with `getFeeForMessage`.
+- Set priority fees — sample recent network fees with `getRecentPrioritizationFees` to land transactions under contention.
+- Stream in real time — subscribe to accounts, programs, logs, slots, and signatures over WebSocket, or use the Yellowstone gRPC Geyser plugin for protobuf streaming straight from validator memory.
 
 ## How to start using the Solana API
 
-To use the Solana API, you need access to a Solana RPC node.
-
-Follow these steps to sign up on Chainstack, deploy a Solana RPC node, and find your endpoint credentials:
+To use the Solana API, you need access to a Solana RPC node. Follow these steps to sign up on Chainstack, deploy a Solana RPC node, and find your endpoint credentials:
 
 <Steps>
 <Step>
@@ -54,9 +85,84 @@ Follow these steps to sign up on Chainstack, deploy a Solana RPC node, and find 
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 </Step>
 </Steps>
+
 Now you are ready to connect to the Solana blockchain and use the Solana API to build.
 
-<Info>
-  **See also**
-  [Build better with Solana](https://chainstack.com/build-better-with-solana/)
-</Info>
+## SDKs and tooling
+
+You can call the API directly over HTTP and WebSocket, or use a maintained SDK:
+
+- JavaScript and TypeScript — [`@solana/kit`](https://github.com/anza-xyz/kit), the modern tree-shakeable successor to `@solana/web3.js` v1 (`npm install @solana/kit`).
+- Python — [Solana.py](https://github.com/michaelhly/solana-py), built on the [solders](https://github.com/kevinheavey/solders) core types (`pip install solana`).
+- Programs — [Anchor 1.0](https://www.anchor-lang.com), the Rust framework for Solana programs, installed through the Anchor Version Manager.
+- Local testing — [LiteSVM](/docs/solana-litesvm-testing) for fast in-process unit tests and [Surfpool](/docs/solana-surfpool) for a full RPC server with a mainnet fork.
+- CLI — the Agave [Solana CLI](https://docs.anza.xyz/cli), pointed at your endpoint with `solana config set --url`.
+
+Point any SDK at your Chainstack endpoint. See [Solana tooling](/docs/solana-tooling) for setup, the modern stack, and end-to-end examples.
+
+<Warning>
+When you set the HTTPS endpoint with `solana config set`, the CLI derives a WebSocket endpoint by swapping the protocol but keeping the same port, which is usually wrong for Chainstack. Set the WebSocket explicitly with `solana config set --ws YOUR_CHAINSTACK_WSS_ENDPOINT`.
+</Warning>
+
+## Networks
+
+Chainstack supports Solana mainnet and devnet, with full and archive node modes and WebSocket connections. Solana has no debug and trace namespace, and the Yellowstone gRPC Geyser plugin is available on mainnet only.
+
+| Feature | Mainnet | Devnet |
+| --- | --- | --- |
+| Full nodes | Yes | Yes |
+| Archive nodes | Yes | Yes |
+| WebSocket | Yes | Yes |
+| Yellowstone gRPC Geyser | Yes (paid add-on) | No |
+| Warp transactions (Trader Nodes) | Yes | Yes |
+
+<Note>
+A full Solana node keeps recent state — roughly the first block available on the node, about 1.5 days' worth. An archive node adds all historical state. For historical reads such as old transactions or balances at a past block, use an archive node. See [Solana archive nodes](/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling).
+</Note>
+
+## Frequently asked questions
+
+### Which Solana clusters does Chainstack support?
+
+Chainstack supports Solana mainnet and devnet. Solana is not EVM, so there is no chain ID — you select a cluster when you deploy a node and connect your application to that node's endpoint. Both clusters offer full and archive nodes with WebSocket connections.
+
+### Does Solana have a chain ID?
+
+No. Chain IDs are an EVM concept. Solana uses clusters — mainnet and devnet — and a genesis hash to distinguish networks. Point your application at the endpoint for the cluster you want; you do not set a numeric chain ID.
+
+### What is the difference between a full and an archive Solana node?
+
+A full node keeps recent state — about the first block available on the node, roughly 1.5 days' worth. An archive node retains all historical state. Use an archive node for historical queries such as `getSignaturesForAddress` over old ranges or `getBlock` for old slots. On Chainstack, archive requests bill at 2 RUs versus 1 RU for a full request.
+
+### How does getProgramAccounts work on Chainstack?
+
+`getProgramAccounts` is available on paid plans and requires a `dataSize` or `memcmp` filter, which keeps the scan bounded. For individual accounts, prefer `getAccountInfo` or batch with `getMultipleAccounts`. See [Solana: getAccountInfo vs getMultipleAccounts](/docs/solana-getaccountinfo-getmultipleaccounts).
+
+### When should I use WebSocket subscriptions versus Yellowstone gRPC?
+
+WebSocket subscriptions (`accountSubscribe`, `programSubscribe`, `logsSubscribe`, and others) are built into every node and are ideal for reacting to specific accounts, programs, or signatures without polling. Yellowstone gRPC Geyser streams live data directly from validator memory with lower latency and protobuf payloads — better for high-throughput indexing, analytics, and trading. It is a paid add-on available on mainnet from the Growth plan. See [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin).
+
+### How do I land transactions reliably and set priority fees?
+
+`sendTransaction` on a Chainstack Solana node forwards over QUIC to the current and next leaders, with no client configuration required. To prioritize under contention, sample recent fees with `getRecentPrioritizationFees` and add a compute-budget priority fee. For the highest landing rate, [Solana Trader Nodes](/docs/solana-trader-nodes) route `sendTransaction` through bloXroute's staked Trader API. See [Solana: Priority fees for faster transactions](/docs/solana-how-to-priority-fees-faster-transactions).
+
+### Which SDK should I use?
+
+For JavaScript and TypeScript, use `@solana/kit` — the modern, tree-shakeable successor to `@solana/web3.js` v1, which is now on a maintenance branch. For Python, use Solana.py, which is built on the solders core types. For on-chain programs, use Anchor 1.0. See [Solana tooling](/docs/solana-tooling) for the full modern stack.
+
+## Related Solana resources
+
+- [Solana methods](/docs/solana-methods) — complete per-method availability and rate-limit reference
+- [Mastering Solana](/docs/solana-development) — development overview and quickstart
+- [Solana tooling](/docs/solana-tooling) — the modern SDK and testing stack
+- [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin) — low-latency streaming from validator memory
+- [Solana Trader Nodes with Warp transactions](/docs/solana-trader-nodes) — staked transaction routing for high landing rates
+- [Solana: Priority fees for faster transactions](/docs/solana-how-to-priority-fees-faster-transactions) — land transactions under contention
+- [Solana: Estimate priority fees with RPC methods](/docs/solana-estimate-priority-fees-getrecentprioritizationfees) — size your priority fee from network data
+- [Solana: getAccountInfo vs getMultipleAccounts](/docs/solana-getaccountinfo-getmultipleaccounts) — choose the right account-read method
+- [Solana: PDAs and cross-program invocations](/docs/solana-program-derived-addresses-and-cross-program-invocations) — program-derived addresses and CPIs
+- [Solana: Anchor development](/docs/solana-anchor-development) — build and test programs with Anchor
+- [Solana: Fast unit testing with LiteSVM](/docs/solana-litesvm-testing) — in-process program tests
+- [Solana: Understanding block time](/docs/solana-understanding-block-time) — slots, blocks, and confirmation latency
+- [Solana archive nodes](/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling) — historical data and tooling
+- [Solana MCP server](/docs/solana-mcp-server) — drive a Solana node from an AI agent

--- a/reference/solana-getting-started.mdx
+++ b/reference/solana-getting-started.mdx
@@ -100,9 +100,9 @@ You can call the API directly over HTTP and WebSocket, or use a maintained SDK:
 
 Point any SDK at your Chainstack endpoint. See [Solana tooling](/docs/solana-tooling) for setup, the modern stack, and end-to-end examples.
 
-<Warning>
-When you set the HTTPS endpoint with `solana config set`, the CLI derives a WebSocket endpoint by swapping the protocol but keeping the same port, which is usually wrong for Chainstack. Set the WebSocket explicitly with `solana config set --ws YOUR_CHAINSTACK_WSS_ENDPOINT`.
-</Warning>
+<Note>
+This applies to **Trader Nodes** only. Their HTTPS and WebSocket endpoints are on different hosts — `nd-….p2pify.com` for HTTPS and `ws-nd-….p2pify.com` for WSS — so `solana config set` cannot derive the WebSocket URL from the HTTPS one by swapping the protocol alone. Set it explicitly with `solana config set --ws YOUR_CHAINSTACK_WSS_ENDPOINT`. On **Global Nodes**, HTTPS and WebSocket share the same host (for example, `solana-mainnet.core.chainstack.com`), so the derived WebSocket URL is correct and no `--ws` flag is needed.
+</Note>
 
 ## Networks
 

--- a/reference/tron-api-reference.mdx
+++ b/reference/tron-api-reference.mdx
@@ -1,12 +1,23 @@
 ---
 title: "TRON API reference: HTTP and JSON-RPC quickstart"
-description: "Use the TRON API on Chainstack to query the DPoS blockchain, send transactions, work with TRC-20 tokens, and build DApps with low-fee throughput."
+description: "Use the TRON API on Chainstack to query the DPoS blockchain, send transactions, work with TRC-20 tokens, and build DApps with low-fee throughput. 168 methods across HTTP wallet, walletsolidity, Ethereum-compatible JSON-RPC, and gRPC, at 1 RU per request."
 ---
-## What is the TRON protocol?
 
-TRON is a decentralized blockchain platform designed to build a free, global digital content entertainment system with distributed storage technology. TRON enables cost-effective sharing of digital content and supports smart contracts, various kinds of blockchain systems, and decentralized applications (DApps). The platform uses a Delegated Proof of Stake (DPoS) consensus mechanism for high throughput and scalability.
+The TRON API gives developers programmatic access to the TRON blockchain across four surfaces on one node endpoint: the HTTP `/wallet` and `/walletsolidity` APIs, an Ethereum-compatible JSON-RPC interface, and gRPC. Chainstack serves all four through a single TRON endpoint at a flat 1 RU per request.
 
-Find useful TRON tools in the [TRON tooling](/docs/tron-tooling) section.
+## TRON API at a glance
+
+| Property | Value |
+| --- | --- |
+| Chain | TRON — Layer 1, Delegated Proof of Stake (DPoS) consensus |
+| Resource model | Energy and bandwidth, obtained by staking TRX (no per-call gas in TRX for resourced accounts) |
+| API surfaces | HTTP `/wallet`, HTTP `/walletsolidity`, Ethereum-compatible JSON-RPC, and gRPC |
+| JSON-RPC chain ID | `0x2b6653dc` (728126428) mainnet, `0xcd8690dc` (3448148188) Nile testnet |
+| Methods served by Chainstack | 168 — 101 `/wallet`, 34 `/walletsolidity`, 33 JSON-RPC |
+| Token standards | TRC-20, TRC-10, and shielded TRC-20 |
+| Networks | Mainnet and Nile testnet |
+| Real-time data | Polling — TRON nodes do not serve WebSocket event subscriptions |
+| Request units | 1 RU per request, no archive split |
 
 <Visibility for="humans">
 <Check>
@@ -18,27 +29,77 @@ Find useful TRON tools in the [TRON tooling](/docs/tron-tooling) section.
 </Check>
 </Visibility>
 
+## What is the TRON protocol
+
+TRON is a decentralized Layer 1 blockchain platform designed to build a free, global digital content entertainment system with distributed storage technology. TRON enables cost-effective sharing of digital content and supports smart contracts, various kinds of blockchain systems, and decentralized applications (DApps).
+
+TRON uses a Delegated Proof of Stake (DPoS) consensus mechanism for high throughput and scalability. Token holders stake TRX to vote for super representatives, who produce blocks on the network. Instead of charging gas in TRX on every call, TRON meters execution through two stakeable resources:
+
+- Bandwidth — consumed by transaction byte size, and used for transfers and most non-contract operations.
+- Energy — consumed by smart contract execution. You obtain energy by staking TRX, which makes contract calls effectively free once an account is resourced.
+
+This resource model is what lets TRON sustain low-cost, high-frequency transactions. For a hands-on walkthrough, see [managing energy and bandwidth with Python](/docs/tron-mastering-energy-bandwidth-with-python-and-chainstack).
+
 ## What is the TRON API
 
-The TRON API allows developers to interact with the TRON blockchain network to build applications. It provides comprehensive functionality for managing accounts, transactions, smart contracts, and blockchain data.
+The TRON API lets developers interact with the TRON blockchain to build applications. It provides functionality for managing accounts, transactions, smart contracts, and blockchain data.
 
-The TRON API supports HTTP API endpoints, JSON-RPC methods compatible with Ethereum, and gRPC for high-performance access—making it easy for developers to work with TRON using their preferred protocol.
+To read data and submit transactions, an application connects to a TRON node endpoint, then calls the surface it needs:
 
-## Key features
+- The HTTP `/wallet` API exposes the full node — accounts, blocks, contracts, resource staking, and transaction creation and broadcasting.
+- The HTTP `/walletsolidity` API serves solidified (confirmed) data, read-only.
+- The JSON-RPC interface offers Ethereum-compatible read methods, so Ethereum-native tooling can query a TRON node.
+- The gRPC interface uses HTTP/2 and Protocol Buffers for high-performance, high-throughput access and indexing.
 
-- **Account Management** — create and manage TRON accounts with full control over permissions and resources
-- **Transaction Processing** — broadcast and track transactions on the TRON network
-- **Smart Contract Interaction** — deploy and interact with smart contracts including TRC20 tokens
-- **Resource Management** — manage bandwidth and energy resources through staking mechanisms
-- **Shielded Transactions** — support for privacy-preserving shielded TRC20 transactions
-- **Governance Participation** — participate in network governance through witness voting and proposals
-- **gRPC Support** — high-performance binary protocol for efficient data access and indexing
+## API surfaces
+
+Chainstack exposes all four surfaces over a single node endpoint. Append the path you need to your endpoint URL, except for gRPC, which connects to a dedicated host on port `443`.
+
+| API surface | Endpoint path | Use it for | Served by |
+| --- | --- | --- | --- |
+| HTTP wallet | `/wallet` | Full node — accounts, blocks, contracts, transactions | Chainstack |
+| HTTP walletsolidity | `/walletsolidity` | Confirmed (solidified) read-only data | Chainstack |
+| Ethereum JSON-RPC | `/jsonrpc` | Ethereum-compatible read operations | Chainstack |
+| gRPC | host on port `443` | High-performance binary access and indexing | Chainstack |
+
+<Note>
+TRON's JSON-RPC is read-only by design. The methods required for transaction submission, such as `eth_sendRawTransaction` and `eth_getTransactionCount`, are not available — use the native `/wallet` API or [TronWeb.js](/docs/tron-tooling#tronwebjs) for writes. See [TRON tooling](/docs/tron-tooling#tooling-compatibility) for the full compatibility notes.
+</Note>
+
+### What you can build
+
+With a Chainstack TRON endpoint you can:
+
+- Create and manage accounts, set multi-signature permissions, and validate addresses through the `/wallet` API.
+- Build, sign, and broadcast transactions, and track them with `gettransactioninfobyid`, `gettransactionbyid`, and the JSON-RPC `eth_getTransactionReceipt`.
+- Transfer and interact with TRC-20 and TRC-10 tokens, and run privacy-preserving shielded TRC-20 operations.
+- Deploy and call smart contracts with `deploycontract`, `triggersmartcontract`, and `triggerconstantcontract`.
+- Manage energy and bandwidth — freeze and stake TRX, delegate resources, and query account resources with `freezebalancev2`, `delegateresource`, and `getaccountresource`.
+- Participate in governance — vote for witnesses, and create, approve, and query proposals.
+- Read chain state through Ethereum-compatible JSON-RPC, compatible with web3.py, Foundry, and Hardhat for read operations.
+- Poll for token transfers and new blocks — see [polling for TRC-20 transfers in Node.js](/docs/tron-polling-for-trc20-transfers).
+
+## Methods
+
+Chainstack serves 168 TRON methods across the four surfaces:
+
+| API surface | Endpoint | Methods | Availability |
+| --- | --- | --- | --- |
+| HTTP wallet | `/wallet` | 101 | All served by Chainstack |
+| HTTP walletsolidity | `/walletsolidity` | 34 | All served by Chainstack |
+| Ethereum JSON-RPC | `/jsonrpc` | 33 | All served by Chainstack |
+
+The 33 JSON-RPC methods cover 27 `eth_*` read methods, plus `net_*`, `web3_*`, and `buildTransaction`. gRPC exposes the `protocol.Wallet`, `protocol.Database`, and `protocol.WalletSolidity` services on the same endpoint.
+
+For the complete, per-method list, see [TRON methods](/docs/tron-methods).
+
+<Note>
+TRON pricing is simple: 1 RU per request, with no archive split. TRON nodes run in archive mode — which for TRON means the complete block and transaction history from genesis, not historical state — and every request is billed as full. See [Request units](/docs/request-units#full-vs-archive-by-protocol).
+</Note>
 
 ## How to start using the TRON API
 
-You need access to a TRON RPC node to use the TRON API.
-
-Follow these steps to sign up on Chainstack, deploy a TRON RPC node, and find your endpoint credentials:
+To use the TRON API, you need access to a TRON node endpoint. Follow these steps to sign up, deploy a node, and find your credentials:
 
 <Steps>
 <Step>
@@ -51,23 +112,71 @@ Follow these steps to sign up on Chainstack, deploy a TRON RPC node, and find yo
 [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 </Step>
 </Steps>
-Now, you can connect to the TRON blockchain and use the TRON API to build.
 
-## API categories
+Now you are ready to connect to the TRON blockchain and build.
 
-The TRON API is organized into several categories:
+## SDKs and tooling
 
-- **Wallet operations** — core wallet functions for address validation, transaction creation, and broadcasting
-- **Account management** — account creation, updates, and permission management
-- **Resource management** — bandwidth and energy staking, delegation, and withdrawal
-- **Block operations** — retrieve block information and monitor the blockchain
-- **Transaction operations** — query and track transactions
-- **Smart contracts** — deploy and interact with smart contracts
-- **Shielded contracts** — privacy-preserving shielded TRC20 operations
-- **Witness and governance** — network governance and witness management
-- **Assets and exchanges** — TRC10 token operations and decentralized exchange functions
-- **JSON-RPC** — Ethereum-compatible JSON-RPC endpoints for read operations (note: transaction submission methods like `eth_sendRawTransaction` are not supported; use the native wallet API instead)
-- **gRPC** — high-performance binary protocol using HTTP/2 and Protocol Buffers; see [TRON tooling](/docs/tron-tooling#grpc-api) for setup and usage
+You can call the API directly over HTTP and gRPC, or use a maintained library:
+
+- TronWeb.js — the official [TronWeb](https://tronweb.network/) JavaScript library. It supports all TRON operations, including contract deployment and transactions, through the `/wallet` API.
+- web3.py and Ethereum tooling — [web3.py](https://github.com/ethereum/web3.py), Foundry, and Hardhat can run read operations against the `/jsonrpc` endpoint, but cannot deploy or send transactions directly. Compile and test with Foundry or Hardhat, then deploy with TronWeb.js in a hybrid workflow.
+- gRPC clients — generate typed clients from the [TRON protocol buffer definitions](https://github.com/tronprotocol/protocol) for Python, Node.js, or Go.
+
+Point any tool at your Chainstack endpoint. See [TRON tooling](/docs/tron-tooling) for setup, the [gRPC API section](/docs/tron-tooling#grpc-api) for generating clients, and the [hybrid workflow](/docs/tron-tooling#hybrid-workflow) for deploying compiled contracts.
+
+## Networks
+
+Chainstack supports TRON mainnet and Nile testnet as Global Nodes. TRON nodes run in archive mode, which for TRON means the complete block and transaction history from genesis rather than historical state — there is no separate full versus archive split.
+
+| Feature | Mainnet | Nile testnet |
+| --- | --- | --- |
+| JSON-RPC chain ID | `0x2b6653dc` (728126428) | `0xcd8690dc` (3448148188) |
+| Block and transaction history | From genesis | From genesis |
+| gRPC endpoint | `tron-mainnet.core.chainstack.com:443` | `tron-nile.core.chainstack.com:443` |
+| Faucet | N/A | [Nile faucet](https://nileex.io/join/getJoinPage) |
+
+<Note>
+TRON archive means full block and transaction history, not historical state. java-tron has no state-at-block queries — `eth_getBalance`, `eth_call`, `eth_getCode`, and `eth_getStorageAt` accept only the `latest` block. This is a protocol limitation ([java-tron#6289](https://github.com/tronprotocol/java-tron/issues/6289)), not a Chainstack one. See [Historical data availability](/docs/tron-tooling#historical-data-availability).
+</Note>
+
+## Frequently asked questions
+
+### What API surfaces does TRON expose on Chainstack?
+
+Four, all on one node endpoint: the HTTP `/wallet` API (full node), the HTTP `/walletsolidity` API (confirmed read-only data), an Ethereum-compatible JSON-RPC interface at `/jsonrpc`, and gRPC on port `443`. Chainstack serves 168 methods across the three HTTP and JSON-RPC surfaces.
+
+### Is TRON's JSON-RPC fully Ethereum-compatible?
+
+No. TRON's JSON-RPC provides Ethereum-compatible methods for read operations only. The methods required to submit transactions, such as `eth_sendRawTransaction` and `eth_getTransactionCount`, are not available. For writes, use the native `/wallet` API or TronWeb.js. The JSON-RPC chain ID is `0x2b6653dc` (728126428) on mainnet.
+
+### What is the difference between energy and bandwidth?
+
+Both are stakeable resources that meter execution instead of charging gas in TRX on every call. Bandwidth is consumed by transaction byte size and covers transfers and most non-contract operations. Energy is consumed by smart contract execution. You obtain both by staking TRX with `freezebalancev2`, which makes operations effectively free once an account is resourced. See [managing energy and bandwidth](/docs/tron-mastering-energy-bandwidth-with-python-and-chainstack).
+
+### How do I work with TRC-20 tokens?
+
+Use the `/wallet` API and TronWeb.js to transfer and call TRC-20 contracts with `triggersmartcontract` and `triggerconstantcontract`. TRON also supports the TRC-10 native token standard and privacy-preserving shielded TRC-20 operations. To monitor transfers, poll the chain — see [polling for TRC-20 transfers in Node.js](/docs/tron-polling-for-trc20-transfers).
+
+### Does TRON support WebSocket subscriptions?
+
+No. TRON nodes do not serve WebSocket connections for event subscriptions, so track on-chain activity by polling block and transaction methods. To follow this capability, see the feature request for [TRON event plugin support](https://ideas.chainstack.com/p/implement-tron-event-plugin).
+
+### Why is there no archive versus full pricing for TRON?
+
+TRON pricing is a flat 1 RU per request, with no archive split. TRON nodes run in archive mode, but for TRON that means the complete block and transaction history from genesis rather than historical state — java-tron has no state-at-block queries. Billing is independent of node mode, so every request is billed as full. See [Request units](/docs/request-units#full-vs-archive-by-protocol).
+
+### When should I use gRPC instead of HTTP?
+
+Use gRPC for high-throughput applications and data indexing, where its HTTP/2 transport and binary Protocol Buffers serialization are more efficient than HTTP. Chainstack serves the `protocol.Wallet`, `protocol.Database`, and `protocol.WalletSolidity` services on the same `:443` endpoint. See the [gRPC API section](/docs/tron-tooling#grpc-api).
+
+## Related TRON resources
+
+- [TRON methods](/docs/tron-methods) — complete per-surface method reference
+- [TRON tooling](/docs/tron-tooling) — TronWeb.js, gRPC, web3.py, Foundry, and Hardhat setup
+- [Managing energy and bandwidth with Python](/docs/tron-mastering-energy-bandwidth-with-python-and-chainstack) — TRON's resource and fee model
+- [Polling for TRC-20 transfers in Node.js](/docs/tron-polling-for-trc20-transfers) — monitor token transfers without WebSocket
+- [Request units](/docs/request-units#full-vs-archive-by-protocol) — how TRON requests are billed
 
 <Info>
   **See also**


### PR DESCRIPTION
Rolls the Hyperliquid GEO template (proven in #471) across the top reference protocols by AI-citation traffic. Each page now leads with an at-a-glance stats table, adds API-surface/methods tables, an inlined capability inventory, an FAQ (plain h3 for Cmd-F + AI lifting), and a hub-link cluster — adapted per protocol, not copy-pasted.

## Pages
- **Ethereum** (`reference/ethereum-getting-started.mdx`, 315 → ~1,580 w) — extended to both layers: execution JSON-RPC + Beacon Chain consensus.
- **Solana** (`reference/solana-getting-started.mdx`, 343 → ~1,780 w) — clusters (no chain ID), WebSocket vs Yellowstone gRPC Geyser, priority fees.
- **TON** (`reference/getting-started-ton.mdx`, ~1,590 w) — v2 node API + v3 indexer surfaces, workchains, jettons/NFTs.
- **TRON** (`reference/tron-api-reference.mdx`, 529 → ~1,760 w) — four surfaces (wallet, walletsolidity, JSON-RPC, gRPC), energy/bandwidth, no historical state.

## Verification
Every figure traced to the repo (methods pages, `node-options-master-list.json`, specs) or a live RPC probe — no competitor numbers copied:
- **Ethereum** — 100 served = 69 execution (eth 39, debug 9, trace 8, erigon 8, net 3, web3 2) + 31 Beacon; txpool_/admin_ correctly marked not-served. Chain IDs 1 / 11155111 / **Hoodi 560048** (live-probed `0x88bb0`); Hoodi archive-only per master list.
- **Solana** — 67 served = 51 HTTP + 16 WS (70 rows − 3 not-served incl. vote-sub). Mainnet + devnet; Geyser mainnet-only paid add-on.
- **TON** — 62 = 28 v2 + 34 v3; workchains -1 / 0; archive on every node.
- **TRON** — 168 = 101 wallet + 34 walletsolidity + 33 JSON-RPC. Mainnet chain ID `0x2b6653dc` (live-probed). **Caught + fixed: Nile chain ID was a mislabeled Shasta value (`0x94a9059e`) → corrected to `0xcd8690dc` (3448148188), live-probed.**

All internal links resolve, no unescaped `$`, CTA blocks preserved verbatim, URLs/slugs unchanged. Nav (`docs.json`) untouched — all four are existing pages.

Drafted by parallel subagents against the HL template, then every hard number independently re-verified before commit.