### PR TITLE
Release note (July 6): Alchemy migration usage via the Alchemy CLI

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 6, 2026" description=" by Ake">
+
+**MCP Server**. Migrating from Alchemy now reads your usage via the [Alchemy CLI](https://www.alchemy.com/docs/alchemy-cli) (`alchemy usage summary`) — the agent pulls your spend and compute-unit volume to estimate your Chainstack savings.
+
+<Button href="/changelog/chainstack-updates-july-6-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: June 17, 2026" description=" by Ake">
 
 **Protocols**. TRON gRPC now serves the [`protocol.WalletSolidity`](/docs/tron-tooling#available-services) service for solidified (confirmed) data, alongside `protocol.Wallet`. Both run on the same `:443` endpoint — select the one you need by the service (stub) in your generated client. Available on TRON mainnet and Nile testnet.

--- a/changelog/chainstack-updates-july-6-2026.mdx
+++ b/changelog/chainstack-updates-july-6-2026.mdx
@@ -1,0 +1,8 @@
+---
+title: "Chainstack updates: July 6, 2026"
+description: "The Chainstack MCP server now reads your Alchemy usage via the Alchemy CLI when migrating, replacing the dashboard screenshot step."
+---
+
+**MCP Server**. When migrating a project to Chainstack from Alchemy, the [Chainstack MCP server](https://mcp.chainstack.com) now reads your Alchemy usage programmatically via the [Alchemy CLI](https://www.alchemy.com/docs/alchemy-cli) (`alchemy --json usage summary`). It pulls your 30-day spend and compute-unit volume to estimate your equivalent Chainstack cost and savings.
+
+For the full migration flow, see the [migrate-to-Chainstack runbook](/docs/migrate-to-chainstack-with-ai).

--- a/docs.json
+++ b/docs.json
@@ -3056,6 +3056,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-6-2026",
           "changelog/chainstack-updates-june-17-2026",
           "changelog/chainstack-updates-june-11-2026",
           "changelog/chainstack-updates-june-10-2026",


### PR DESCRIPTION
Docs release note for the v1.10.7 MCP server change: migrating from Alchemy now reads usage via the Alchemy CLI (`alchemy usage summary`) instead of a dashboard screenshot.

Three coordinated edits: new standalone page `changelog/chainstack-updates-july-6-2026.mdx`, the `<Update>` feed block in `changelog.mdx` (newest-first), and the `docs.json` Release-notes nav entry.

Counterpart to chainstacklabs/mcp-server#10 (public changelog) and chainstack/mcp-server#35 (v1.10.7).