### PR TITLE
fix(docs,node-options): Multiple data inconsistencies (Blast, Oasis Sapphire, Holesky chainId)

### DIFF
--- a/docs/blob-transactions-the-hard-way.mdx
+++ b/docs/blob-transactions-the-hard-way.mdx
@@ -231,7 +231,7 @@ Let's first run the script and then have a look at the transaction committed to 
 
   tx = {
       "type": 3, # Type-3 transaction
-      "chainId": 11155111,  # Hoodi 560048; Sepolia 11155111; Holesky 17000 (deprecated on Oct 31, 2025)
+      "chainId": 560048,  # Hoodi testnet (Holesky successor)
       "from": acct.address,
       "to": "0x0000000000000000000000000000000000000000", # Does not matter what account you send it to
       "value": 0,

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -2248,7 +2248,7 @@
             "cloud": "Chainstack Global Network",
             "node_type": "Global Node",
             "region": "global1",
-            "location": "Global",
+            "location": "Worldwide",
             "deployment_options": [
               {
                 "mode": "Full",
@@ -2268,7 +2268,7 @@
               "cloud": "Chainstack Global Network",
               "node_type": "Global Node",
               "region": "global1",
-              "location": "Global",
+              "location": "Worldwide",
               "deployment_options": [
                 {
                   "mode": "Full",

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1172,13 +1172,13 @@
     "Blast": {
       "protocol_name": "Blast",
       "supported_modes": [
-        "Full"
+        "Archive"
       ],
       "full_mode_query_limit": "N/A",
-      "archive_mode_available": false,
+      "archive_mode_available": true,
       "debug_trace_available": true,
       "warp_transactions_available": false,
-      "dedicated_node_availability": "N/A",
+      "dedicated_node_availability": "Platform",
       "mainnet": {
         "network_name": "Mainnet",
         "faucet_url": "N/A",


### PR DESCRIPTION
## Problem
The `blob-transactions-the-hard-way.mdx` tutorial contained an incorrect chain ID reference:

- `chainId` was set to `11155111` (Sepolia)
- But the comment mentioned Holesky (`17000`) which was deprecated on Oct 31, 2025
- This created confusion between Sepolia, Holesky, and Hoodi testnets

## Solution
Updated the example to use Hoodi (Holesky's successor testnet):

- `chainId`: `11155111` → `560048` (Hoodi)
- Comment: clarified as `Hoodi testnet (Holesky successor)`

## Verification
- [x] Holesky deprecated date confirmed: October 31, 2025
- [x] Hoodi chain ID verified: `560048`
- [x] Sepolia chain ID verified: `11155111` (not used in this example)
- [x] Tutorial now references the correct, active testnet

## Consolidated Fixes

This PR combines the following fixes:

1. **Blast protocol config** (Fixes #519)
   - `supported_modes`: `["Full"]` → `["Archive"]`
   - `archive_mode_available`: `false` → `true`
   - `dedicated_node_availability`: `"N/A"` → `"Platform"`

2. **Oasis Sapphire location** (Fixes #521)
   - `location`: `"Global"` → `"Worldwide"` (consistency with 90+ other protocols)

3. **Holesky chain ID** (Fixes #523)
   - `chainId`: `11155111` → `560048` (Hoodi, Holesky's successor)
   - Removed deprecated Holesky reference