### PR TITLE
docs: link Base and Optimism Flashblocks how-tos from the mempool page

### DIFF
--- a/docs/mempool-configuration.mdx
+++ b/docs/mempool-configuration.mdx
@@ -8,7 +8,7 @@ Mempool configurations vary wildly across different protocols & node client conf
 The table here is a maintained reference of mempool configurations & specifics across all the protocols that Chainstack supports.
 
 <Note>
-On protocols with no public mempool, pending-transaction methods like `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` return empty by design — pending transactions are visible only to the sequencer. On Base and Optimism, use Flashblocks for a real-time pre-confirmed transaction stream: [Base](/docs/flashblocks-on-base), [Optimism](/docs/flashblocks-on-optimism).
+On protocols with no public mempool, pending-transaction methods like `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` return empty by design — pending transactions are visible only to the sequencer. On Base and Optimism, follow transactions in real time with Flashblocks instead — see the how-to guides ([Base](/docs/base-streaming-transactions-flashblocks), [Optimism](/docs/optimism-streaming-transactions-flashblocks)) or how Flashblocks works ([Base](/docs/flashblocks-on-base), [Optimism](/docs/flashblocks-on-optimism)).
 </Note>
 
 The table structure:


### PR DESCRIPTION
The mempool configurations note linked the Flashblocks concept pages; this adds the how-to tutorials (Base streaming, Optimism tracking) as the actionable next step when a pending-transaction method returns empty on a no-mempool chain. `mintlify broken-links` clean.