### PR TITLE
docs: add batchClearinghouseStates to the Hyperliquid methods table

### DIFF
--- a/docs/hyperliquid-methods.mdx
+++ b/docs/hyperliquid-methods.mdx
@@ -61,6 +61,7 @@ HyperEVM methods listed as `/evm` are also reachable on `/nanoreth`. See [Hyperl
 | approvedBuilders | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
 | perpConciseAnnotations | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
 | settledOutcome | /info | HyperCore | <Icon icon="square-check" iconType="solid" /> |
+| batchClearinghouseStates | /info | HyperCore | Hyperliquid public RPC |
 | allMids | /info | HyperCore | Hyperliquid public RPC |
 | userFills | /info | HyperCore | Hyperliquid public RPC |
 | userFillsByTime | /info | HyperCore | Hyperliquid public RPC |


### PR DESCRIPTION
## What

Adds the `batchClearinghouseStates` HyperCore `/info` method to the availability table in `hyperliquid-methods`, marked **Hyperliquid public RPC**.

| Method | Endpoint | Engine | Availability |
| --- | --- | --- | --- |
| batchClearinghouseStates | /info | HyperCore | Hyperliquid public RPC |

## Why

Hyperliquid reference pages are the top agent-read cluster in the docs (10 of the top 15 agent-viewed pages this week). `batchClearinghouseStates` — the batch form of `clearinghouseState` — was the one missing row; completing the table serves that audience and matches what competitors document.

## Verification (live, this cycle)

Verified on a Chainstack Hyperliquid **mainnet** node and against Hyperliquid's public RPC:

- The method is real — it takes a `users` array (confirmed by deserializer calibration: garbage types and wrong field names both fail to deserialize; `users` is accepted).
- On the Chainstack HL node it returns `Failed to deserialize the JSON body into the target type` — the documented signal for a public-RPC-only method — while the public RPC returns data. ⇒ **public-RPC-only**, consistent with the existing "Hyperliquid public RPC" rows.

Also spot-checked the table while I had a live node: existing availability labels are accurate (`spotClearinghouseState`/`openOrders` available; `metaAndAssetCtxs`/`l2Book` public-only — all correct). Candidate "missing" methods (`bbo`, `twapStates`, `activeAssetCtx`, `fastAssetCtxs`) are WebSocket subscription types, not `/info` methods, so they're correctly absent.

Local checks: `mint validate` ✅ · `mint broken-links` ✅.