### PR TITLE
docs: Sui JSON-RPC→gRPC migration guide + gRPC endpoint page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1431,6 +1431,8 @@
               "docs/ronin-tooling",
               "docs/blast-tooling",
               "docs/sui-tooling",
+              "docs/sui-grpc-endpoint",
+              "docs/sui-migrate-json-rpc-to-grpc",
               "docs/berachain-tooling",
               "docs/monad-tooling",
               "docs/linea-tooling",

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -1,0 +1,80 @@
+---
+title: "Sui gRPC endpoint"
+description: "The Chainstack Sui endpoint serves JSON-RPC and gRPC on the same node, with deep checkpoint retention and x-token authentication. Migrate off Sui's public JSON-RPC without switching providers."
+---
+
+The Chainstack Sui endpoint serves both JSON-RPC and gRPC on the **same node**, so you can migrate off Sui Foundation's public JSON-RPC — [shutting down Jul 31, 2026](/docs/sui-migrate-json-rpc-to-grpc) — without re-syncing or switching providers. Keep calling JSON-RPC while you port your code, then move each call to gRPC on the same endpoint.
+
+## What you get
+
+- One node, both interfaces — JSON-RPC over HTTPS and native gRPC over HTTP/2, from a single Chainstack Sui node.
+- Deep checkpoint retention — tens of millions of checkpoints of history for point lookups and backfills.
+- Server reflection enabled on gRPC — explore services and call methods with grpcurl, no proto compilation needed.
+- `x-token` authentication on gRPC and API-key or basic auth on JSON-RPC.
+
+## Endpoints
+
+Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+
+| Interface | Endpoint | Authentication |
+| --- | --- | --- |
+| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_KEY` | API key in URL |
+| JSON-RPC (HTTPS, basic auth) | `https://sui-mainnet.core.chainstack.com` | username and password |
+| gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
+
+Testnet uses the `sui-testnet.core.chainstack.com` host in the same format.
+
+## Checkpoint retention
+
+A Sui full node serves a moving window of recent checkpoints rather than the full ledger from genesis. Query the current window with `GetServiceInfo`, which reports the tip (`checkpointHeight`) and the oldest checkpoint the node still holds (`lowestAvailableCheckpoint`):
+
+```bash
+grpcurl -H "x-token: YOUR_X_TOKEN" \
+  sui-mainnet.core.chainstack.com:443 \
+  sui.rpc.v2.LedgerService/GetServiceInfo
+```
+
+```json
+{
+  "chain": "mainnet",
+  "epoch": "1184",
+  "checkpointHeight": "296723264",
+  "lowestAvailableCheckpoint": "253124671",
+  "server": "sui-node/1.74.1-8fc60f1fa966"
+}
+```
+
+In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671 to 296,723,264 — about 43.6M checkpoints of history. The window advances as the chain grows; check `lowestAvailableCheckpoint` at runtime for the current floor. For reads older than the window, query an archival store.
+
+## Verify your endpoint
+
+<CodeGroup>
+  ```bash JSON-RPC
+  curl --request POST \
+    --url https://sui-mainnet.core.chainstack.com/YOUR_KEY \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "sui_getLatestCheckpointSequenceNumber",
+      "params": []
+    }'
+  ```
+
+  ```bash gRPC
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    sui-mainnet.core.chainstack.com:443 \
+    list
+  ```
+</CodeGroup>
+
+The gRPC list returns the available `sui.rpc.v2` services: `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`.
+
+<Info>
+  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint, which continues to work.
+</Info>
+
+## Next steps
+
+- [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc) — call-by-call method mapping and quickstart.
+- [Sui tooling](/docs/sui-tooling) — SDKs and per-language connection code.

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -10,19 +10,18 @@ The Chainstack Sui endpoint serves both JSON-RPC and gRPC on the **same node**, 
 - One node, both interfaces — JSON-RPC over HTTPS and native gRPC over HTTP/2, from a single Chainstack Sui node.
 - Deep checkpoint retention — tens of millions of checkpoints of history for point lookups and backfills.
 - Server reflection enabled on gRPC — explore services and call methods with grpcurl, no proto compilation needed.
-- `x-token` authentication on gRPC and API-key or basic auth on JSON-RPC.
+- `x-token` authentication on gRPC; auth token or basic auth on JSON-RPC.
 
 ## Endpoints
 
-Find your endpoint and credentials on Chainstack under your Sui node's **Access and credentials** tab.
+Find your endpoint and credentials on Chainstack under your Sui node's **Access and credentials** tab. Copy the full HTTPS endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`) — it already carries your auth token.
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |
-| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN` | auth token in the URL |
-| JSON-RPC (HTTPS, basic auth) | `https://sui-mainnet.core.chainstack.com` | username and password |
+| JSON-RPC (HTTPS) | `YOUR_CHAINSTACK_ENDPOINT` | auth token or basic auth, built into the endpoint |
 | gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
 
-Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. The auth token is the node's access credential, not your Chainstack platform API key. For every authentication option, see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios).
+Testnet gRPC is `sui-testnet.core.chainstack.com:443`. The auth token and x-token are the node's access credentials, not your Chainstack platform API key. For every authentication option, see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios).
 
 ## Checkpoint retention
 
@@ -51,7 +50,7 @@ In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671
 <CodeGroup>
   ```bash JSON-RPC
   curl --request POST \
-    --url https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN \
+    --url YOUR_CHAINSTACK_ENDPOINT \
     --header 'Content-Type: application/json' \
     --data '{
       "jsonrpc": "2.0",

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -14,7 +14,7 @@ The Chainstack Sui endpoint serves both JSON-RPC and gRPC on the **same node**, 
 
 ## Endpoints
 
-Find your endpoint and credentials on Chainstack under your Sui node's **Access and credentials** tab. Copy the full HTTPS endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`) — it already carries your auth token.
+Find your endpoint and credentials on Chainstack — see [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials). Copy the full HTTPS endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`) — it already carries your auth token.
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -70,7 +70,7 @@ In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671
 The gRPC list returns the available `sui.rpc.v2` services: `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`.
 
 <Info>
-  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint, which continues to work.
+  The official Sui TypeScript SDK (`@mysten/sui`) works here over a native gRPC transport — see [the setup in Sui tooling](/docs/sui-tooling#grpc-from-code). Its default gRPC-Web transport is not supported on Chainstack yet (HTTP 415), so browser apps should use JSON-RPC or proxy gRPC through a backend.
 </Info>
 
 ## Next steps

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -14,15 +14,15 @@ The Chainstack Sui endpoint serves both JSON-RPC and gRPC on the **same node**, 
 
 ## Endpoints
 
-Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+Find your endpoint and credentials on Chainstack under your Sui node's **Access and credentials** tab.
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |
-| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_KEY` | API key in URL |
+| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN` | auth token in the URL |
 | JSON-RPC (HTTPS, basic auth) | `https://sui-mainnet.core.chainstack.com` | username and password |
 | gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
 
-Testnet uses the `sui-testnet.core.chainstack.com` host in the same format.
+Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. The auth token is the node's access credential, not your Chainstack platform API key. For every authentication option, see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios).
 
 ## Checkpoint retention
 
@@ -51,7 +51,7 @@ In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671
 <CodeGroup>
   ```bash JSON-RPC
   curl --request POST \
-    --url https://sui-mainnet.core.chainstack.com/YOUR_KEY \
+    --url https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN \
     --header 'Content-Type: application/json' \
     --data '{
       "jsonrpc": "2.0",

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -67,7 +67,7 @@ In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671
   ```
 </CodeGroup>
 
-The gRPC list returns the available `sui.rpc.v2` services: `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`.
+The `list` output shows the node's `sui.rpc.v2` services — [Sui tooling](/docs/sui-tooling#grpc-api) describes what each one is for.
 
 <Info>
   The official Sui TypeScript SDK (`@mysten/sui`) works here over a native gRPC transport — see [the setup in Sui tooling](/docs/sui-tooling#grpc-from-code). Its default gRPC-Web transport is not supported on Chainstack yet (HTTP 415), so browser apps should use JSON-RPC or proxy gRPC through a backend.

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -23,12 +23,10 @@ Only Sui Foundation's **public good** JSON-RPC endpoints are being turned off. J
 
 The reason to migrate anyway is that gRPC is the interface Sui invests in going forward. gRPC uses HTTP/2 and Protocol Buffers for binary serialization, which makes payloads smaller and adds server-side streaming — you subscribe to new checkpoints instead of polling for them.
 
-On Chainstack, the migration is **JSON-RPC → gRPC**. Chainstack serves Sui over JSON-RPC and gRPC — not GraphQL RPC — so:
+On Chainstack, the migration is **JSON-RPC → gRPC**, and both run on the same node:
 
 - Move performance-sensitive and streaming workloads to **gRPC** — backends, indexers, typed clients, low-latency lookups, transaction submission, and checkpoint streaming.
 - Keep everything else on **JSON-RPC**. It stays up on your Chainstack endpoint, and methods that have no gRPC equivalent (event and transaction-block queries, and so on) keep working over it — you do not have to move them.
-
-Sui also offers **GraphQL RPC** (for frontends and flexible historical queries) and an **archival store** (for deep history beyond a full node's retention window) on its own infrastructure. Chainstack does not serve these — if you specifically need GraphQL, query Sui's GraphQL service directly.
 
 ## Chainstack Sui endpoints
 
@@ -77,16 +75,13 @@ Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and writ
 
 ### No gRPC equivalent — keep on JSON-RPC
 
-These methods have no gRPC equivalent, but they keep working on your Chainstack JSON-RPC endpoint — Sui Foundation is retiring its own public endpoints, not removing JSON-RPC from the node software, so Chainstack's JSON-RPC is unaffected. Keep calling these over JSON-RPC; you do not need GraphQL for them. The last column names Sui's GraphQL equivalent in case you move that workload to Sui's GraphQL service, which Chainstack does not host.
+These methods have no gRPC equivalent, but they keep working on your Chainstack JSON-RPC endpoint — Sui Foundation is retiring its own public endpoints, not removing JSON-RPC from the node software, so Chainstack's JSON-RPC is unaffected. Keep calling them over JSON-RPC:
 
-| JSON-RPC method | On Chainstack | Sui GraphQL equivalent |
-| --- | --- | --- |
-| `suix_queryTransactionBlocks` | Keep on JSON-RPC | `transactions` query |
-| `suix_queryEvents` | Keep on JSON-RPC | `events` query |
-| `sui_getCheckpoints` | Keep on JSON-RPC | `checkpoints` query |
-| `suix_getStakes`, `suix_getStakesByIds` | Keep on JSON-RPC | `address.stakedSuis` query |
-| `suix_getValidatorsApy` | Keep on JSON-RPC | Compute client-side from validator pool exchange rates |
-| `suix_subscribeEvent`, `suix_subscribeTransaction` | Keep on JSON-RPC (WebSocket) | `events` query (poll), or gRPC `SubscriptionService/SubscribeCheckpoints` and filter client-side |
+- `suix_queryTransactionBlocks` and `suix_queryEvents`
+- `sui_getCheckpoints`
+- `suix_getStakes` and `suix_getStakesByIds`
+- `suix_getValidatorsApy`
+- `suix_subscribeEvent` and `suix_subscribeTransaction`, over the JSON-RPC WebSocket endpoint
 
 ### Indexer and analytics methods
 
@@ -94,7 +89,7 @@ A few JSON-RPC methods return aggregated analytics that come from Sui's indexer 
 
 | JSON-RPC method | What to use instead |
 | --- | --- |
-| `suix_getEpochs` | For current epoch data — validators, committee, gas price — call `suix_getLatestSuiSystemState` (JSON-RPC) or `LedgerService/GetEpoch` (gRPC) on Chainstack. For historical epoch enumeration, query Sui's GraphQL `epochs`. |
+| `suix_getEpochs` | For epoch data — validators, committee, gas price — call `suix_getLatestSuiSystemState` (JSON-RPC) or `LedgerService/GetEpoch` (gRPC) on Chainstack. Enumerating past epochs is an indexer job, not a node call. |
 | `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Network analytics (TPS, active addresses, popular calls). Derive them by indexing your Chainstack node's checkpoint stream (gRPC `SubscriptionService/SubscribeCheckpoints`) into your own store, or use a Sui analytics provider. Most applications do not need these. |
 
 <Note>

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -10,9 +10,9 @@ Sui Foundation is shutting down its **public** JSON-RPC endpoints. On Chainstack
 
   - Testnet — week of Jul 6, 2026
   - Mainnet — week of Jul 20, 2026
-  - Full protocol-level deactivation — Jul 31, 2026
+  - Sui Foundation's public JSON-RPC fully retired — Jul 31, 2026
 
-  Any app still calling those public URLs stops working after these dates.
+  Any app still calling those public URLs stops working after these dates. This retires Sui Foundation's free public service — it does not remove JSON-RPC from the node software, so operators like Chainstack keep serving it.
 </Warning>
 
 ## What is actually being deprecated
@@ -41,7 +41,7 @@ Testnet gRPC is `sui-testnet.core.chainstack.com:443`. For every authentication 
 
 ## Method mapping
 
-Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and write JSON-RPC methods map directly to a gRPC call. A handful of query and metrics methods have no gRPC equivalent — on Chainstack, most of those keep working over JSON-RPC, and a few are not served at all. The tables below give the path for each common JSON-RPC method.
+Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and write JSON-RPC methods map directly to a gRPC call. A handful of query methods have no gRPC equivalent but keep working on Chainstack's JSON-RPC; a few analytics methods come from Sui's indexer and no full node serves them. The tables below give the path for each common JSON-RPC method.
 
 ### Maps to gRPC
 
@@ -75,7 +75,7 @@ Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and writ
 
 ### No gRPC equivalent — keep on JSON-RPC
 
-These methods have no gRPC equivalent, but they remain available on your Chainstack JSON-RPC endpoint, which stays up. Keep calling them over JSON-RPC — you do not need GraphQL for them. The last column names Sui's GraphQL equivalent in case you move that workload to Sui's GraphQL service, which Chainstack does not host.
+These methods have no gRPC equivalent, but they keep working on your Chainstack JSON-RPC endpoint — Sui Foundation is retiring its own public endpoints, not removing JSON-RPC from the node software, so Chainstack's JSON-RPC is unaffected. Keep calling these over JSON-RPC; you do not need GraphQL for them. The last column names Sui's GraphQL equivalent in case you move that workload to Sui's GraphQL service, which Chainstack does not host.
 
 | JSON-RPC method | On Chainstack | Sui GraphQL equivalent |
 | --- | --- | --- |
@@ -86,14 +86,14 @@ These methods have no gRPC equivalent, but they remain available on your Chainst
 | `suix_getValidatorsApy` | Keep on JSON-RPC | Compute client-side from validator pool exchange rates |
 | `suix_subscribeEvent`, `suix_subscribeTransaction` | Keep on JSON-RPC (WebSocket) | `events` query (poll), or gRPC `SubscriptionService/SubscribeCheckpoints` and filter client-side |
 
-### Not served by Chainstack
+### Indexer and analytics methods
 
-A few JSON-RPC methods are neither available on Chainstack nor have a gRPC equivalent. Sui provides these through GraphQL RPC or an indexer — both hosted outside Chainstack.
+A few JSON-RPC methods return aggregated analytics that come from Sui's indexer layer, not from a full node. A full node — Sui's or Chainstack's — does not serve them over JSON-RPC or gRPC (calling them on Chainstack returns `-32601 Method not found`). Get the underlying data these way:
 
-| JSON-RPC method | Where to get it |
+| JSON-RPC method | What to use instead |
 | --- | --- |
-| `suix_getEpochs` | Sui GraphQL `epochs` query. For the current epoch only, use gRPC `LedgerService/GetEpoch` or `suix_getLatestSuiSystemState` on Chainstack. |
-| `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Run an indexer |
+| `suix_getEpochs` | For current epoch data — validators, committee, gas price — call `suix_getLatestSuiSystemState` (JSON-RPC) or `LedgerService/GetEpoch` (gRPC) on Chainstack. For historical epoch enumeration, query Sui's GraphQL `epochs`. |
+| `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Network analytics (TPS, active addresses, popular calls). Derive them by indexing your Chainstack node's checkpoint stream (gRPC `SubscriptionService/SubscribeCheckpoints`) into your own store, or use a Sui analytics provider. Most applications do not need these. |
 
 <Note>
   Real-time event subscriptions have two paths on Chainstack. Keep using `suix_subscribeEvent` over the JSON-RPC WebSocket endpoint, or subscribe to checkpoints over gRPC with `SubscriptionService/SubscribeCheckpoints` and filter events client-side. gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions.

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -30,7 +30,7 @@ Sui also offers **GraphQL RPC** (for frontends and flexible historical queries) 
 
 ## Chainstack Sui endpoints
 
-Both interfaces are on the same node. Copy your JSON-RPC endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`, with its auth token built in) from the node's **Access and credentials** tab on Chainstack; the gRPC endpoint is the host and port below.
+Both interfaces are on the same node. Copy your JSON-RPC endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`, with its auth token built in) from Chainstack — see [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials). The gRPC endpoint is the host and port below.
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -33,10 +33,10 @@ Both interfaces are on the same node. Find your endpoint and token on Chainstack
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |
-| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_KEY` | API key in URL |
+| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN` | auth token in the URL |
 | gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
 
-Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. See [Sui tooling](/docs/sui-tooling) for SDK setup and per-language connection code.
+Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. Both interfaces also accept basic authentication (username and password) instead of the auth token — see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios) for every option. See [Sui tooling](/docs/sui-tooling) for SDK setup and per-language connection code.
 
 ## Method mapping
 

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -141,19 +141,41 @@ The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `Transa
 
 ## gRPC from code
 
-Native gRPC works from any language over HTTP/2 with TLS. Authenticate by attaching the `x-token` metadata header to every call. Generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto), then call the service methods from the mapping tables.
+In TypeScript, use the official Sui SDK (`@mysten/sui`) with a **native gRPC transport**. The SDK's default transport is gRPC-Web, which Chainstack does not serve (it returns HTTP 415), so pass a `@protobuf-ts/grpc-transport` transport backed by `@grpc/grpc-js` and authenticate with the `x-token` metadata header. From other languages, generate stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto) and attach the same `x-token` metadata.
+
+<Note>
+  Use recent client versions — `@mysten/sui` 2.16 or later and `@grpc/grpc-js` 1.14 or later. Older releases mishandle gRPC streams and produce intermittent `RST` and internal errors under load; current versions are reliable.
+</Note>
 
 <CodeGroup>
+  ```typescript TypeScript
+  // npm install @mysten/sui @protobuf-ts/grpc-transport @grpc/grpc-js
+  import { SuiGrpcClient } from '@mysten/sui/grpc';
+  import { GrpcTransport } from '@protobuf-ts/grpc-transport';
+  import { ChannelCredentials } from '@grpc/grpc-js';
+
+  const client = new SuiGrpcClient({
+    network: 'mainnet',
+    transport: new GrpcTransport({
+      host: 'sui-mainnet.core.chainstack.com:443',
+      channelCredentials: ChannelCredentials.createSsl(),
+      meta: { 'x-token': 'YOUR_X_TOKEN' },
+    }),
+  });
+
+  // High-level helpers on client.core; raw services on client.ledgerService, etc.
+  const gasPrice = await client.core.getReferenceGasPrice();
+  console.log(gasPrice.referenceGasPrice);
+  ```
+
   ```python Python
   import grpc
 
-  # Native gRPC channel over TLS
+  # Native gRPC channel over TLS; x-token metadata on every call
   channel = grpc.secure_channel(
       "sui-mainnet.core.chainstack.com:443",
       grpc.ssl_channel_credentials(),
   )
-
-  # x-token metadata is required on every call
   metadata = (("x-token", "YOUR_X_TOKEN"),)
 
   # Using stubs generated from Sui's protos, e.g. LedgerService:
@@ -164,28 +186,10 @@ Native gRPC works from any language over HTTP/2 with TLS. Authenticate by attach
   # )
   # print(resp.checkpoint_height)
   ```
-
-  ```javascript Node.js
-  const grpc = require('@grpc/grpc-js');
-
-  // Native gRPC channel over TLS
-  const credentials = grpc.credentials.createSsl();
-
-  // x-token metadata is required on every call
-  const metadata = new grpc.Metadata();
-  metadata.add('x-token', 'YOUR_X_TOKEN');
-
-  // Using stubs generated from Sui's protos, e.g. LedgerService:
-  // const client = new LedgerServiceClient(
-  //   'sui-mainnet.core.chainstack.com:443', credentials);
-  // client.getServiceInfo({}, metadata, (err, resp) => {
-  //   console.log(resp.checkpointHeight);
-  // });
-  ```
 </CodeGroup>
 
 <Info>
-  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint, which continues to work.
+  Browser apps cannot use this path yet. The SDK's browser transport is gRPC-Web, which Chainstack does not serve (HTTP 415). From the browser, call your Chainstack JSON-RPC endpoint, or proxy gRPC through your own backend.
 </Info>
 
 ## Next steps

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -1,0 +1,188 @@
+---
+title: "Migrate Sui from JSON-RPC to gRPC"
+description: "Sui Foundation shuts down its public JSON-RPC endpoints on Jul 31, 2026. Map each JSON-RPC method to its gRPC or GraphQL replacement and keep your Sui app running on Chainstack."
+---
+
+Sui Foundation is shutting down its **public** JSON-RPC endpoints. Migrate each call to the Sui gRPC API (backends, indexers, streaming) or GraphQL RPC (frontends, analytics, historical queries). Your Chainstack Sui endpoint serves JSON-RPC and gRPC on the **same node**, so you can migrate call by call without switching providers or re-syncing.
+
+<Warning>
+  Sui Foundation's public JSON-RPC endpoints (`fullnode.mainnet.sui.io`, `fullnode.testnet.sui.io`) shut down on this schedule:
+
+  - Testnet — week of Jul 6, 2026
+  - Mainnet — week of Jul 20, 2026
+  - Full protocol-level deactivation — Jul 31, 2026
+
+  Any app still calling those public URLs stops working after these dates.
+</Warning>
+
+## What is actually being deprecated
+
+Only Sui Foundation's **public good** JSON-RPC endpoints are being turned off. JSON-RPC is deprecated in the `sui-node` software but not removed — node operators can keep JSON-RPC serving. Your **Chainstack Sui JSON-RPC endpoint keeps working**, so the deadline is not a hard cutover for Chainstack customers: you can keep calling JSON-RPC while you port your code to gRPC on the same endpoint.
+
+The reason to migrate anyway is that gRPC is the interface Sui invests in going forward. gRPC uses HTTP/2 and Protocol Buffers for binary serialization, which makes payloads smaller and adds server-side streaming — you subscribe to new checkpoints instead of polling for them.
+
+Pick your target by workload:
+
+- gRPC — backend systems, indexers, typed clients, low-latency lookups, transaction submission, and streaming subscriptions.
+- GraphQL RPC — frontends, dynamic-language clients, and flexible filtered historical queries.
+- Archival store — deep historical reads across the full ledger from genesis, beyond a full node's retention window.
+
+## Chainstack Sui endpoints
+
+Both interfaces are on the same node. Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+
+| Interface | Endpoint | Authentication |
+| --- | --- | --- |
+| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_KEY` | API key in URL |
+| gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
+
+Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. See [Sui tooling](/docs/sui-tooling) for SDK setup and per-language connection code.
+
+## Method mapping
+
+Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and write JSON-RPC methods map directly to a gRPC call; a set of query and metrics methods move to GraphQL only. The tables below list the replacement for each common JSON-RPC method.
+
+### Maps to gRPC
+
+| JSON-RPC method | gRPC service and method |
+| --- | --- |
+| `sui_getChainIdentifier` | `LedgerService/GetServiceInfo` (read `chainId`) |
+| `sui_getLatestCheckpointSequenceNumber` | `LedgerService/GetServiceInfo` (read `checkpointHeight`) |
+| `sui_getCheckpoint` | `LedgerService/GetCheckpoint` |
+| `sui_getObject` | `LedgerService/GetObject` |
+| `sui_multiGetObjects` | `LedgerService/BatchGetObjects` |
+| `sui_getTransactionBlock` | `LedgerService/GetTransaction` |
+| `sui_multiGetTransactionBlocks` | `LedgerService/BatchGetTransactions` |
+| `suix_getLatestSuiSystemState` | `LedgerService/GetEpoch` (system state in read mask) |
+| `suix_getCommitteeInfo` | `LedgerService/GetEpoch` (committee in read mask) |
+| `sui_getProtocolConfig` | `LedgerService/GetEpoch` (protocol config in read mask) |
+| `suix_getBalance` | `StateService/GetBalance` |
+| `suix_getAllBalances` | `StateService/ListBalances` |
+| `suix_getCoins` | `StateService/ListOwnedObjects` (filter `type: 0x2::coin::Coin`) |
+| `suix_getCoinMetadata` | `StateService/GetCoinInfo` |
+| `suix_getTotalSupply` | `StateService/GetCoinInfo` |
+| `suix_getOwnedObjects` | `StateService/ListOwnedObjects` |
+| `suix_getDynamicFields` | `StateService/ListDynamicFields` |
+| `sui_dryRunTransactionBlock` | `TransactionExecutionService/SimulateTransaction` |
+| `sui_devInspectTransactionBlock` | `TransactionExecutionService/SimulateTransaction` (`checksEnabled: false`) |
+| `sui_executeTransactionBlock` | `TransactionExecutionService/ExecuteTransaction` |
+| `sui_getNormalizedMoveModule` | `MovePackageService/GetPackage` |
+| `sui_getNormalizedMoveFunction` | `MovePackageService/GetFunction` |
+| `sui_getNormalizedMoveStruct` | `MovePackageService/GetDatatype` |
+| `suix_resolveNameServiceAddress` | `NameService/LookupName` |
+| `suix_resolveNameServiceNames` | `NameService/ReverseLookupName` |
+
+### Moves to GraphQL only
+
+These methods have no gRPC equivalent — use GraphQL RPC (or an indexer for the metrics methods).
+
+| JSON-RPC method | Replacement |
+| --- | --- |
+| `suix_queryTransactionBlocks` | `transactions` GraphQL query |
+| `suix_queryEvents` | `events` GraphQL query |
+| `sui_subscribeEvent`, `sui_subscribeTransaction` | `events` GraphQL query, or gRPC `SubscriptionService/SubscribeCheckpoints` and filter client-side |
+| `sui_getCheckpoints` | `checkpoints` GraphQL query |
+| `suix_getEpochs` | `epochs` GraphQL query |
+| `suix_getStakes` | `address.stakedSuis` GraphQL query |
+| `suix_getValidatorsApy` | No canonical replacement — compute client-side from validator pool exchange rates |
+| `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Use an indexer |
+
+<Note>
+  Real-time event subscriptions change shape. gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions. For event-level streams, query the `events` GraphQL endpoint on an interval, or subscribe to checkpoints over gRPC and filter events client-side.
+</Note>
+
+## gRPC quickstart
+
+The fastest way to confirm your endpoint and explore the API is [grpcurl](https://github.com/fullstorydev/grpcurl). Sui gRPC has server reflection enabled, so you can list services and call methods without compiling proto files.
+
+<CodeGroup>
+  ```bash List services
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    sui-mainnet.core.chainstack.com:443 \
+    list
+  ```
+
+  ```bash Node and chain info
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    sui-mainnet.core.chainstack.com:443 \
+    sui.rpc.v2.LedgerService/GetServiceInfo
+  ```
+
+  ```bash Get a checkpoint
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    -d '{"sequence_number": 296000000}' \
+    sui-mainnet.core.chainstack.com:443 \
+    sui.rpc.v2.LedgerService/GetCheckpoint
+  ```
+</CodeGroup>
+
+`GetServiceInfo` returns the chain, current epoch, and the node's checkpoint range:
+
+```json
+{
+  "chainId": "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S",
+  "chain": "mainnet",
+  "epoch": "1184",
+  "checkpointHeight": "296723264",
+  "lowestAvailableCheckpoint": "253124671",
+  "server": "sui-node/1.74.1-8fc60f1fa966"
+}
+```
+
+The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`. Run `grpcurl ... describe sui.rpc.v2.LedgerService` to see each service's methods and message shapes.
+
+## gRPC from code
+
+Native gRPC works from any language over HTTP/2 with TLS. Authenticate by attaching the `x-token` metadata header to every call. Generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto), then call the service methods from the mapping tables.
+
+<CodeGroup>
+  ```python Python
+  import grpc
+
+  # Native gRPC channel over TLS
+  channel = grpc.secure_channel(
+      "sui-mainnet.core.chainstack.com:443",
+      grpc.ssl_channel_credentials(),
+  )
+
+  # x-token metadata is required on every call
+  metadata = (("x-token", "YOUR_X_TOKEN"),)
+
+  # Using stubs generated from Sui's protos, e.g. LedgerService:
+  # from sui.rpc.v2 import ledger_service_pb2, ledger_service_pb2_grpc
+  # stub = ledger_service_pb2_grpc.LedgerServiceStub(channel)
+  # resp = stub.GetServiceInfo(
+  #     ledger_service_pb2.GetServiceInfoRequest(), metadata=metadata
+  # )
+  # print(resp.checkpoint_height)
+  ```
+
+  ```javascript Node.js
+  const grpc = require('@grpc/grpc-js');
+
+  // Native gRPC channel over TLS
+  const credentials = grpc.credentials.createSsl();
+
+  // x-token metadata is required on every call
+  const metadata = new grpc.Metadata();
+  metadata.add('x-token', 'YOUR_X_TOKEN');
+
+  // Using stubs generated from Sui's protos, e.g. LedgerService:
+  // const client = new LedgerServiceClient(
+  //   'sui-mainnet.core.chainstack.com:443', credentials);
+  // client.getServiceInfo({}, metadata, (err, resp) => {
+  //   console.log(resp.checkpointHeight);
+  // });
+  ```
+</CodeGroup>
+
+<Info>
+  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint, which continues to work.
+</Info>
+
+## Next steps
+
+- [Sui tooling](/docs/sui-tooling) — SDKs, JSON-RPC, and gRPC connection setup.
+- [Sui gRPC endpoint](/docs/sui-grpc-endpoint) — checkpoint retention, authentication, and how Chainstack fronts both interfaces on one node.
+- [Sui gRPC overview](https://docs.sui.io/concepts/grpc-overview) — Sui's own gRPC reference.
+- [Sui JSON-RPC migration guide](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/json-rpc-migration) — the upstream mapping and SDK migration notes.

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -134,7 +134,13 @@ The fastest way to confirm your endpoint and explore the API is [grpcurl](https:
 }
 ```
 
-The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`. Run `grpcurl ... describe sui.rpc.v2.LedgerService` to see each service's methods and message shapes.
+To inspect any service's methods and message shapes, describe it:
+
+```bash
+grpcurl -H "x-token: YOUR_X_TOKEN" \
+  sui-mainnet.core.chainstack.com:443 \
+  describe sui.rpc.v2.LedgerService
+```
 
 ## gRPC from code
 

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -30,14 +30,14 @@ Sui also offers **GraphQL RPC** (for frontends and flexible historical queries) 
 
 ## Chainstack Sui endpoints
 
-Both interfaces are on the same node. Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+Both interfaces are on the same node. Copy your JSON-RPC endpoint (shown below as `YOUR_CHAINSTACK_ENDPOINT`, with its auth token built in) from the node's **Access and credentials** tab on Chainstack; the gRPC endpoint is the host and port below.
 
 | Interface | Endpoint | Authentication |
 | --- | --- | --- |
-| JSON-RPC (HTTPS) | `https://sui-mainnet.core.chainstack.com/YOUR_AUTH_TOKEN` | auth token in the URL |
+| JSON-RPC (HTTPS) | `YOUR_CHAINSTACK_ENDPOINT` | auth token or basic auth, built into the endpoint |
 | gRPC | `sui-mainnet.core.chainstack.com:443` | `x-token` metadata header |
 
-Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. Both interfaces also accept basic authentication (username and password) instead of the auth token — see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios) for every option. See [Sui tooling](/docs/sui-tooling) for SDK setup and per-language connection code.
+Testnet gRPC is `sui-testnet.core.chainstack.com:443`. For every authentication option, see [Authentication methods available on Chainstack](/docs/authentication-methods-for-different-scenarios). See [Sui tooling](/docs/sui-tooling) for SDK setup and per-language connection code.
 
 ## Method mapping
 

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Migrate Sui from JSON-RPC to gRPC"
-description: "Sui Foundation shuts down its public JSON-RPC endpoints on Jul 31, 2026. Map each JSON-RPC method to its gRPC or GraphQL replacement and keep your Sui app running on Chainstack."
+description: "Sui Foundation shuts down its public JSON-RPC endpoints on Jul 31, 2026. Migrate call by call to gRPC on Chainstack, where JSON-RPC and gRPC run on the same node and JSON-RPC keeps working."
 ---
 
-Sui Foundation is shutting down its **public** JSON-RPC endpoints. Migrate each call to the Sui gRPC API (backends, indexers, streaming) or GraphQL RPC (frontends, analytics, historical queries). Your Chainstack Sui endpoint serves JSON-RPC and gRPC on the **same node**, so you can migrate call by call without switching providers or re-syncing.
+Sui Foundation is shutting down its **public** JSON-RPC endpoints. On Chainstack, your Sui node serves JSON-RPC and gRPC on the **same endpoint**, so you migrate call by call — keep using JSON-RPC while you port each call to gRPC, with no provider switch and no re-sync.
 
 <Warning>
   Sui Foundation's public JSON-RPC endpoints (`fullnode.mainnet.sui.io`, `fullnode.testnet.sui.io`) shut down on this schedule:
@@ -21,11 +21,12 @@ Only Sui Foundation's **public good** JSON-RPC endpoints are being turned off. J
 
 The reason to migrate anyway is that gRPC is the interface Sui invests in going forward. gRPC uses HTTP/2 and Protocol Buffers for binary serialization, which makes payloads smaller and adds server-side streaming — you subscribe to new checkpoints instead of polling for them.
 
-Pick your target by workload:
+On Chainstack, the migration is **JSON-RPC → gRPC**. Chainstack serves Sui over JSON-RPC and gRPC — not GraphQL RPC — so:
 
-- gRPC — backend systems, indexers, typed clients, low-latency lookups, transaction submission, and streaming subscriptions.
-- GraphQL RPC — frontends, dynamic-language clients, and flexible filtered historical queries.
-- Archival store — deep historical reads across the full ledger from genesis, beyond a full node's retention window.
+- Move performance-sensitive and streaming workloads to **gRPC** — backends, indexers, typed clients, low-latency lookups, transaction submission, and checkpoint streaming.
+- Keep everything else on **JSON-RPC**. It stays up on your Chainstack endpoint, and methods that have no gRPC equivalent (event and transaction-block queries, and so on) keep working over it — you do not have to move them.
+
+Sui also offers **GraphQL RPC** (for frontends and flexible historical queries) and an **archival store** (for deep history beyond a full node's retention window) on its own infrastructure. Chainstack does not serve these — if you specifically need GraphQL, query Sui's GraphQL service directly.
 
 ## Chainstack Sui endpoints
 
@@ -40,7 +41,7 @@ Testnet uses the `sui-testnet.core.chainstack.com` host in the same format. Both
 
 ## Method mapping
 
-Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and write JSON-RPC methods map directly to a gRPC call; a set of query and metrics methods move to GraphQL only. The tables below list the replacement for each common JSON-RPC method.
+Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and write JSON-RPC methods map directly to a gRPC call. A handful of query and metrics methods have no gRPC equivalent — on Chainstack, most of those keep working over JSON-RPC, and a few are not served at all. The tables below give the path for each common JSON-RPC method.
 
 ### Maps to gRPC
 
@@ -72,23 +73,30 @@ Sui's gRPC API is organized into services under `sui.rpc.v2`. Most read and writ
 | `suix_resolveNameServiceAddress` | `NameService/LookupName` |
 | `suix_resolveNameServiceNames` | `NameService/ReverseLookupName` |
 
-### Moves to GraphQL only
+### No gRPC equivalent — keep on JSON-RPC
 
-These methods have no gRPC equivalent — use GraphQL RPC (or an indexer for the metrics methods).
+These methods have no gRPC equivalent, but they remain available on your Chainstack JSON-RPC endpoint, which stays up. Keep calling them over JSON-RPC — you do not need GraphQL for them. The last column names Sui's GraphQL equivalent in case you move that workload to Sui's GraphQL service, which Chainstack does not host.
 
-| JSON-RPC method | Replacement |
+| JSON-RPC method | On Chainstack | Sui GraphQL equivalent |
+| --- | --- | --- |
+| `suix_queryTransactionBlocks` | Keep on JSON-RPC | `transactions` query |
+| `suix_queryEvents` | Keep on JSON-RPC | `events` query |
+| `sui_getCheckpoints` | Keep on JSON-RPC | `checkpoints` query |
+| `suix_getStakes`, `suix_getStakesByIds` | Keep on JSON-RPC | `address.stakedSuis` query |
+| `suix_getValidatorsApy` | Keep on JSON-RPC | Compute client-side from validator pool exchange rates |
+| `suix_subscribeEvent`, `suix_subscribeTransaction` | Keep on JSON-RPC (WebSocket) | `events` query (poll), or gRPC `SubscriptionService/SubscribeCheckpoints` and filter client-side |
+
+### Not served by Chainstack
+
+A few JSON-RPC methods are neither available on Chainstack nor have a gRPC equivalent. Sui provides these through GraphQL RPC or an indexer — both hosted outside Chainstack.
+
+| JSON-RPC method | Where to get it |
 | --- | --- |
-| `suix_queryTransactionBlocks` | `transactions` GraphQL query |
-| `suix_queryEvents` | `events` GraphQL query |
-| `sui_subscribeEvent`, `sui_subscribeTransaction` | `events` GraphQL query, or gRPC `SubscriptionService/SubscribeCheckpoints` and filter client-side |
-| `sui_getCheckpoints` | `checkpoints` GraphQL query |
-| `suix_getEpochs` | `epochs` GraphQL query |
-| `suix_getStakes` | `address.stakedSuis` GraphQL query |
-| `suix_getValidatorsApy` | No canonical replacement — compute client-side from validator pool exchange rates |
-| `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Use an indexer |
+| `suix_getEpochs` | Sui GraphQL `epochs` query. For the current epoch only, use gRPC `LedgerService/GetEpoch` or `suix_getLatestSuiSystemState` on Chainstack. |
+| `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Run an indexer |
 
 <Note>
-  Real-time event subscriptions change shape. gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions. For event-level streams, query the `events` GraphQL endpoint on an interval, or subscribe to checkpoints over gRPC and filter events client-side.
+  Real-time event subscriptions have two paths on Chainstack. Keep using `suix_subscribeEvent` over the JSON-RPC WebSocket endpoint, or subscribe to checkpoints over gRPC with `SubscriptionService/SubscribeCheckpoints` and filter events client-side. gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions.
 </Note>
 
 ## gRPC quickstart

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -6,14 +6,16 @@ description: "Sui Foundation shuts down its public JSON-RPC endpoints on Jul 31,
 Sui Foundation is shutting down its **public** JSON-RPC endpoints. On Chainstack, your Sui node serves JSON-RPC and gRPC on the **same endpoint**, so you migrate call by call — keep using JSON-RPC while you port each call to gRPC, with no provider switch and no re-sync.
 
 <Warning>
-  Sui Foundation's public JSON-RPC endpoints (`fullnode.mainnet.sui.io`, `fullnode.testnet.sui.io`) shut down on this schedule:
-
-  - Testnet — week of Jul 6, 2026
-  - Mainnet — week of Jul 20, 2026
-  - Sui Foundation's public JSON-RPC fully retired — Jul 31, 2026
-
-  Any app still calling those public URLs stops working after these dates. This retires Sui Foundation's free public service — it does not remove JSON-RPC from the node software, so operators like Chainstack keep serving it.
+  Apps calling Sui Foundation's public endpoints `fullnode.mainnet.sui.io` or `fullnode.testnet.sui.io` stop working after Jul 31, 2026.
 </Warning>
+
+Sui Foundation retires its public JSON-RPC in stages:
+
+| Milestone | Date |
+| --- | --- |
+| Testnet public JSON-RPC off | Week of Jul 6, 2026 |
+| Mainnet public JSON-RPC off | Week of Jul 20, 2026 |
+| Public JSON-RPC fully retired | Jul 31, 2026 |
 
 ## What is actually being deprecated
 
@@ -96,7 +98,7 @@ A few JSON-RPC methods return aggregated analytics that come from Sui's indexer 
 | `suix_getNetworkMetrics`, `suix_getAddressMetrics`, `suix_getMoveCallMetrics` | Network analytics (TPS, active addresses, popular calls). Derive them by indexing your Chainstack node's checkpoint stream (gRPC `SubscriptionService/SubscribeCheckpoints`) into your own store, or use a Sui analytics provider. Most applications do not need these. |
 
 <Note>
-  Real-time event subscriptions have two paths on Chainstack. Keep using `suix_subscribeEvent` over the JSON-RPC WebSocket endpoint, or subscribe to checkpoints over gRPC with `SubscriptionService/SubscribeCheckpoints` and filter events client-side. gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions.
+  gRPC streaming exposes only `SubscribeCheckpoints`, not per-event subscriptions. For event streams, keep `suix_subscribeEvent` on the JSON-RPC WebSocket, or subscribe to checkpoints over gRPC and filter client-side.
 </Note>
 
 ## gRPC quickstart
@@ -189,7 +191,7 @@ In TypeScript, use the official Sui SDK (`@mysten/sui`) with a **native gRPC tra
 </CodeGroup>
 
 <Info>
-  Browser apps cannot use this path yet. The SDK's browser transport is gRPC-Web, which Chainstack does not serve (HTTP 415). From the browser, call your Chainstack JSON-RPC endpoint, or proxy gRPC through your own backend.
+  This path is server-side only. The SDK's browser transport is gRPC-Web, which Chainstack does not serve yet (HTTP 415) — from the browser, use JSON-RPC or proxy gRPC through your backend.
 </Info>
 
 ## Next steps

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -1,13 +1,116 @@
 ---
 title: "Sui tooling"
-description: "Sui blockchain development tools guide. Use TypeScript SDK, Rust SDK, Python pysui, Go SDK, and JSON-RPC API for building Sui applications with Chainstack."
+description: "Sui blockchain development tools guide. Use gRPC, JSON-RPC, the TypeScript SDK, Rust SDK, Python pysui, and Go SDK to build Sui applications with Chainstack."
 ---
 
-Get started with a [reliable Sui RPC endpoint](https://chainstack.com/build-better-with-sui/) to use the tools below.
+Get started with a [reliable Sui RPC endpoint](https://chainstack.com/build-better-with-sui/) to use the tools below. Your Chainstack Sui node serves both gRPC and JSON-RPC on the same endpoint.
+
+<Warning>
+  Sui Foundation shuts down its public JSON-RPC endpoints in July 2026 (full deactivation Jul 31, 2026). Chainstack's own JSON-RPC endpoints keep working, but gRPC is the interface Sui invests in going forward. See [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc) for the call-by-call mapping.
+</Warning>
+
+## gRPC API
+
+Sui nodes on Chainstack support gRPC for high-performance access. gRPC uses HTTP/2 and Protocol Buffers for binary serialization, which makes payloads smaller and adds server-side streaming — ideal for indexers, backends, and low-latency lookups. gRPC is the forward path as Sui deprecates JSON-RPC.
+
+### Endpoint and authentication
+
+Your Sui gRPC endpoint is `sui-mainnet.core.chainstack.com:443` (testnet: `sui-testnet.core.chainstack.com:443`), with TLS. Authenticate by passing your token in the `x-token` metadata header on every call. Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+
+### Explore with grpcurl
+
+Sui gRPC has server reflection enabled, so [grpcurl](https://github.com/fullstorydev/grpcurl) can list services and call methods without compiling proto files:
+
+<CodeGroup>
+  ```bash List services
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    sui-mainnet.core.chainstack.com:443 \
+    list
+  ```
+
+  ```bash Node and chain info
+  grpcurl -H "x-token: YOUR_X_TOKEN" \
+    sui-mainnet.core.chainstack.com:443 \
+    sui.rpc.v2.LedgerService/GetServiceInfo
+  ```
+</CodeGroup>
+
+The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`.
+
+### gRPC from code
+
+Generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto), then attach the `x-token` metadata to every call:
+
+<CodeGroup>
+  ```python Python
+  import grpc
+
+  channel = grpc.secure_channel(
+      "sui-mainnet.core.chainstack.com:443",
+      grpc.ssl_channel_credentials(),
+  )
+  metadata = (("x-token", "YOUR_X_TOKEN"),)
+
+  # With stubs generated from Sui's protos:
+  # stub = ledger_service_pb2_grpc.LedgerServiceStub(channel)
+  # resp = stub.GetServiceInfo(
+  #     ledger_service_pb2.GetServiceInfoRequest(), metadata=metadata
+  # )
+  # print(resp.checkpoint_height)
+  ```
+
+  ```javascript Node.js
+  const grpc = require('@grpc/grpc-js');
+
+  const credentials = grpc.credentials.createSsl();
+  const metadata = new grpc.Metadata();
+  metadata.add('x-token', 'YOUR_X_TOKEN');
+
+  // With stubs generated from Sui's protos:
+  // const client = new LedgerServiceClient(
+  //   'sui-mainnet.core.chainstack.com:443', credentials);
+  // client.getServiceInfo({}, metadata, (err, resp) => {
+  //   console.log(resp.checkpointHeight);
+  // });
+  ```
+
+  ```go Go
+  package main
+
+  import (
+      "context"
+
+      "google.golang.org/grpc"
+      "google.golang.org/grpc/credentials"
+      "google.golang.org/grpc/metadata"
+  )
+
+  func main() {
+      creds := credentials.NewTLS(nil)
+      conn, err := grpc.Dial(
+          "sui-mainnet.core.chainstack.com:443",
+          grpc.WithTransportCredentials(creds),
+      )
+      if err != nil {
+          panic(err)
+      }
+      defer conn.Close()
+
+      ctx := metadata.AppendToOutgoingContext(
+          context.Background(), "x-token", "YOUR_X_TOKEN",
+      )
+      _ = ctx // pass ctx to your generated gRPC client calls
+  }
+  ```
+</CodeGroup>
+
+<Info>
+  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint.
+</Info>
 
 ## JSON-RPC API
 
-Interact with your Sui node using the [Sui JSON-RPC API](https://docs.sui.io/sui-api-ref).
+Interact with your Sui node using the [Sui JSON-RPC API](https://docs.sui.io/sui-api-ref). Chainstack's JSON-RPC endpoints keep working after Sui's public endpoints shut down, so this is a valid path while you migrate to gRPC.
 
 Use your Chainstack Sui RPC endpoint to make API calls. Example to get the latest checkpoint:
 
@@ -56,109 +159,6 @@ Use your Chainstack Sui RPC endpoint to make API calls. Example to get the lates
   print(response.json()['result'])
   ```
 </CodeGroup>
-
-## gRPC API
-
-Sui nodes on Chainstack support gRPC for high-performance access. gRPC uses HTTP/2 and Protocol Buffers for efficient binary serialization, making it ideal for streaming data and high-throughput applications.
-
-### Endpoint format
-
-Your Sui gRPC endpoint is available at:
-
-```
-sui-mainnet.core.chainstack.com:443
-sui-testnet.core.chainstack.com:443
-```
-
-### Authentication
-
-gRPC endpoints use x-token authentication. Pass your token in the request metadata:
-
-- **x-token** — your authentication token from the Chainstack console
-
-### Usage examples
-
-<CodeGroup>
-  ```bash grpcurl
-  grpcurl -H "x-token: YOUR_X_TOKEN" \
-    sui-mainnet.core.chainstack.com:443 \
-    list
-  ```
-
-  ```python Python
-  import grpc
-
-  # Create channel with TLS
-  channel = grpc.secure_channel(
-      'sui-mainnet.core.chainstack.com:443',
-      grpc.ssl_channel_credentials()
-  )
-
-  # Add x-token to metadata for all calls
-  metadata = [('x-token', 'YOUR_X_TOKEN')]
-
-  # Use the channel with your gRPC stubs
-  # Example: stub = SuiServiceStub(channel)
-  # response = stub.SomeMethod(request, metadata=metadata)
-  ```
-
-  ```javascript Node.js
-  const grpc = require('@grpc/grpc-js');
-
-  // Create credentials with TLS
-  const credentials = grpc.credentials.createSsl();
-
-  // Create channel
-  const channel = new grpc.Channel(
-    'sui-mainnet.core.chainstack.com:443',
-    credentials
-  );
-
-  // Add x-token to metadata for calls
-  const metadata = new grpc.Metadata();
-  metadata.add('x-token', 'YOUR_X_TOKEN');
-
-  // Use with your gRPC client
-  ```
-
-  ```go Go
-  package main
-
-  import (
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/credentials"
-      "google.golang.org/grpc/metadata"
-      "context"
-  )
-
-  func main() {
-      // Create TLS credentials
-      creds := credentials.NewTLS(nil)
-
-      // Connect to gRPC endpoint
-      conn, err := grpc.Dial(
-          "sui-mainnet.core.chainstack.com:443",
-          grpc.WithTransportCredentials(creds),
-      )
-      if err != nil {
-          panic(err)
-      }
-      defer conn.Close()
-
-      // Add x-token to context
-      ctx := metadata.AppendToOutgoingContext(
-          context.Background(),
-          "x-token", "YOUR_X_TOKEN",
-      )
-
-      // Use ctx with your gRPC calls
-  }
-  ```
-</CodeGroup>
-
-<Info>
-  Find your gRPC endpoint and x-token in the Chainstack console under your Sui node's **Access and credentials** section.
-</Info>
 
 ## Sui TypeScript SDK
 

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -6,7 +6,7 @@ description: "Sui blockchain development tools guide. Use gRPC, JSON-RPC, the Ty
 Get started with a [reliable Sui RPC endpoint](https://chainstack.com/build-better-with-sui/) to use the tools below. Your Chainstack Sui node serves both gRPC and JSON-RPC on the same endpoint.
 
 <Warning>
-  Sui Foundation retires its public JSON-RPC endpoints in July 2026 (fully by Jul 31). This shuts down Sui's free public service, not JSON-RPC in the node software — Chainstack's own JSON-RPC endpoints keep working, but gRPC is the interface Sui invests in going forward. See [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc) for the call-by-call mapping.
+  Sui Foundation retires its public JSON-RPC endpoints by Jul 31, 2026. Chainstack's own JSON-RPC keeps working, but gRPC is the path forward — see [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).
 </Warning>
 
 ## gRPC API
@@ -124,7 +124,7 @@ In TypeScript, use the official `@mysten/sui` SDK with a native gRPC transport (
 </CodeGroup>
 
 <Info>
-  Browser apps cannot use gRPC on Chainstack yet. The `@mysten/sui` SDK's browser transport is gRPC-Web, which Chainstack does not serve (HTTP 415). The native gRPC transport above works only in Node.js and other server runtimes. From the browser, call your Chainstack JSON-RPC endpoint, or proxy gRPC through your own backend.
+  The native gRPC transport above works only in Node.js and other server runtimes. The SDK's browser transport is gRPC-Web, which Chainstack does not serve yet (HTTP 415) — from the browser, use JSON-RPC or proxy gRPC through your backend.
 </Info>
 
 ## JSON-RPC API

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -35,7 +35,16 @@ Sui gRPC has server reflection enabled, so [grpcurl](https://github.com/fullstor
   ```
 </CodeGroup>
 
-The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, and `NameService`.
+The node exposes six `sui.rpc.v2` services:
+
+| Service | Use it for |
+| --- | --- |
+| `LedgerService` | Checkpoints, objects, transactions, epochs, and node info |
+| `StateService` | Balances, coins, owned objects, and dynamic fields |
+| `TransactionExecutionService` | Executing and simulating transactions |
+| `SubscriptionService` | Streaming checkpoints |
+| `MovePackageService` | Move packages, modules, functions, and datatypes |
+| `NameService` | SuiNS name resolution |
 
 ### gRPC from code
 

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -39,9 +39,28 @@ The available `sui.rpc.v2` services are `LedgerService`, `StateService`, `Transa
 
 ### gRPC from code
 
-Generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto), then attach the `x-token` metadata to every call:
+In TypeScript, use the official `@mysten/sui` SDK with a native gRPC transport (its default transport is gRPC-Web, which Chainstack does not serve). From other languages, generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto). Either way, attach the `x-token` metadata to every call, and use recent client versions — `@mysten/sui` 2.16+ and `@grpc/grpc-js` 1.14+ — since older releases produce intermittent gRPC errors under load.
 
 <CodeGroup>
+  ```typescript TypeScript
+  // npm install @mysten/sui @protobuf-ts/grpc-transport @grpc/grpc-js
+  import { SuiGrpcClient } from '@mysten/sui/grpc';
+  import { GrpcTransport } from '@protobuf-ts/grpc-transport';
+  import { ChannelCredentials } from '@grpc/grpc-js';
+
+  const client = new SuiGrpcClient({
+    network: 'mainnet',
+    transport: new GrpcTransport({
+      host: 'sui-mainnet.core.chainstack.com:443',
+      channelCredentials: ChannelCredentials.createSsl(),
+      meta: { 'x-token': 'YOUR_X_TOKEN' },
+    }),
+  });
+
+  const gasPrice = await client.core.getReferenceGasPrice();
+  console.log(gasPrice.referenceGasPrice);
+  ```
+
   ```python Python
   import grpc
 
@@ -105,7 +124,7 @@ Generate typed stubs from [Sui's proto definitions](https://github.com/MystenLab
 </CodeGroup>
 
 <Info>
-  The official Sui TypeScript SDK (`@mysten/sui`) uses gRPC-Web over HTTPS, which Chainstack Sui endpoints do not serve yet — those requests return HTTP 415. Until gRPC-Web is supported, use native gRPC (Node.js `@grpc/grpc-js`, Python, Go, or grpcurl), or keep using your Chainstack JSON-RPC endpoint.
+  Browser apps cannot use gRPC on Chainstack yet. The `@mysten/sui` SDK's browser transport is gRPC-Web, which Chainstack does not serve (HTTP 415). The native gRPC transport above works only in Node.js and other server runtimes. From the browser, call your Chainstack JSON-RPC endpoint, or proxy gRPC through your own backend.
 </Info>
 
 ## JSON-RPC API

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -15,7 +15,7 @@ Sui nodes on Chainstack support gRPC for high-performance access. gRPC uses HTTP
 
 ### Endpoint and authentication
 
-Your Sui gRPC endpoint is `sui-mainnet.core.chainstack.com:443` (testnet: `sui-testnet.core.chainstack.com:443`), with TLS. Authenticate by passing your token in the `x-token` metadata header on every call. Find your endpoint and token on Chainstack under your Sui node's **Access and credentials** tab.
+Your Sui gRPC endpoint is `sui-mainnet.core.chainstack.com:443` (testnet: `sui-testnet.core.chainstack.com:443`), with TLS. Authenticate by passing your token in the `x-token` metadata header on every call. To find your endpoint and token on Chainstack, see [View node access and credentials](/docs/manage-your-node#view-node-access-and-credentials).
 
 ### Explore with grpcurl
 

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -6,7 +6,7 @@ description: "Sui blockchain development tools guide. Use gRPC, JSON-RPC, the Ty
 Get started with a [reliable Sui RPC endpoint](https://chainstack.com/build-better-with-sui/) to use the tools below. Your Chainstack Sui node serves both gRPC and JSON-RPC on the same endpoint.
 
 <Warning>
-  Sui Foundation shuts down its public JSON-RPC endpoints in July 2026 (full deactivation Jul 31, 2026). Chainstack's own JSON-RPC endpoints keep working, but gRPC is the interface Sui invests in going forward. See [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc) for the call-by-call mapping.
+  Sui Foundation retires its public JSON-RPC endpoints in July 2026 (fully by Jul 31). This shuts down Sui's free public service, not JSON-RPC in the node software — Chainstack's own JSON-RPC endpoints keep working, but gRPC is the interface Sui invests in going forward. See [Migrate Sui from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc) for the call-by-call mapping.
 </Warning>
 
 ## gRPC API


### PR DESCRIPTION
## What

Sui Foundation shuts down its **public** JSON-RPC endpoints in July 2026 (testnet week of Jul 6, mainnet week of Jul 20, full deactivation **Jul 31, 2026**). Every Sui app pointed at `fullnode.mainnet/testnet.sui.io` has to migrate to gRPC or GraphQL, or to a provider that still fronts JSON-RPC.

Chainstack serves **JSON-RPC and gRPC on the same Sui node**, so customers can keep calling JSON-RPC while they port code to gRPC on the same endpoint — no re-sync, no provider switch. These pages make that path discoverable and indexed before Sui devs start searching.

## Changes

- **New — `docs/sui-migrate-json-rpc-to-grpc.mdx`**: what's actually deprecated (public endpoints only), deadline, call-by-call method mapping (JSON-RPC → `sui.rpc.v2` gRPC services, plus the GraphQL-only methods), grpcurl quickstart, and native-gRPC code for Python/Node.
- **New — `docs/sui-grpc-endpoint.mdx`**: same-node positioning, checkpoint retention (how to read the live window via `GetServiceInfo`), `x-token` auth, verification snippets.
- **`docs/sui-tooling.mdx`**: lead with gRPC, add the deprecation warning, and replace the previous non-functional gRPC stub examples with a verified grpcurl quickstart + connection code.
- **`docs.json`**: both new pages added under Cloud > Guides > Tooling.

## Verification

All facts verified live against a Chainstack Sui mainnet node (`sui-node/1.74.1`):

- JSON-RPC works (`sui_getLatestCheckpointSequenceNumber`, `sui_getChainIdentifier`).
- Native gRPC works with `x-token`; reflection lists the real `sui.rpc.v2` services (`LedgerService`, `StateService`, `TransactionExecutionService`, `SubscriptionService`, `MovePackageService`, `NameService`). Method mapping cross-checked against Sui's official migration guide.
- Official Sui TypeScript SDK path (gRPC-Web over HTTPS) returns **HTTP 415** — documented as a current limitation with the native-gRPC / JSON-RPC workaround.

`mint validate` and `mint broken-links` both pass.