### PR TITLE
migrate runbook: note Node.js 22+ requirement for Alchemy CLI

### DIFF
--- a/docs/migrate-to-chainstack-with-ai.mdx
+++ b/docs/migrate-to-chainstack-with-ai.mdx
@@ -82,7 +82,7 @@ If the user is migrating from another RPC provider — **QuickNode**, **Alchemy*
           -H 'accept: application/json' -H 'x-api-key: <QUICKNODE_API_KEY>'
      ```
      This returns API Credits used and remaining for the period. Per-method and per-chain breakdowns are at `/v0/usage/rpc/by-method` and `/v0/usage/rpc/by-chain` — `by-method` also flags each method as `archive: true`/`false`, which maps to Chainstack's 2 RU per archive request (vs 1 RU standard), so you can convert precisely instead of by an average. If the user would rather not create a key, a **screenshot** of the **Usage & Billing** page works too — read the figures straight from the image.
-   - **Alchemy** — the [Alchemy CLI](https://www.alchemy.com/docs/alchemy-cli) exposes usage programmatically. Have the user install it (`npm i -g @alchemy/cli`) and run `alchemy auth login` once — a one-time browser sign-in to their own Alchemy account (there is no headless API-key path for `usage`). Then fetch their spend and compute-unit consumption:
+   - **Alchemy** — the [Alchemy CLI](https://www.alchemy.com/docs/alchemy-cli) exposes usage programmatically. Have the user install it (`npm i -g @alchemy/cli`, which needs Node.js 22+) and run `alchemy auth login` once — a one-time browser sign-in to their own Alchemy account (there is no headless API-key path for `usage`). Then fetch their spend and compute-unit consumption:
 
      ```
      alchemy --json usage summary


### PR DESCRIPTION
`@alchemy/cli` declares `engines: { node: ">=22" }` (verified via `npm view @alchemy/cli@0.17.6 engines`), so users on older Node hit an engine failure before `alchemy auth login` or the screenshot fallback. Add "needs Node.js 22+" to the install step.

Mirrors the same fix on the skill side (chainstack/mcp-server#35). Caught by @easeev's review.