### PR TITLE
docs: fix stale chain IDs (base/blast tooling) + restore hybrid-hosting to nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1020,7 +1020,8 @@
               "docs/global-elastic-node",
               "docs/unlimited-node",
               "docs/trader-node",
-              "docs/dedicated-node"
+              "docs/dedicated-node",
+              "docs/hybrid-hosting"
             ]
           },
           {

--- a/docs/base-tooling.mdx
+++ b/docs/base-tooling.mdx
@@ -370,7 +370,7 @@ where
 * NETWORK\_ID — Base network ID:
 
   * Mainnet: `8453`
-  * Goerli Testnet: `84531`
+  * Sepolia: `84532`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -398,7 +398,7 @@ where
 * NETWORK\_ID — Base network ID:
 
   * Mainnet: `8453`
-  * Goerli Testnet: `84531`
+  * Sepolia: `84532`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -424,7 +424,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
    * NETWORK\_ID — Base network ID:
 
      * Mainnet: `8453`
-     * Goerli Testnet: `84531`
+     * Sepolia: `84532`
 
 Example to run the deployment script:
 

--- a/docs/blast-tooling.mdx
+++ b/docs/blast-tooling.mdx
@@ -292,11 +292,11 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 ## Brownie
 
 1. Install [Brownie](https://eth-brownie.readthedocs.io/en/stable/install.html).
-2. Use the `brownie networks add` command with the node endpoint. For example, Base mainnet:
+2. Use the `brownie networks add` command with the node endpoint. For example, Blast mainnet:
 
    <CodeGroup>
      ```shell Shell
-     brownie networks add Base ID name="NETWORK_NAME" host= YOUR_CHAINSTACK_ENDPOINT chainid=NETWORK_ID
+     brownie networks add Blast ID name="NETWORK_NAME" host= YOUR_CHAINSTACK_ENDPOINT chainid=NETWORK_ID
      ```
    </CodeGroup>
 
@@ -308,10 +308,9 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 
    * YOUR\_CHAINSTACK\_ENDPOINT — your node HTTPS or WSS endpoint protected either with the key or password
 
-   * NETWORK\_ID — Base network ID:
+   * NETWORK\_ID — Blast network ID:
 
-     * Mainnet: `8453`
-     * Goerli Testnet: `84531`
+     * Mainnet: `81457`
 
 Example to run the deployment script:
 


### PR DESCRIPTION
## What

Fixes stale/incorrect chain-ID references in two EVM tooling pages and restores an accidentally-orphaned page to nav. Finishes the C1 cleanup started in #490.

## Changes

- **`base-tooling`** — the `NETWORK_ID` examples listed the deprecated **Base Goerli** testnet (`84531`) in 3 places → updated to **Base Sepolia (`84532`)**, the current testnet (already used in our B20 tutorial).
- **`blast-tooling`** — the Brownie `NETWORK_ID` section was copy-pasted from Base: it said "Base", used Base's mainnet ID `8453`, and listed dead Base Goerli. → relabeled to **Blast**, corrected the mainnet chain ID to **`81457`**, and dropped the dead testnet row.
- **`docs.json`** — re-added `docs/hybrid-hosting` to the **Core** nav group. It's a current offering (Chainstack-managed nodes in your own cloud, distinct from Self-Hosted) that had been orphaned from nav — so it was still built/served but unreachable via navigation.

## Verification

- Chain IDs verified, not assumed: **Base Sepolia `84532`** is confirmed in our own docs; **Blast mainnet `81457`** verified **live via `eth_chainId`** on a Chainstack Blast node (`0x13e31`).
- `mint broken-links` clean · `mint validate` passed · `docs.json` valid.
