### PR TITLE
fix(node options): Blast protocol configuration inconsistencies

### DIFF
--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1172,13 +1172,13 @@
     "Blast": {
       "protocol_name": "Blast",
       "supported_modes": [
-        "Full"
+        "Archive"
       ],
       "full_mode_query_limit": "N/A",
-      "archive_mode_available": false,
+      "archive_mode_available": true,
       "debug_trace_available": true,
       "warp_transactions_available": false,
-      "dedicated_node_availability": "N/A",
+      "dedicated_node_availability": "Platform",
       "mainnet": {
         "network_name": "Mainnet",
         "faucet_url": "N/A",


### PR DESCRIPTION
## Problem
The `Blast` protocol entry had multiple data inconsistencies in `node-options-master-list.json`:

1. `supported_modes: ["Full"]` but actual deployment is `Archive` mode
2. `archive_mode_available: false` but there is an Archive deployment
3. `dedicated_node_availability: "N/A"` but deployments exist on Partner Network

## Solution
Updated Blast configuration to match actual deployment data:

- `supported_modes`: `["Full"]` → `["Archive"]`
- `archive_mode_available`: `false` → `true`
- `dedicated_node_availability`: `"N/A"` → `"Platform"`

## Verification
- [x] Ran programmatic validation against `node-options-master-list.json`
- [x] Confirmed Blast is the only protocol with `supported_modes`/`deployment_options` mismatch
- [x] Fix aligns with actual deployment data in the same file

## Related
Fixes #519