### PR TITLE
docs: correct Blast to Full + Archive (archive mode was mismarked)

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -153,6 +153,7 @@ description: Browse available cloud providers, regions, and geographic locations
 
 | Network | Cloud                      | Region    | Location  | Mode      | Debug & trace       |
 | ------- | -------------------------- | --------- | --------- | --------- | ------------------- |
+| Mainnet | Chainstack Partner Network | global2   | Worldwide | Full      | Available           |
 | Mainnet | Chainstack Partner Network | global2   | Worldwide | Archive   | Available           |
 
 ## Sui

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1172,10 +1172,11 @@
     "Blast": {
       "protocol_name": "Blast",
       "supported_modes": [
-        "Full"
+        "Full",
+        "Archive"
       ],
       "full_mode_query_limit": "N/A",
-      "archive_mode_available": false,
+      "archive_mode_available": true,
       "debug_trace_available": true,
       "warp_transactions_available": false,
       "dedicated_node_availability": "N/A",
@@ -1189,6 +1190,11 @@
             "region": "global2",
             "location": "Worldwide",
             "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
               {
                 "mode": "Archive",
                 "debug_trace": true,


### PR DESCRIPTION
## What

The master-list `Blast` entry was internally inconsistent — `supported_modes: ["Full"]`, `archive_mode_available: false`, but the mainnet deployment option was `Archive`-only. The live deployment catalog confirms Blast serves **full + archive + debug_trace** on a Global node.

## Changes
- `node-options-master-list.json` — `supported_modes` → `["Full", "Archive"]`, `archive_mode_available` → `true`, added the `Full` mainnet deployment option.
- `nodes-clouds-regions-and-locations.mdx` — added the `Full` row for Blast mainnet (was Archive-only).
- `protocols-networks.mdx` — already showed "Full, Archive"; no change.

## Verification
- Live deployment catalog: `blast-mainnet` = Global, `[full, archive, debug_trace]`.
- Cloud/region (Partner Network / `global2`) verified correct against the catalog (`CC-0017`/`global2`) and left unchanged.
- JSON valid; trailing newline preserved; `mint validate` running (will confirm green).

_Origin: the same Blast inconsistency was flagged in a community PR; reworked here with catalog verification + table regeneration._