### PR TITLE
docs: add Bepolia Testnet network ID to Berachain tooling

### DIFF
--- a/docs/berachain-tooling.mdx
+++ b/docs/berachain-tooling.mdx
@@ -73,6 +73,7 @@ where
 * NETWORK\_ID — Berachain network ID:
 
   * Mainnet: `80094`
+  * Bepolia Testnet: `80069`
 
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).


### PR DESCRIPTION
Follow-up to #516 (Bepolia Testnet is now a supported Global Node). The tooling guide's network-ID list only showed Mainnet; adds **Bepolia Testnet: `80069`** (verified via [ChainList](https://chainlist.org/chain/80069) + [Berachain docs](https://docs.berachain.com/developers/network-configurations)).

One-line addition to an existing list — no code, components, or nav changes.