### PR TITLE
fix: zkEVM reference redirect wildcard (old method URLs 404 instead of redirecting)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -82,7 +82,7 @@
     { "source": "/docs/polygon-zkevm-methods", "destination": "/docs/protocols-networks" },
     { "source": "/docs/polygon-zkevm-tooling", "destination": "/docs/protocols-networks" },
     { "source": "/docs/polygon-zkevm-tutorial-deploy-a-smart-contract-using-hardhat", "destination": "/docs/protocols-networks" },
-    { "source": "/reference/zkevm-:slug*", "destination": "/reference/blockchain-apis" }
+    { "source": "/reference/zkevm-:slug", "destination": "/reference/blockchain-apis" }
   ],
   "api": {
     "openapi": [


### PR DESCRIPTION
## Why

Prod-verification of the zkEVM decommission (#500 + build fix #501) found the `/reference/zkevm-*` URLs return **404** instead of redirecting. The page redirects (`/docs/polygon-zkevm-*`) work; only the reference wildcard was broken.

**Cause:** #500 used `"source": "/reference/zkevm-:slug*"`. Per [Mintlify's redirect docs](https://www.mintlify.com/docs/create/redirects#wildcard-redirects), a `:slug*` wildcard matches a **whole path segment** (`/beta/:slug*` → `/beta/introduction`). A splat attached to a literal in-segment prefix (`zkevm-:slug*`) doesn't match `/reference/zkevm-batchnumber`, so those URLs fall through to 404.

## What

One line: `/reference/zkevm-:slug*` → `/reference/zkevm-:slug` (single-segment param, the proven path-to-regexp form — same family as the working `/docs/polygon-zkevm-*` entries).

## Verification

- `mint broken-links --check-redirects` → **success, no broken links found** (destination `/reference/blockchain-apis` resolves)
- `docs.json` valid JSON
- Runtime source-match will be confirmed against prod after deploy (local validate can't test wildcard matching — that's the gap that hid #500's failure)

## After merge

Confirm on prod: `/reference/zkevm-batchnumber` → **308** → `/reference/blockchain-apis`.