### PR TITLE
docs: correctness — billing plan count + Solana land-tx pillar backlinks

### DIFF
--- a/docs/enhancing-solana-spl-token-transfers-with-retry-logic.mdx
+++ b/docs/enhancing-solana-spl-token-transfers-with-retry-logic.mdx
@@ -3,6 +3,8 @@ title: "Solana: Enhancing SPL token transfers with retry logic"
 description: Add retry logic to Solana SPL token transfers using transaction confirmation polling and exponential backoff for reliable token delivery on Chainstack.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * This guide adds simple retry logic to the SPL token transfer process on Solana, building on the [previous code](/docs/transferring-spl-tokens-on-solana-typescript).
 * We wrap transaction submissions in a loop, retrying up to a set limit (`MAX_RETRY_FUNCTION`) with a short delay to handle transient failures (e.g., `TransactionExpiredBlockheightExceededError`).

--- a/docs/manage-your-billing.mdx
+++ b/docs/manage-your-billing.mdx
@@ -145,7 +145,7 @@ If neither path produces a resolution within a reasonable window, the bank charg
  * Your subscription plan
  * Your support level
 
- Chainstack offers four types of subscription plans which differ depending on your Web3 objectives. The final price of each subscription plan is made up of a base charge for the features included and the number of API requests made to your deployed nodes.
+ Chainstack offers five types of subscription plans which differ depending on your Web3 objectives. The final price of each subscription plan is made up of a base charge for the features included and the number of API requests made to your deployed nodes.
 
  [Each subscription plan also has a default support level](https://chainstack.com/pricing/) included into it. You can change your subscription plan any time, while the support level can be changed only for paid subscriptions. Switching between subscription plans and support levels occurs independently from each other.
 

--- a/docs/solana-analyzing-adjacent-transactions-for-priority-fees.mdx
+++ b/docs/solana-analyzing-adjacent-transactions-for-priority-fees.mdx
@@ -3,6 +3,8 @@ title: "Solana: Analyzing adjacent transactions for priority fees"
 description: Analyze adjacent transactions in Solana blocks to calculate optimal priority fees based on actual compute unit prices paid by neighboring transactions.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * This Python script inspects the fee usage in blocks adjacent to your own target transaction on Solana, focusing on the same on-chain program.
 * It decodes compute budget instructions (priority fees) to show both your transaction’s fee and those of other transactions in nearby blocks.

--- a/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
+++ b/docs/solana-estimate-priority-fees-getrecentprioritizationfees.mdx
@@ -3,6 +3,8 @@ title: "Solana: Estimate priority fees with RPC methods"
 description: Estimate Solana transaction priority fees using getRecentPrioritizationFees to calculate compute unit prices for faster confirmation on Chainstack.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * The `getRecentPrioritizationFees` method provides real-time insights into recent priority fee data on Solana.
 * It helps you dynamically gauge how much extra fee (in micro-lamports/Compute Unit) others are paying.

--- a/docs/solana-how-to-handle-the-transaction-expiry-error.mdx
+++ b/docs/solana-how-to-handle-the-transaction-expiry-error.mdx
@@ -3,6 +3,8 @@ title: "Solana: How to handle the transaction expiry error"
 description: Diagnose and fix Solana transaction expiration errors with blockhash refresh strategies, retry logic, and confirmation polling on Chainstack nodes.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * The `TransactionExpiredBlockheightExceededError` occurs when Solana transactions aren’t confirmed before a specified block window (the `lastValidBlockHeight`).
 * Network congestion, high throughput, and delayed transaction propagation can all trigger this error.

--- a/docs/solana-how-to-priority-fees-faster-transactions.mdx
+++ b/docs/solana-how-to-priority-fees-faster-transactions.mdx
@@ -3,6 +3,8 @@ title: "Solana: Priority fees for faster transactions"
 description: Set optimal Solana priority fees using compute budget instructions to accelerate transaction processing and avoid dropped transactions on Chainstack.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * Priority fees on Solana let you attach a higher compute unit price to your transactions, boosting confirmation speed.
 * They’re especially useful during network congestion or in time-critical situations like NFT drops or rapid trading.

--- a/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
+++ b/docs/solana-priority-fees-for-a-jupiter-in-python.mdx
@@ -3,6 +3,8 @@ title: "Solana: Priority fees for a Jupiter Swap in Python"
 description: Calculate and apply optimal priority fees for Jupiter swap transactions on Solana using Python with compute budget instructions through Chainstack.
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * Jupiter offers a quick way to swap tokens on Solana but lacks a Python SDK, so we query Jupiter’s public API for quotes and transaction data.
 * We calculate our priority fee by fetching recent block data via `getRecentPrioritizationFees`, then derive the median fee and multiply it by a user-defined factor.

--- a/docs/solana-transactions-block-time-yellowstone-grpc.mdx
+++ b/docs/solana-transactions-block-time-yellowstone-grpc.mdx
@@ -3,6 +3,8 @@ title: "Solana: Associating transactions with block and block time using Yellows
 description: "Join Solana transactions to their block and block time in a single Yellowstone gRPC stream, without a second stream or a per-block getBlockTime call."
 ---
 
+> **Part of the [How to land transactions on Solana](/docs/solana-how-to-land-transactions) guide.**
+
 **TLDR:**
 * A Yellowstone gRPC transaction update carries the `slot`, but not the block time. Block time arrives only on a block-metadata update.
 * Subscribe to `transactions`, `blocks_meta`, and `slots` on one stream, then join on `slot`: buffer transactions by slot, and stamp them with the block time when that slot's `block_meta` arrives.


### PR DESCRIPTION
## What

Two audit-surfaced, verified correctness/IA fixes.

1. **Plan count** — `manage-your-billing.mdx` said *"Chainstack offers **four** types of subscription plans"*. There are **five**: Developer / Growth / Pro / Business / Enterprise (confirmed against the live pricing page). Fixed to "five".
2. **Pillar backlinks** — the new [How to land transactions on Solana](/docs/solana-how-to-land-transactions) pillar (#488) had **0 inbound links**. Added a one-line up-link from each of its **7 landing spokes** (priority-fees, estimate, adjacent-tx, Jupiter, expiry, retry-logic, gRPC block-time) so the hub-and-spoke cluster links both ways — better for retrieval and for humans.

## Note — two audit flags were false positives (deliberately NOT changed)

- **`limits.mdx` "10k vs 100 contradiction"** — not a contradiction: line 37 is `eth_newFilter` (Developer = 10,000 blocks), lines 39–45 are `eth_getLogs` (Developer = 100). Different methods.
- **`limits.mdx` "phantom Pro plan"** — Pro is a **real** tier (verified against live pricing: $199/mo). Left as-is.

## Verification

- Plan count verified against the live Chainstack pricing (5 tiers).
- 7 spokes now link to the pillar (grep-confirmed; was 0).
- `mint broken-links` clean · `mint validate` passed.
