### PR TITLE
docs(limits): Solana getTokenAccountsByOwner RL is now region-specific (80/20)

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -108,17 +108,23 @@ The following limits are applied on all subscription plans:
 
 ## Solana method limits
 
-The following per-method RPS limits apply identically across all regions:
+The following per-method RPS limits apply across all regions, except where a regional override is noted below:
 
 | Method | RPS |
 | ------ | --- |
 | `getBlockTime` | 500 |
 | `getBlock` | 400 |
 | `getTokenSupply` | 300 |
-| `getTokenAccountsByOwner` | 80 |
+| `getTokenAccountsByOwner` | 80 — reduced to 20 in select regions (see below) |
 | `getSupply` | 2 |
 | `getLargestAccounts` | 0 — available on [Dedicated Nodes](/docs/dedicated-node) only |
 | `getTokenLargestAccounts` | 0 — available on [Dedicated Nodes](/docs/dedicated-node) only |
+
+[`getTokenAccountsByOwner`](/reference/solana-gettokenaccountsbyowner) — 80 RPS by default, reduced to 20 RPS in these regions:
+
+- Chainstack Cloud Frankfurt `fra1` RPS: 20
+- Chainstack Cloud Los Angeles `lax2` RPS: 20
+- Chainstack Cloud Singapore `sgp1` RPS: 20
 
 [`getProgramAccounts`](/reference/solana-getprogramaccounts) — unfiltered requests to large programs are blocked; always use `dataSize` or `memcmp` filters:
 

--- a/docs/solana-methods.mdx
+++ b/docs/solana-methods.mdx
@@ -51,7 +51,7 @@ For per-method rate limits, plan restrictions, and archive data availability, se
 | [getSupply](/reference/solana-getsupply) | <Icon icon="square-check"  iconType="solid" /> | Paid plans only. 2 RPS |
 | [getTokenAccountBalance](/reference/solana-gettokenaccountbalance) | <Icon icon="square-check"  iconType="solid" /> | |
 | [getTokenAccountsByDelegate](/reference/solana-gettokenaccountsbydelegate) | <Icon icon="square-check"  iconType="solid" /> | |
-| [getTokenAccountsByOwner](/reference/solana-gettokenaccountsbyowner) | <Icon icon="square-check"  iconType="solid" /> | Paid plans only. 80 RPS |
+| [getTokenAccountsByOwner](/reference/solana-gettokenaccountsbyowner) | <Icon icon="square-check"  iconType="solid" /> | Paid plans only. 80 RPS; lower in some regions — see [limits](/docs/limits#solana-method-limits) |
 | [getTokenLargestAccounts](/reference/solana-gettokenlargestaccounts) | <Icon icon="square-check"  iconType="solid" /> | |
 | [getTokenSupply](/reference/solana-gettokensupply) | <Icon icon="square-check"  iconType="solid" /> | 300 RPS |
 | [getTransaction](/reference/gettransaction) | <Icon icon="square-check"  iconType="solid" /> | Supports archive data |


### PR DESCRIPTION
## What

[INFRA-10122](https://github.com/chainstack/masternodes/pull/5550) lowers the `getTokenAccountsByOwner` static rate limit on `solana-mainnet` from **80 RPS → 20 RPS** in three regions:

- Frankfurt (`fra1`)
- Los Angeles (`lax2`)
- Singapore (`sgp1`)

Other regions — New York (`nyc1`), London (`lon2`), and dedicated nodes (e.g. `rg-142-423`) — **keep 80 RPS**. The limit is therefore no longer identical across all regions.

## Changes

- `docs/limits.mdx` — softened the "identical across all regions" wording, annotated the `getTokenAccountsByOwner` table row, and added a per-region breakdown (mirroring the existing `getProgramAccounts` regional note).
- `docs/solana-methods.mdx` — noted the limit is lower in some regions and linked to the limits page (single source of truth).

## Source

Verified against the masternodes config diff in [#5550](https://github.com/chainstack/masternodes/pull/5550): `getTokenAccountsByOwner` `capacity: 80 → 20` in `lat-sgp-1`, `lim-fra-1`, `lim-lax-2`.

> ⚠️ **Dependency:** masternodes [#5550](https://github.com/chainstack/masternodes/pull/5550) is still **open**. Hold this doc merge until the rate-limit change is deployed, so the docs match production.

`mint broken-links` passes.