### PR TITLE
docs: deprecate Cronos Testnet (node offering sunset July 17, 2026)

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -272,7 +272,6 @@ description: Browse available cloud providers, regions, and geographic locations
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 | Mainnet | Chainstack Cloud          | fra1    | Frankfurt | Archive | Available     |
 | Mainnet | Chainstack Cloud          | fra1    | Frankfurt | Full    | Available     |
-| Testnet | Virtuozzo                 | eu3     | Amsterdam | Full    | NA            |
 
 ## Gnosis Chain
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -34,7 +34,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Centrifuge | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-centrifuge/#request) |
 | Core | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-core/#request) |
 | Corn | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-corn/#request) |
-| Cronos | Elastic, Dedicated | Full, Archive | Full | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Cronos | Elastic, Dedicated | Full, Archive | Full | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Cronos zkEVM | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Dogecoin | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/build-better-with-dogecoin/#request) |
 | dYdX | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -2008,27 +2008,7 @@
           }
         ]
       },
-      "testnets": [
-        {
-          "network_name": "Testnet",
-          "faucet_url": "https://cronos.org/faucet",
-          "locations": [
-            {
-              "cloud": "Virtuozzo",
-              "node_type": "Trader Node",
-              "region": "eu3",
-              "location": "Amsterdam",
-              "deployment_options": [
-                {
-                  "mode": "Full",
-                  "debug_trace": false,
-                  "warp_transactions": false
-                }
-              ]
-            }
-          ]
-        }
-      ],
+      "testnets": [],
       "additional_notes": "N/A"
     },
     "Gnosis Chain": {


### PR DESCRIPTION
## Why

The Cronos **Testnet** node offering is being deprecated on **July 17, 2026** (customer announcement 2026-07-07). **Cronos Mainnet and Cronos zkEVM are unaffected** — this is a testnet-only removal, so it's a light catalog touch (no pages deleted).

## What

- `node-options-master-list.json` — Cronos `testnets` → `[]` (was one Trader Node entry)
- `docs/protocols-networks.mdx` — Cronos row Testnet column → `-`
- `docs/nodes-clouds-regions-and-locations.mdx` — remove the Cronos Testnet row

## Verification

- `mint validate` → **build validation passed**
- `mint broken-links` → **no broken links**
- `scripts/generate_llms_txt.py --check` → **up to date** (no page-level change)

## Notes / follow-ups

- ⚠️ The announcement cites the affected testnet node as **"Trader Nodes, CC Lon1"**, but the master-list had the Cronos testnet at **Virtuozzo / eu3 / Amsterdam**. The removal is correct regardless (the whole testnet goes), but the master-list location data for that node may have been stale.
- 🔎 **Separate decision needed (not in this PR):** `docs/cronos-tutorial-dutch-auction-smart-contracts-on-cronos-with-hardhat.mdx` is built around deploying to **Cronos testnet via a Chainstack node** (its "join the Cronos testnet" step + the Cronos faucet). Once the testnet offering is gone, that step breaks. Options: retire the tutorial, repoint it to Cronos Mainnet, or leave it. Flagging for a call.