### PR TITLE
docs: add Berachain Bepolia Testnet as a Global Node

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -164,9 +164,11 @@ description: Browse available cloud providers, regions, and geographic locations
 
 ## Berachain
 
-| Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
-| ------- | -------------------------- | ------- | --------- | ------- | ------------- |
-| Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
+| Network         | Cloud                      | Region  | Location  | Mode    | Debug & trace |
+| --------------- | -------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet         | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
+| Bepolia Testnet | Chainstack Global Network  | global1 | Worldwide | Full    | Available     |
+| Bepolia Testnet | Chainstack Global Network  | global1 | Worldwide | Archive | Available     |
 
 ## Linea
 

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -164,11 +164,12 @@ description: Browse available cloud providers, regions, and geographic locations
 
 ## Berachain
 
-| Network         | Cloud                      | Region  | Location  | Mode    | Debug & trace |
-| --------------- | -------------------------- | ------- | --------- | ------- | ------------- |
-| Mainnet         | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
-| Bepolia Testnet | Chainstack Global Network  | global1 | Worldwide | Full    | Available     |
-| Bepolia Testnet | Chainstack Global Network  | global1 | Worldwide | Archive | Available     |
+| Network         | Cloud                     | Region  | Location  | Mode    | Debug & trace |
+| --------------- | ------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet         | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
+| Mainnet         | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
+| Bepolia Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
+| Bepolia Testnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 
 ## Linea
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -22,7 +22,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Avalanche | Elastic, Dedicated | Full, Archive | Full, Archive | Fuji Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | B^2 | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-b2/#request) |
 | Base | Elastic, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Berachain | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Berachain | Elastic, Dedicated | Full, Archive | Full, Archive | Bepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Bitcoin | Elastic, Dedicated | Full | Full | Signet, Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Bitlayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-bitlayer/#request) |
 | Bittensor | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1270,11 +1270,16 @@
         "faucet_url": "N/A",
         "locations": [
           {
-            "cloud": "Chainstack Partner Network",
+            "cloud": "Chainstack Global Network",
             "node_type": "Global Node",
-            "region": "global2",
+            "region": "global1",
             "location": "Worldwide",
             "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
               {
                 "mode": "Archive",
                 "debug_trace": true,

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1284,7 +1284,32 @@
           }
         ]
       },
-      "testnets": [],
+      "testnets": [
+        {
+          "network_name": "Bepolia Testnet",
+          "faucet_url": "N/A",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Full",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                },
+                {
+                  "mode": "Archive",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
       "additional_notes": "N/A"
     },
     "Linea": {


### PR DESCRIPTION
## What

Makes **Berachain Mainnet and Bepolia Testnet** available as Global Nodes on the Chainstack Global Network.

- **Networks** — Mainnet, Bepolia Testnet
- **Cloud / region** — Chainstack Global Network, `global1`, Worldwide
- **Modes** — Full and Archive (both networks)
- **Debug & trace** — available (both networks)

## Changes

- `node-options-master-list.json` — Berachain: Mainnet moved to Chainstack Global Network (`global1`) with Full + Archive; added the Bepolia Testnet Global Node with Full + Archive (source of truth).
- `docs/protocols-networks.mdx` — regenerated Berachain row: testnet support `Full, Archive`, testnet network `Bepolia Testnet`.
- `docs/nodes-clouds-regions-and-locations.mdx` — regenerated Berachain section: Mainnet and Bepolia Testnet, each with Full and Archive rows on `global1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)