### PR TITLE
docs: remove deprecated web3.js from 24 EVM tooling pages

### DIFF
--- a/docs/arbitrum-tooling.mdx
+++ b/docs/arbitrum-tooling.mdx
@@ -49,45 +49,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Arbitrum nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Arbitrum nodes deployed with Chainstack.

--- a/docs/aurora-tooling.mdx
+++ b/docs/aurora-tooling.mdx
@@ -45,45 +45,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Aurora nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Aurora nodes deployed with Chainstack.

--- a/docs/avalanche-tooling.mdx
+++ b/docs/avalanche-tooling.mdx
@@ -95,45 +95,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-### web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Avalanche nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-#### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-#### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ### web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Avalanche nodes deployed with Chainstack.

--- a/docs/base-tooling.mdx
+++ b/docs/base-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Base tooling"
-description: "Complete Base tooling guide for Chainstack nodes. Use Geth, MetaMask, Hardhat, web3.js, ethers.js, GraphQL, Foundry, and more to build dApps on Base blockchain."
+description: "Complete Base tooling guide for Chainstack nodes. Use Geth, MetaMask, Hardhat, ethers.js, GraphQL, Foundry, and more to build dApps on Base blockchain."
 ---
 
 Get started with a [reliable Base RPC endpoint](https://chainstack.com/build-better-with-base/) to use the tools below.
@@ -129,49 +129,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
 For a detailed tutorial with Remix IDE, see [Trust fund account with Remix](/docs/ethereum-tutorial-trust-fund-account-with-remix).
-
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Base nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require("web3");
-
-  const web3 = new Web3(
-    new Web3.providers.HttpProvider("YOUR_CHAINSTACK_ENDPOINT")
-  );
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require("web3");
-
-  const web3 = new Web3(
-    new Web3.providers.WebsocketProvider("YOUR_CHAINSTACK_ENDPOINT")
-  );
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password
 
 ## web3.py
 

--- a/docs/blast-tooling.mdx
+++ b/docs/blast-tooling.mdx
@@ -51,48 +51,6 @@ This will engage MetaMask and make Remix IDE interact with the network through a
 
 For a detailed tutorial with Remix IDE, see [Trust fund account with Remix](/docs/ethereum-tutorial-trust-fund-account-with-remix).
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Blast nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const { Web3 } = require("web3");
-
-  const node_url = "CHAINSTACK_NODE_URL";
-  const web3 = new Web3(node_url);
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const { Web3 } = require("web3");
-
-  const web3 = new Web3(
-    new Web3.providers.WebsocketProvider("YOUR_CHAINSTACK_ENDPOINT")
-  );
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Blast nodes deployed with Chainstack.

--- a/docs/bsc-tooling.mdx
+++ b/docs/bsc-tooling.mdx
@@ -130,46 +130,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and BNB Smart Chain nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and BNB Smart Chain nodes deployed with Chainstack.

--- a/docs/celo-tooling.mdx
+++ b/docs/celo-tooling.mdx
@@ -9,30 +9,6 @@ Get started with a [reliable Celo RPC endpoint](https://chainstack.com/build-bet
 
 On [node access details](/docs/manage-your-node#view-node-access-and-credentials), click **Connect wallet**.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Celo nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-
-2. Connect over HTTP.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const {Web3} = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Celo nodes deployed with Chainstack.

--- a/docs/cronos-tooling.mdx
+++ b/docs/cronos-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cronos tooling"
-description: "Complete Cronos tooling guide for Chainstack nodes. Use MetaMask, Hardhat, web3.js, ethers.js, Remix IDE, Foundry, and more to build dApps on Cronos blockchain."
+description: "Complete Cronos tooling guide for Chainstack nodes. Use MetaMask, Hardhat, ethers.js, Remix IDE, Foundry, and more to build dApps on Cronos blockchain."
 ---
 
 Get started with a [reliable Cronos RPC endpoint](https://chainstack.com/build-better-with-cronos/) to use the tools below.
@@ -51,46 +51,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
-
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Cronos nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
 
 ## web3.py
 

--- a/docs/ethereum-tooling.mdx
+++ b/docs/ethereum-tooling.mdx
@@ -76,34 +76,6 @@ To enable Remix IDE to interact with the network through a Chainstack node, you 
 
 WebSockets and HTTP are essential communication protocols in web applications. WebSockets enable two-way, persistent communication between a client and a server, useful for real-time price feeds, live transaction monitoring, and event notifications. In contrast, HTTP follows a one-way, request-response model, ideal for retrieving periodic price updates and transaction histories.
 
-### web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Ethereum nodes deployed with Chainstack.
-
-1. Install web3.js
-   <CodeGroup>
-     ```bash Bash
-     npm install web3
-     ```
-   </CodeGroup>
-2. Initialize HTTP or WebSocket provider
-   <CodeGroup>
-     ```javascript Javascript
-     import { Web3, HttpProvider, WebSocketProvider } from 'web3';
-
-     // Using HTTP provider
-     const httpProvider = new Web3(new HttpProvider("/*YOUR_HTTP_CHAINSTACK_ENDPOINT*/"));
-     httpProvider.eth.getBlockNumber().then(console.log);
-
-     // Using WebSocket provider
-     const wsProvider = new Web3(new WebSocketProvider("/*YOUR_WS_CHAINSTACK_ENDPOINT*/"));
-     wsProvider.eth.getBlockNumber().then((blockNumber) => {
-         console.log(blockNumber);
-         wsProvider.currentProvider.safeDisconnect();
-     });
-     ```
-   </CodeGroup>
-
 ### ethers.js
 
 Build DApps using [ethers.js](https://github.com/ethers-io/ethers.js) and Ethereum nodes deployed with Chainstack.

--- a/docs/fantom-tooling.mdx
+++ b/docs/fantom-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fantom tooling"
-description: "Complete Fantom tooling guide for Chainstack nodes. Use MetaMask, Hardhat, web3.js, ethers.js, Foundry, Remix IDE, and more to build dApps on Fantom blockchain."
+description: "Complete Fantom tooling guide for Chainstack nodes. Use MetaMask, Hardhat, ethers.js, Foundry, Remix IDE, and more to build dApps on Fantom blockchain."
 ---
 
 Get started with a [reliable Fantom RPC endpoint](https://chainstack.com/build-better-with-fantom/) to use the tools below.
@@ -86,46 +86,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
-
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Fantom nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
 
 ## web3.py
 

--- a/docs/filecoin-tooling.mdx
+++ b/docs/filecoin-tooling.mdx
@@ -29,45 +29,6 @@ To make Remix IDE interact with the network through a Filecoin node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Filecoin node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Filecoin nodes.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('FILECOIN_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where FILECOIN\_ENDPOINT is your node HTTPS endpoint.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('FILECOIN_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where FILECOIN\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Filecoin nodes.

--- a/docs/fuse-tooling.mdx
+++ b/docs/fuse-tooling.mdx
@@ -50,44 +50,6 @@ To make Remix IDE interact with the network through a Fuse node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Fuse node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Fuse nodes.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_NODE_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_FUSE\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_NODE_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_FUSE\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Fuse nodes.

--- a/docs/gnosis-tooling.mdx
+++ b/docs/gnosis-tooling.mdx
@@ -63,51 +63,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Gnosis Chain nodes deployed with Chainstack.
-
-<Steps>
-  <Step>
-    Install [web3.js](https://web3js.readthedocs.io/).
-  </Step>
-  <Step>
-    Connect over HTTP or WebSocket.
-  </Step>
-</Steps>
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Gnosis Chain nodes deployed with Chainstack.

--- a/docs/harmony-tooling.mdx
+++ b/docs/harmony-tooling.mdx
@@ -46,45 +46,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Harmony nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Harmony nodes deployed with Chainstack.

--- a/docs/klaytn-tooling.mdx
+++ b/docs/klaytn-tooling.mdx
@@ -28,29 +28,6 @@ On [node access details](/docs/manage-your-node#view-node-access-and-credentials
   ```
 </CodeGroup>
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Klaytn nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const {Web3} = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Klaytn nodes deployed with Chainstack.

--- a/docs/moonbeam-tooling.mdx
+++ b/docs/moonbeam-tooling.mdx
@@ -15,29 +15,6 @@ Find the [Substrate tools](https://docs.moonbeam.network/builders/build/substrat
 
 On [node access details](/docs/manage-your-node#view-node-access-and-credentials), click **Connect wallet**.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Moonbeam nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const {Web3} = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where `YOUR_CHAINSTACK_ENDPOINT` is your node HTTPS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Moonbeam nodes deployed with Chainstack.

--- a/docs/oasis-sapphire-tooling.mdx
+++ b/docs/oasis-sapphire-tooling.mdx
@@ -71,44 +71,6 @@ where
 
 5. Run `npx hardhat run --network sapphire_testnet scripts/deploy.js`, and Hardhat will deploy using Chainstack.
 
-### web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Oasis Sapphire nodes deployed with Chainstack.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-#### HTTPS
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```js JavaScript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-#### WSS
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```js JavaScript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ### node.js
 
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):

--- a/docs/opbnb-tooling.mdx
+++ b/docs/opbnb-tooling.mdx
@@ -9,28 +9,6 @@ Get started with a [reliable opBNB RPC endpoint](https://chainstack.com/build-be
 
 On [node access details](/docs/manage-your-node#view-node-access-and-credentials), click **Connect wallet**.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and opBNB nodes deployed with Chainstack.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const {Web3} = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where `YOUR_CHAINSTACK_ENDPOINT` is your node HTTPS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and opBNB nodes deployed with Chainstack.

--- a/docs/optimism-tooling.mdx
+++ b/docs/optimism-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Optimism tooling"
-description: "Complete Optimism tooling guide for Chainstack nodes. Use MetaMask, Hardhat, web3.js, ethers.js, Foundry, GraphQL, and more to build dApps on Optimism Layer 2."
+description: "Complete Optimism tooling guide for Chainstack nodes. Use MetaMask, Hardhat, ethers.js, Foundry, GraphQL, and more to build dApps on Optimism Layer 2."
 ---
 
 Get started with a [reliable Optimism RPC endpoint](https://chainstack.com/build-better-with-optimism/) to use the tools below.
@@ -48,45 +48,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
-
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Polygon nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
 
 ## web3.py
 

--- a/docs/polygon-tooling.mdx
+++ b/docs/polygon-tooling.mdx
@@ -117,44 +117,6 @@ To make Remix IDE interact with the network through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy** tab. Select **Injected Provider - MetaMask** in **Environment**.
 This will engage MetaMask and make Remix IDE interact with the network through a Chainstack node.
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Polygon nodes deployed with Chainstack.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Polygon nodes deployed with Chainstack.

--- a/docs/polygon-zkevm-tooling.mdx
+++ b/docs/polygon-zkevm-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Polygon zkEVM tooling"
-description: "Complete Polygon zkEVM tooling guide for Chainstack nodes. Use MetaMask, Hardhat, web3.js, ethers.js, Brownie, Remix IDE, and more for zkEVM development."
+description: "Complete Polygon zkEVM tooling guide for Chainstack nodes. Use MetaMask, Hardhat, ethers.js, Brownie, Remix IDE, and more for zkEVM development."
 ---
 
 <Warning>
@@ -45,28 +45,6 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
    },
    };
    ```
-### web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Polygon zkEVM nodes deployed with Chainstack.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-#### HTTPS
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```js JavaScript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
 ### web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Polygon zkEVM nodes deployed with Chainstack.

--- a/docs/ronin-tooling.mdx
+++ b/docs/ronin-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ronin tooling"
-description: "Complete Ronin tooling guide for Chainstack nodes. Use web3.js, web3.py, ethers.js with HTTP and WebSocket connections to build Web3 games on Ronin blockchain."
+description: "Complete Ronin tooling guide for Chainstack nodes. Use web3.py, ethers.js with HTTP and WebSocket connections to build Web3 games on Ronin blockchain."
 ---
 
 Get started with a [reliable Ronin RPC endpoint](https://chainstack.com/build-better-with-ronin/) to use the tools below.
@@ -24,45 +24,6 @@ There is no block overlap between the two backends. Range-based methods like `et
 
 The Ronin mainnet is also planned to migrate to an Ethereum L2 in Q1–Q2 2026. The mainnet chain ID will remain `2020`.
 </Warning>
-
-## web3.js
-
-Build DApps using [web3.js](https://github.com/web3/web3.js) and Ronin nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
 
 ## web3.py
 

--- a/docs/scroll-tooling.mdx
+++ b/docs/scroll-tooling.mdx
@@ -128,45 +128,6 @@ This will engage MetaMask and make Remix IDE interact with the network through a
 
 For a detailed tutorial with Remix IDE, see [Trust fund account with Remix](/docs/ethereum-tutorial-trust-fund-account-with-remix).
 
-## web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and Scroll nodes deployed with Chainstack.
-
-1. Install [web3.js](https://web3js.readthedocs.io/).
-2. Connect over HTTP or WebSocket.
-
-### HTTP
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password
-
-### WebSocket
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```javascript Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password
-
 ## web3.py
 
 Build DApps using [web3.py](https://github.com/ethereum/web3.py) and Scroll nodes deployed with Chainstack.

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "zkSync Era tooling"
-description: "zkSync Era development tools guide. Use zksync-ethers SDK, Hardhat, MetaMask, web3.js, ethers.js, and Remix IDE with Chainstack zkSync Era nodes."
+description: "zkSync Era development tools guide. Use zksync-ethers SDK, Hardhat, MetaMask, ethers.js, and Remix IDE with Chainstack zkSync Era nodes."
 ---
 
 Get started with a [reliable zkSync Era RPC endpoint](https://chainstack.com/build-better-with-zksync-era/) to use the tools below.
@@ -71,45 +71,6 @@ Configure [Hardhat](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync)
 <Info>
   Follow the tutorial for a better understanding: [zkSync Era∎: Develop a custom paymaster contract](/docs/zksync-tutorial-develop-a-custom-paymaster-contract)
 </Info>
-
-### web3.js
-
-Build DApps using [web3.js](https://github.com/ethereum/web3.js/) and zkSync Era nodes deployed with Chainstack.
-1. Install [web3.js](https://web3js.readthedocs.io/).
-
-2. Connect over HTTP or WebSocket.
-
-#### HTTPS
-
-Use the `HttpProvider` object to connect to your node HTTPS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```js Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.HttpProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either with the key or password.
-
-#### WSS
-
-Use the `WebsocketProvider` object to connect to your node WSS endpoint and get the latest block number:
-
-<CodeGroup>
-  ```js Javascript
-  const Web3 = require('web3');
-
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('YOUR_CHAINSTACK_ENDPOINT'));
-
-  web3.eth.getBlockNumber().then(console.log);
-  ```
-</CodeGroup>
-
-where YOUR\_CHAINSTACK\_ENDPOINT is your node WSS endpoint protected either with the key or password.
 
 ### web3.py
 


### PR DESCRIPTION
ChainSafe sunset **web3.js** (the EVM JavaScript library) in 2025, steering developers to viem/ethers. This removes it from the EVM tooling pages so we stop recommending a dead library. Follows the same call made on the Ethereum getting-started page in #472.

## What changed
- Deleted the dedicated `### web3.js` section (heading + install + HTTP/WebSocket provider examples) from **24 EVM tooling pages**.
- Dropped `web3.js` from **7 frontmatter descriptions** that listed it as a tool.
- **Kept** every other library section: `ethers.js`, `viem`, `web3.py`, `web3.php`, `web3j`. Every page retains a modern JS path (ethers/viem).

## How
- CRLF-safe, level-aware section strip (removes the web3.js heading through the next same-or-higher heading, so nested `### HTTP`/`### WebSocket` code subsections go with it).
- Verified: 0 web3.js JS signatures remain (`from 'web3'`, `require('web3')`, `npm install web3`, headings); `<CodeGroup>` tags balanced on every page; all 24 pages render 200 locally.

## Deliberately excluded
- **Quorum** — web3.js is its *only* JS library (others are Truffle, web3j, JSON-RPC). Deleting it outright would leave no JS option. Handling it separately (likely replace with an ethers.js section).
- **`@solana/web3.js`** — a different, current library (Solana's SDK). Untouched.
- **~400 EVM reference *method* pages** with web3.js code examples — a separate, larger pass (rewriting runnable samples), not this PR.