### PR TITLE
docs: Polygon runs on Bor — trace_*/erigon_* unavailable, migrate to debug_*

### DIFF
--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -7,6 +7,21 @@ Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM m
 
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 
+<Warning>
+**Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet by August 1, 2026.** After the cutover, the Erigon-only `trace_*` and `erigon_*` namespaces will no longer be available on Polygon — Bor serves the Geth `debug_trace*` methods instead.
+</Warning>
+
+If your app uses the Parity `trace_*` methods, migrate to their `debug_*` equivalents before the deadline:
+
+| Erigon `trace_*` method | Replacement on Bor |
+| --- | --- |
+| `trace_transaction` | [`debug_traceTransaction`](/reference/polygon-tracetransaction) with `callTracer` |
+| `trace_block` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with `callTracer` |
+| `trace_call` | [`debug_traceCall`](/reference/polygon-tracecall) with `callTracer` |
+| `trace_filter`, `trace_replayBlockTransactions`, `trace_replayTransaction` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) per block, or [`eth_getLogs`](/docs/understanding-eth-getlogs-limitations) for event ranges |
+
+The `debug_trace*` methods return equivalent execution traces on Bor (verified live on Chainstack Polygon nodes). The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
+
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -55,14 +70,14 @@ See also [interactive Polygon API call examples](/reference/polygon-getting-star
 | txpool\_status                           | <Icon icon="xmark"  iconType="solid" />            |         |
 | web3\_clientVersion                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | web3\_sha3                               | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_blockNumber                      | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_forks                            | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getBlockByTimestamp              | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getHeaderByHash                  | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getHeaderByNumber                | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getLatestLogs                    | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_getLogsByHash                    | <Icon icon="square-check"  iconType="solid" />            |         |
+| erigon\_blockNumber                      | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_forks                            | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getBlockByTimestamp              | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getHeaderByHash                  | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getHeaderByNumber                | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getLatestLogs                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_getLogsByHash                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
 | debug\_getBadBlocks                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_storageRangeAt                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_getTrieFlushInterval              | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -71,14 +86,14 @@ See also [interactive Polygon API call examples](/reference/polygon-getting-star
 | debug\_traceBlockByNumber                | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceCall                         | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceTransaction                  | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_block                             | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_call                              | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_callMany                          | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_filter                            | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_rawTransaction                    | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_replayBlockTransactions           | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_replayTransaction                 | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_transaction                       | <Icon icon="square-check"  iconType="solid" />            |         |
+| trace\_block                             | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_call                              | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_callMany                          | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_filter                            | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_rawTransaction                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_replayBlockTransactions           | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_replayTransaction                 | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_transaction                       | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
 | bor\_getAuthor                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentProposer                  | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentValidators                | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -7,11 +7,7 @@ Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM m
 
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 
-<Info>
-  Chainstack serves Polygon on the **Bor** client; archive nodes run Bor with PBSS. Bor does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces — use the Geth `debug_trace*` methods instead.
-</Info>
-
-The Parity `trace_*` methods map to their `debug_*` equivalents on Bor:
+Polygon runs on the Bor client, which does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces. Migrate the `trace_*` methods to their `debug_*` equivalents:
 
 | Parity `trace_*` method | Replacement on Bor |
 | --- | --- |

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -7,22 +7,22 @@ Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM m
 
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 
-<Warning>
-Chainstack retires the Erigon client from Polygon Mainnet on **July 29, 2026**. After that, the Erigon-only `trace_*` and `erigon_*` namespaces stop working — migrate to the `debug_trace*` equivalents below.
-</Warning>
+<Info>
+  Chainstack serves Polygon on the **Bor** client; archive nodes run Bor with PBSS. Bor does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces — use the Geth `debug_trace*` methods instead.
+</Info>
 
-Chainstack is moving Polygon archive from Erigon to Bor with PBSS, ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1, 2026. If your app uses the Parity `trace_*` methods, migrate to their `debug_*` equivalents before July 29:
+The Parity `trace_*` methods map to their `debug_*` equivalents on Bor:
 
-| Erigon `trace_*` method | Replacement on Bor |
+| Parity `trace_*` method | Replacement on Bor |
 | --- | --- |
 | `trace_transaction` | [`debug_traceTransaction`](/reference/polygon-tracetransaction) with `callTracer` |
 | `trace_block` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with `callTracer` |
 | `trace_call` | [`debug_traceCall`](/reference/polygon-tracecall) with `callTracer` |
 | `trace_filter`, `trace_replayBlockTransactions`, `trace_replayTransaction` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) per block, or [`eth_getLogs`](/docs/understanding-eth-getlogs-limitations) for event ranges |
 
-The `debug_trace*` methods return equivalent execution traces on Bor (verified live on Chainstack Polygon nodes). The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
+The `debug_trace*` methods return equivalent execution traces on Bor. The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
 
-`eth_getProof` also changes with the move to Bor: it returns proofs only for roughly the latest 128 blocks, whereas Erigon served the full history. If you rely on historical state proofs on Polygon, retrieve them before July 29, 2026.
+On Bor, `eth_getProof` returns proofs only for roughly the latest 128 blocks, not full history.
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
@@ -44,7 +44,7 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | eth\_getFilterChanges                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getFilterLogs                       | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getLogs                             | <Icon icon="square-check"  iconType="solid" />            |         |
-| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            | Latest ~128 blocks only after Jul 29, 2026 (Bor) |
+| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            | Latest ~128 blocks only (Bor) |
 | eth\_getStorageAt                        | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockHashAndIndex   | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockNumberAndIndex | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -72,14 +72,14 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | txpool\_status                           | <Icon icon="xmark"  iconType="solid" />            |         |
 | web3\_clientVersion                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | web3\_sha3                               | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_blockNumber                      | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_forks                            | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getBlockByTimestamp              | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getHeaderByHash                  | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getHeaderByNumber                | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getLatestLogs                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| erigon\_getLogsByHash                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_blockNumber                      | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_forks                            | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getBlockByTimestamp              | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getHeaderByHash                  | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getHeaderByNumber                | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getLatestLogs                    | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
+| erigon\_getLogsByHash                    | <Icon icon="xmark"  iconType="solid" />            | Use `eth_*` |
 | debug\_getBadBlocks                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_storageRangeAt                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_getTrieFlushInterval              | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -88,14 +88,14 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | debug\_traceBlockByNumber                | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceCall                         | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceTransaction                  | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_block                             | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_call                              | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_callMany                          | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_filter                            | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_rawTransaction                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_replayBlockTransactions           | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_replayTransaction                 | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
-| trace\_transaction                       | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_block                             | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_call                              | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_callMany                          | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_filter                            | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_rawTransaction                    | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_replayBlockTransactions           | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_replayTransaction                 | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
+| trace\_transaction                       | <Icon icon="xmark"  iconType="solid" />            | Use `debug_trace*` |
 | bor\_getAuthor                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentProposer                  | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentValidators                | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -22,8 +22,6 @@ The Parity `trace_*` methods map to their `debug_*` equivalents on Bor:
 
 The `debug_trace*` methods return equivalent execution traces on Bor. The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
 
-On Bor, `eth_getProof` returns proofs only for roughly the latest 128 blocks, not full history.
-
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
 | eth\_accounts                            | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -44,7 +42,7 @@ On Bor, `eth_getProof` returns proofs only for roughly the latest 128 blocks, no
 | eth\_getFilterChanges                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getFilterLogs                       | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getLogs                             | <Icon icon="square-check"  iconType="solid" />            |         |
-| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            | Latest ~128 blocks only (Bor) |
+| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getStorageAt                        | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockHashAndIndex   | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockNumberAndIndex | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -8,10 +8,10 @@ Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM m
 See also [interactive Polygon API call examples](/reference/polygon-getting-started).
 
 <Warning>
-**Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet by August 1, 2026.** After the cutover, the Erigon-only `trace_*` and `erigon_*` namespaces will no longer be available on Polygon — Bor serves the Geth `debug_trace*` methods instead.
+Chainstack retires the Erigon client from Polygon Mainnet on **July 29, 2026**. After that, the Erigon-only `trace_*` and `erigon_*` namespaces stop working — migrate to the `debug_trace*` equivalents below.
 </Warning>
 
-If your app uses the Parity `trace_*` methods, migrate to their `debug_*` equivalents before the deadline:
+Chainstack is moving Polygon archive from Erigon to Bor with PBSS, ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1, 2026. If your app uses the Parity `trace_*` methods, migrate to their `debug_*` equivalents before July 29:
 
 | Erigon `trace_*` method | Replacement on Bor |
 | --- | --- |
@@ -21,6 +21,8 @@ If your app uses the Parity `trace_*` methods, migrate to their `debug_*` equiva
 | `trace_filter`, `trace_replayBlockTransactions`, `trace_replayTransaction` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) per block, or [`eth_getLogs`](/docs/understanding-eth-getlogs-limitations) for event ranges |
 
 The `debug_trace*` methods return equivalent execution traces on Bor (verified live on Chainstack Polygon nodes). The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
+
+`eth_getProof` also changes with the move to Bor: it returns proofs only for roughly the latest 128 blocks, whereas Erigon served the full history. If you rely on historical state proofs on Polygon, retrieve them before July 29, 2026.
 
 | Method                                   | Availability | Comment |
 | ---------------------------------------- | ------------ | ------- |
@@ -42,7 +44,7 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | eth\_getFilterChanges                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getFilterLogs                       | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getLogs                             | <Icon icon="square-check"  iconType="solid" />            |         |
-| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            |         |
+| eth\_getProof                            | <Icon icon="square-check"  iconType="solid" />            | Latest ~128 blocks only after Jul 29, 2026 (Bor) |
 | eth\_getStorageAt                        | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockHashAndIndex   | <Icon icon="square-check"  iconType="solid" />            |         |
 | eth\_getTransactionByBlockNumberAndIndex | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -70,14 +72,14 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | txpool\_status                           | <Icon icon="xmark"  iconType="solid" />            |         |
 | web3\_clientVersion                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | web3\_sha3                               | <Icon icon="square-check"  iconType="solid" />            |         |
-| erigon\_blockNumber                      | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_forks                            | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getBlockByTimestamp              | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getHeaderByHash                  | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getHeaderByNumber                | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getLatestLogs                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| erigon\_getLogsByHash                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| erigon\_blockNumber                      | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_forks                            | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getBlockByTimestamp              | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getBlockReceiptsByBlockHash      | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getHeaderByHash                  | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getHeaderByNumber                | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getLatestLogs                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| erigon\_getLogsByHash                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
 | debug\_getBadBlocks                      | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_storageRangeAt                    | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_getTrieFlushInterval              | <Icon icon="square-check"  iconType="solid" />            |         |
@@ -86,14 +88,14 @@ The `debug_trace*` methods return equivalent execution traces on Bor (verified l
 | debug\_traceBlockByNumber                | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceCall                         | <Icon icon="square-check"  iconType="solid" />            |         |
 | debug\_traceTransaction                  | <Icon icon="square-check"  iconType="solid" />            |         |
-| trace\_block                             | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_call                              | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_callMany                          | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_filter                            | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_rawTransaction                    | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_replayBlockTransactions           | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_replayTransaction                 | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
-| trace\_transaction                       | <Icon icon="square-check"  iconType="solid" />            | Deprecating Aug 1, 2026 — Erigon sunset |
+| trace\_block                             | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_call                              | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_callMany                          | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_filter                            | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_rawTransaction                    | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_replayBlockTransactions           | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_replayTransaction                 | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
+| trace\_transaction                       | <Icon icon="square-check"  iconType="solid" />            | Removed Jul 29, 2026 — Erigon retired |
 | bor\_getAuthor                           | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentProposer                  | <Icon icon="square-check"  iconType="solid" />            |         |
 | bor\_getCurrentValidators                | <Icon icon="square-check"  iconType="solid" />            |         |

--- a/reference/polygon-trace_block.mdx
+++ b/reference/polygon-trace_block.mdx
@@ -6,6 +6,10 @@ description: "Polygon API method that returns traces for all the transactions wi
 
 Polygon API method that returns traces for all the transactions within a specific block. Developers can use the `trace_block` method to gain insight into the behavior of smart contracts within a block, analyze gas usage and optimize their contracts accordingly. This method is only available on an Erigon instance.
 
+<Warning>
+**Deprecating August 1, 2026.** Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet, so the Erigon-only `trace_*` namespace will stop working on Polygon. Migrate to [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with the `callTracer`, which returns equivalent per-transaction call traces for a block on Bor.
+</Warning>
+
 <Visibility for="humans">
 <Check>
 **Get your own node endpoint today**

--- a/reference/polygon-trace_block.mdx
+++ b/reference/polygon-trace_block.mdx
@@ -7,7 +7,7 @@ description: "Polygon API method that returns traces for all the transactions wi
 Polygon API method that returns traces for all the transactions within a specific block. Developers can use the `trace_block` method to gain insight into the behavior of smart contracts within a block, analyze gas usage and optimize their contracts accordingly. This method is only available on an Erigon instance.
 
 <Warning>
-**Retiring July 29, 2026.** Chainstack retires the Erigon client from Polygon Mainnet (ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1), moving Polygon archive to Bor with PBSS, so the Erigon-only `trace_*` namespace stops working on Polygon. Migrate to [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with the `callTracer`, which returns equivalent per-transaction call traces for a block on Bor.
+**Not available on Polygon.** Chainstack serves Polygon on the Bor client (archive uses Bor with PBSS), which does not implement the Erigon-only `trace_*` namespace. Use [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with the `callTracer`, which returns equivalent per-transaction call traces for a block on Bor.
 </Warning>
 
 <Visibility for="humans">

--- a/reference/polygon-trace_block.mdx
+++ b/reference/polygon-trace_block.mdx
@@ -7,7 +7,7 @@ description: "Polygon API method that returns traces for all the transactions wi
 Polygon API method that returns traces for all the transactions within a specific block. Developers can use the `trace_block` method to gain insight into the behavior of smart contracts within a block, analyze gas usage and optimize their contracts accordingly. This method is only available on an Erigon instance.
 
 <Warning>
-**Deprecating August 1, 2026.** Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet, so the Erigon-only `trace_*` namespace will stop working on Polygon. Migrate to [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with the `callTracer`, which returns equivalent per-transaction call traces for a block on Bor.
+**Retiring July 29, 2026.** Chainstack retires the Erigon client from Polygon Mainnet (ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1), moving Polygon archive to Bor with PBSS, so the Erigon-only `trace_*` namespace stops working on Polygon. Migrate to [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with the `callTracer`, which returns equivalent per-transaction call traces for a block on Bor.
 </Warning>
 
 <Visibility for="humans">

--- a/reference/polygon-trace_transaction.mdx
+++ b/reference/polygon-trace_transaction.mdx
@@ -6,6 +6,10 @@ description: "Polygon API method that traces a specific transaction. trace_trans
 
 Polygon API method that traces a specific transaction. It provides a detailed record of all the steps taken by the Ethereum Virtual Machine (EVM) during the execution, including all the operations performed and the changes made to the blockchain state. This method is available on Erigon only.
 
+<Warning>
+**Deprecating August 1, 2026.** Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet, so the Erigon-only `trace_*` namespace will stop working on Polygon. Migrate to [`debug_traceTransaction`](/reference/polygon-tracetransaction) with the `callTracer`, which returns an equivalent call trace on Bor.
+</Warning>
+
 <Visibility for="humans">
 <Check>
 **Get your own node endpoint today**

--- a/reference/polygon-trace_transaction.mdx
+++ b/reference/polygon-trace_transaction.mdx
@@ -7,7 +7,7 @@ description: "Polygon API method that traces a specific transaction. trace_trans
 Polygon API method that traces a specific transaction. It provides a detailed record of all the steps taken by the Ethereum Virtual Machine (EVM) during the execution, including all the operations performed and the changes made to the blockchain state. This method is available on Erigon only.
 
 <Warning>
-**Retiring July 29, 2026.** Chainstack retires the Erigon client from Polygon Mainnet (ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1), moving Polygon archive to Bor with PBSS, so the Erigon-only `trace_*` namespace stops working on Polygon. Migrate to [`debug_traceTransaction`](/reference/polygon-tracetransaction) with the `callTracer`, which returns an equivalent call trace on Bor.
+**Not available on Polygon.** Chainstack serves Polygon on the Bor client (archive uses Bor with PBSS), which does not implement the Erigon-only `trace_*` namespace. Use [`debug_traceTransaction`](/reference/polygon-tracetransaction) with the `callTracer`, which returns an equivalent call trace on Bor.
 </Warning>
 
 <Visibility for="humans">

--- a/reference/polygon-trace_transaction.mdx
+++ b/reference/polygon-trace_transaction.mdx
@@ -7,7 +7,7 @@ description: "Polygon API method that traces a specific transaction. trace_trans
 Polygon API method that traces a specific transaction. It provides a detailed record of all the steps taken by the Ethereum Virtual Machine (EVM) during the execution, including all the operations performed and the changes made to the blockchain state. This method is available on Erigon only.
 
 <Warning>
-**Deprecating August 1, 2026.** Polygon is [sunsetting Erigon](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on mainnet, so the Erigon-only `trace_*` namespace will stop working on Polygon. Migrate to [`debug_traceTransaction`](/reference/polygon-tracetransaction) with the `callTracer`, which returns an equivalent call trace on Bor.
+**Retiring July 29, 2026.** Chainstack retires the Erigon client from Polygon Mainnet (ahead of [Polygon's upstream Erigon sunset](https://forum.polygon.technology/t/sunsetting-erigon-support/21872) on August 1), moving Polygon archive to Bor with PBSS, so the Erigon-only `trace_*` namespace stops working on Polygon. Migrate to [`debug_traceTransaction`](/reference/polygon-tracetransaction) with the `callTracer`, which returns an equivalent call trace on Bor.
 </Warning>
 
 <Visibility for="humans">


### PR DESCRIPTION
Represents the **Polygon-on-Bor end-state** as current fact (no transition dates):

- Polygon on Chainstack runs the **Bor** client; archive uses **Bor + PBSS**.
- The Parity **`trace_*`** and **`erigon_*`** namespaces are **not available** (marked unavailable in the method table; map to `debug_trace*` / `eth_*`, with a migration table).

Files: `docs/polygon-methods.mdx` (Info note + migration table + method-table rows flipped to unavailable); `reference/polygon-trace_transaction.mdx` and `reference/polygon-trace_block.mdx` (present-state "not available on Polygon — use debug_*" notes).

`mint validate` + `mint broken-links` pass.

> ⚠️ **Merge timing:** this doc asserts the end-state as current, which is only accurate once Erigon is actually retired from Chainstack Polygon (**~Jul 29, 2026**). Merging before then would tell users `trace_*`/`erigon_*` are gone while they still work. **Merge at/after the cutover**, not earlier.

Context (not in the doc): Chainstack retires Erigon Jul 29 (Infra decision / INFRA-9692), ahead of Polygon's upstream Erigon sunset Aug 1.

**Dropped:** an earlier `eth_getProof` "~128 blocks on Bor" caveat — that's a PBSS *default* but is version/config-dependent (Geth v1.17+ `history.trienode` restores historical proofs), and unconfirmed for our production Bor archive. Pending Infra confirmation of the Bor config; re-add only if confirmed.
