### PR TITLE
docs: web3.js deprecation banners on 14 tutorial pages

### DIFF
--- a/docs/celo-build-a-simple-voting-dapp-with-foundry-nextjs-and-web3js.mdx
+++ b/docs/celo-build-a-simple-voting-dapp-with-foundry-nextjs-and-web3js.mdx
@@ -3,6 +3,11 @@ title: "Celo: Build a voting dApp with Foundry and Next.js"
 description: Build a voting dApp on Celo with a Solidity contract deployed via Foundry and a React/Next.js frontend using web3.js and MetaMask for interaction.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * You’ll build a simple voting DApp on Celo: a Solidity contract (Voting.sol) deployed with Foundry, and a React/Next.js front-end with web3.js to interact via MetaMask.
 * The Solidity contract defines two initial candidates (Luna, Orion) and basic voting logic, tested with Foundry’s test suite.

--- a/docs/deep-dive-into-merkle-proofs-and-eth-getproof-ethereum-rpc-method.mdx
+++ b/docs/deep-dive-into-merkle-proofs-and-eth-getproof-ethereum-rpc-method.mdx
@@ -3,6 +3,11 @@ title: "Deep dive into Merkle proofs and eth_getProof"
 description: Understand Merkle proofs and use eth_getProof to verify Ethereum account state and storage slots without trusting a full node for data authenticity.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR**
 * Introduces the eth\_getProof method, which returns a Merkle proof of an account’s state and storage at a specific block.
 * Explains Ethereum’s Merkle trie structure and how merkle proofs allow verifying account/storage data without downloading the entire state.

--- a/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
+++ b/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
@@ -3,6 +3,11 @@ title: "Ethereum logs tutorial series: Logs and filters"
 description: Master Ethereum event logs and filters with practical examples covering eth_getLogs, topics encoding, and smart contract event monitoring on Chainstack.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR**
 * Explains how Ethereum logs provide an immutable record of on-chain events, while filters allow targeted retrieval of these logs based on addresses, topics, or block ranges.
 * Demonstrates retrieving historical logs with getPastLogs for one-time queries, and real-time subscription to new logs with eth\_subscribe for reactive DApps.

--- a/docs/expanding-your-blockchain-horizons-the-eth_getblockreceipts-emulator.mdx
+++ b/docs/expanding-your-blockchain-horizons-the-eth_getblockreceipts-emulator.mdx
@@ -3,6 +3,11 @@ title: eth_getBlockReceipts emulator for blockchain data
 description: "Build eth_getBlockReceipts emulator with Node.js and web3.js using Chainstack. Replicate transaction receipt retrieval for EVM chains without native support."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR**
 * Demonstrates building a stand-in for the eth\_getBlockReceipts method (available natively on Erigon and newer Geth versions) using the eth\_getBlockByNumber and eth\_getTransactionReceipt calls on any EVM chain.
 * Uses Node.js and web3.js to fetch all transaction receipts for a specified block, grouping them into a single array – effectively replicating the one-call convenience of eth\_getBlockReceipts.

--- a/docs/fetching-transfer-events-with-getpastevents-for-a-bayc-nft.mdx
+++ b/docs/fetching-transfer-events-with-getpastevents-for-a-bayc-nft.mdx
@@ -3,6 +3,11 @@ title: Fetch BAYC transfer events with web3.js getPastEvents
 description: Retrieve BAYC NFT transfer history using web3.js getPastEvents method with event log filtering through a Chainstack Ethereum node for NFT analytics.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR**
 
 * Set up a node.js script using web3.js to connect to Ethereum via Chainstack endpoints.

--- a/docs/handle-real-time-data-using-websockets-with-javascript-and-python.mdx
+++ b/docs/handle-real-time-data-using-websockets-with-javascript-and-python.mdx
@@ -3,6 +3,11 @@ title: Handle real-time data with WebSockets in JS & Python
 description: Connect to Chainstack WebSocket endpoints for real-time blockchain data streaming using web3.js, ethers.js, and Python with auto-reconnect logic.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR**
 * Demonstrates how to connect to the Chainstack API over WebSockets for real-time blockchain data using web3.js, ethers.js, and Python.
 * Explains the advantages of WebSocket vs. HTTP (bidirectional, persistent connection).

--- a/docs/harnessing-chainlink-oracles-with-chainstack-fetching-real-time-crypto-prices-from-ethereum.mdx
+++ b/docs/harnessing-chainlink-oracles-with-chainstack-fetching-real-time-crypto-prices-from-ethereum.mdx
@@ -3,6 +3,11 @@ title: "Chainlink oracles: Fetch real-time crypto prices"
 description: Fetch real-time cryptocurrency prices from Chainlink oracle contracts on Ethereum using web3.js and a Chainstack node, removing reliance on external APIs.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Set up a node.js script using web3.js to connect to Ethereum via Chainstack endpoints.
 * Fetch real-time crypto prices through Chainlink’s AggregatorV3Interface contracts, removing reliance on external APIs.

--- a/docs/http-batch-request-vs-multicall-contract.mdx
+++ b/docs/http-batch-request-vs-multicall-contract.mdx
@@ -3,6 +3,11 @@ title: "HTTP batch request VS multicall contract"
 description: Compare HTTP batch requests and Multicall contracts for efficient blockchain data fetching, with performance benchmarks and code examples on Chainstack.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Both HTTP batch requests and multicall contracts can bundle multiple calls to reduce client-server overhead and improve response times.
 * In the tests, HTTP batch requests often slightly outperformed multicall contracts, but both outperformed sending multiple single requests by a significant margin.

--- a/docs/make-your-dapp-more-reliable-with-chainstack.mdx
+++ b/docs/make-your-dapp-more-reliable-with-chainstack.mdx
@@ -3,6 +3,11 @@ title: "Make your dApp more reliable with Chainstack"
 description: Improve dApp reliability with Chainstack global elastic nodes for automatic geographic load balancing, failover routing, and low-latency RPC connections.
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Explains how Chainstack’s global node feature can boost your DApp’s reliability by balancing traffic automatically based on user location.
 * Demonstrates a JavaScript load balancer script using multiple Chainstack endpoints, distributing requests across different regions to avoid single-point failures.

--- a/docs/migrating-from-google-cloud-blockchain-node-engine-to-chainstack.mdx
+++ b/docs/migrating-from-google-cloud-blockchain-node-engine-to-chainstack.mdx
@@ -4,6 +4,11 @@ sidebarTitle: "Google Blockchain Node Engine"
 description: "Step-by-step guide to migrate from Google Cloud Blockchain Node Engine and Blockchain RPC to Chainstack before the December 15, 2026 shutdown, covering node-type mapping, endpoint and authentication changes, and code examples."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Google Cloud is shutting down Blockchain Node Engine (BNE) and Blockchain RPC on December 15, 2026, and will delete all nodes and endpoints on that date.
 * New BNE node and endpoint creation has been disabled since June 15, 2026, so you can migrate existing workloads but you can't provision new BNE resources.

--- a/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
+++ b/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
@@ -3,6 +3,11 @@ title: "Tracking some Bored Apes: The Ethereum event logs tutorial"
 description: "Learn Ethereum event logs with BAYC NFT transfers. Fetch smart contract events using eth_getLogs, web3.js subscriptions, and filter by topics with Chainstack."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Shows how Ethereum events in Solidity serve as logs, capturing contract activity (e.g. NFT transfers).
 * Explains the event signature and parameter indexing, plus how to find them on Etherscan or through hashing with keccak256.

--- a/docs/understanding-eth-getlogs-limitations.mdx
+++ b/docs/understanding-eth-getlogs-limitations.mdx
@@ -3,6 +3,11 @@ title: "Understanding eth_getLogs limitations"
 description: "Master eth_getLogs block range limits and best practices. Paginate queries, filter efficiently, and optimize Ethereum log retrieval for scalable DApps."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * `eth_getLogs` is a powerful method to retrieve Ethereum logs but can strain node resources if not managed properly.
 * Always adhere to your network’s recommended block range limit and paginate larger queries to avoid timeout errors.

--- a/docs/web3-nodejs-from-zero-to-a-full-fledged-project.mdx
+++ b/docs/web3-nodejs-from-zero-to-a-full-fledged-project.mdx
@@ -3,6 +3,11 @@ title: "Web3 node.js: From zero to a full-fledged project"
 description: "Complete Web3 Node.js development guide. Learn nvm setup, web3.js best practices, security, testing with Mocha/Chai, and production deployment strategies."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Discusses how to set up a Node.js environment (via nvm) for smooth version management and package handling (via npm).
 * Covers Web3.js usage, project structure tips, and key security practices like environment variable storage and address checksums.

--- a/docs/web3js-how-to-use-the-new-chainstack-plugin.mdx
+++ b/docs/web3js-how-to-use-the-new-chainstack-plugin.mdx
@@ -3,6 +3,11 @@ title: "Web3.js: How to use the Chainstack plugin"
 description: "Integrate Chainstack nodes with web3.js using @chainsafe/web3-plugin-chainstack. Securely authenticate, fetch node details, and use Platform API endpoints."
 ---
 
+<Note>
+This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.
+</Note>
+
+
 **TLDR:**
 * Seamlessly integrate Chainstack-managed nodes with web3.js using the @chainsafe/web3-plugin-chainstack plugin.
 * Securely authenticate with Chainstack’s API to fetch node details and dynamically build endpoints.


### PR DESCRIPTION
Final piece of the web3.js sweep. These 14 tutorials use web3.js as their JavaScript library. Rather than rewrite each (substantial, low-traffic) or delete them (loses URL/SEO equity and the tutorials still help people on web3.js), each gets a `<Note>` at the top:

> This tutorial uses **web3.js**, which is [no longer maintained](https://github.com/web3/web3.js) (ChainSafe sunset it in 2025). For new projects, use [ethers.js or viem](/docs/ethereum-tooling) — the concepts here still apply; only the library calls differ.

After this, **no page presents web3.js as current without a heads-up**, which completes the consistency goal cheaply.

**Left as-is (web3.js by design):**
- *Redundant event listener with ethers/web3.js* — deliberately contrasts both libraries
- *Send Warp transactions with web3.js, ethers.js, web3.py, and ethclient-go* — a multi-library showcase

Banner is idempotent, placed after frontmatter, `<Note>` tags balanced, frontmatter intact. `docs.json` untouched.