### PR TITLE
docs: Base pending-tx filter returns empty (private mempool), point to Flashblocks

### DIFF
--- a/docs/base-methods.mdx
+++ b/docs/base-methods.mdx
@@ -41,7 +41,7 @@ See also [interactive Base API call examples](/reference/base-api-reference).
 | eth\_maxPriorityFeePerGas                | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_newBlockFilter                      | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_newFilter                           | <Icon icon="square-check"  iconType="solid" />            |                       |
-| eth\_newPendingTransactionFilter         | <Icon icon="square-check"  iconType="solid" />            |                       |
+| eth\_newPendingTransactionFilter         | <Icon icon="square-check"  iconType="solid" />            | Returns empty — mempool is private to the sequencer |
 | eth\_signTransaction                     | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_subscribe                           | <Icon icon="square-check"  iconType="solid" />            |                       |
 | eth\_subscribe newFlashblockTransactions | <Icon icon="square-check"  iconType="solid" />            | Flashblocks WS only   |

--- a/docs/mempool-configuration.mdx
+++ b/docs/mempool-configuration.mdx
@@ -7,6 +7,10 @@ Mempool configurations vary wildly across different protocols & node client conf
 
 The table here is a maintained reference of mempool configurations & specifics across all the protocols that Chainstack supports.
 
+<Note>
+On protocols with no public mempool, pending-transaction methods like `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` return empty by design — pending transactions are visible only to the sequencer. On Base and Optimism, use Flashblocks for a real-time pre-confirmed transaction stream: [Base](/docs/flashblocks-on-base), [Optimism](/docs/flashblocks-on-optimism).
+</Note>
+
 The table structure:
 
 * Protocol — protocol name.

--- a/reference/base-newpendingtransactionfilter.mdx
+++ b/reference/base-newpendingtransactionfilter.mdx
@@ -6,6 +6,10 @@ description: "Base API method that creates a filter in the node to notify when n
 
 Base API method that creates a filter in the node to notify when new pending transactions are received. To check if the state has changed, call eth\_getFilterChanges with the filter ID returned by this method.
 
+<Warning>
+On Base, this method returns an empty array by design — the mempool is [private to the sequencer](/docs/mempool-configuration), so there are no public pending transactions to surface. For a real-time transaction stream, use [Flashblocks](/docs/flashblocks-on-base) instead.
+</Warning>
+
 <Visibility for="humans">
 <Check>
 **Get your own node endpoint today**
@@ -33,5 +37,7 @@ The `eth_newPendingTransactionFilter` method is useful for applications that nee
 * Creating real-time transaction tracking interfaces
 * Implementing MEV (Maximal Extractable Value) strategies
 * Monitoring specific addresses for pending transactions
+
+On Base, these patterns are not served by `eth_newPendingTransactionFilter` — the mempool is private to the sequencer, so the filter returns no pending transactions, and the `eth_subscribe("newPendingTransactions")` subscription stays empty too. The `pending` block tag returns pre-confirmed [Flashblock](/docs/flashblocks-on-base) state, not mempool contents, so a populated pending block does not mean this filter should return data. To stream transactions as the sequencer pre-confirms them, subscribe to [`eth_subscribe newFlashblockTransactions`](/reference/base-subscribe-newflashblocktransactions).
 
 Note: After creating the filter, you need to poll `eth_getFilterChanges` periodically to get updates. Filters timeout if they're not used for a period of time, so applications should be prepared to recreate them if necessary.


### PR DESCRIPTION
## What

Base has no public mempool — it is private to the sequencer — so `eth_newPendingTransactionFilter` + `eth_getFilterChanges` and `eth_subscribe("newPendingTransactions")` return empty by design. The docs did not state this consequence where readers hit it (the method reference page, the methods matrix), which leads to "filter returns an empty array" confusion.

## Changes

- `reference/base-newpendingtransactionfilter.mdx` — short `<Warning>` (returns empty by design; use Flashblocks). Detail in the Use case section: the `newPendingTransactions` subscription is empty too, and the `pending` tag returns pre-confirmed Flashblock state, not mempool contents.
- `docs/mempool-configuration.mdx` — `<Note>` stating the consequence, with Flashblocks links for Base and Optimism.
- `docs/base-methods.mdx` — caveat on the `eth_newPendingTransactionFilter` row.

## Validation

`mintlify broken-links` clean; all affected pages build and render locally.
