### PR TITLE
docs: keep callouts short (CLAUDE.md, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ Use appropriate components for content:
 | `<Card>`, `<CardGroup>` | Highlighting content |
 | `<Frame>` | Wrapping images with alt text |
 
+Keep callouts short — one or two sentences. A callout is a glanceable alert, not a container for long explanations; if the content runs to a paragraph or more, move it into normal prose and keep only the key takeaway in the callout.
+
 ## 8. Code examples
 
 When adding code examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ description: "Concise description for SEO and navigation"
 - `<Info>` for neutral contextual information
 - `<Check>` for success confirmations
 
+Keep callouts short — one or two sentences. A callout is a glanceable alert, not a container for long explanations. If the content runs to a paragraph or more, put it in normal prose and keep only the single key takeaway in the callout.
+
 ### Code examples
 
 - When appropriate, include complete, runnable examples


### PR DESCRIPTION
Adds callout-length guidance: callouts should be one-to-two-sentence glanceable alerts, not containers for long explanations; longer content goes in normal prose. Updates the Mintlify components guidance in both CLAUDE.md and AGENTS.md.