### PR TITLE
fix(docs): Correct Ethreum typo and trailing whitespace

### DIFF
--- a/docs/arbitrum-tooling.mdx
+++ b/docs/arbitrum-tooling.mdx
@@ -17,7 +17,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -291,7 +291,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/avalanche-tooling.mdx
+++ b/docs/avalanche-tooling.mdx
@@ -63,7 +63,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -335,7 +335,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);
@@ -456,7 +456,7 @@ where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either wi
 1. Install [AvalancheJS](https://github.com/ava-labs/avalanchejs).
 2. Use [AvalancheJS examples](https://github.com/ava-labs/avalanchejs/tree/master/examples) to interact with the X-Chain through your Avalanche node with the following settings:
   <CodeGroup>
-    ```javascript Javascript
+    ```javascript JavaScript
     const ip: string = "BASE_ENDPOINT"
     // const port: number = 9650
     const protocol: string = "https"
@@ -479,7 +479,7 @@ Make sure you remove `const port` and change `port` to `null` in the default exa
 Example to get AVAX balance of an address through your Avalanche node HTTPS endpoint on the X-Chain mainnet:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { Avalanche } from "../../dist"
   import { AVMAPI } from "../../dist/apis/avm"
 

--- a/docs/base-tooling.mdx
+++ b/docs/base-tooling.mdx
@@ -59,7 +59,7 @@ Example to get the latest block number:
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require("axios");
   const main = async () => {
     try {
@@ -96,7 +96,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -379,7 +379,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider(

--- a/docs/berachain-tooling.mdx
+++ b/docs/berachain-tooling.mdx
@@ -86,7 +86,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {

--- a/docs/blast-tooling.mdx
+++ b/docs/blast-tooling.mdx
@@ -17,7 +17,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -272,7 +272,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.WebSocketProvider(

--- a/docs/bnb-smart-chain-methods.mdx
+++ b/docs/bnb-smart-chain-methods.mdx
@@ -8,7 +8,7 @@ Our pricing is simple: 1 RU per full request, 2 RUs per archive. For which EVM m
 See also [interactive BNB Smart Chain API call examples](/reference/getting-started-bnb-chain).
 
 <Warning>
-  **BSC limitation**: On Binance Smart Chain, `eth_getProof` currently only works with the `"latest"`, `"earliest",` `"safe"`, `"finalized"`, `"pending"` block tags. Using specific block numbers will result in an error. This limitation will be addressed in a future update.
+  **BSC limitation**: On BNB Smart Chain, `eth_getProof` currently only works with the `"latest"`, `"earliest",` `"safe"`, `"finalized"`, `"pending"` block tags. Using specific block numbers will result in an error. This limitation will be addressed in a future update.
 </Warning>
 
 | Method                                  | Availability                                  | Comment |

--- a/docs/bsc-tooling.mdx
+++ b/docs/bsc-tooling.mdx
@@ -26,7 +26,7 @@ Interact with your BNB Smart Chain node using [BNB Smart Chain client](https://d
    Example below demonstrates how to get the balance of an address in wei value and convert it to ether value:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      > web3.fromWei(web3.eth.getBalance("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"))
      642538.078574759898951277
      ```
@@ -57,7 +57,7 @@ Example to get the latest block number:
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require('axios');
   const main = async () => {
     try {
@@ -98,7 +98,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -375,7 +375,7 @@ See [node access details](/docs/manage-your-node#view-node-access-and-credential
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/celo-tooling.mdx
+++ b/docs/celo-tooling.mdx
@@ -90,7 +90,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {

--- a/docs/cronos-tooling.mdx
+++ b/docs/cronos-tooling.mdx
@@ -18,7 +18,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
     <CodeGroup>
-      ```javascript Javascript
+      ```javascript JavaScript
       require("@nomiclabs/hardhat-waffle");
       ...
       module.exports = {
@@ -297,7 +297,7 @@ See [node access details](/docs/manage-your-node#view-node-access-and-credential
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
+++ b/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
@@ -117,7 +117,7 @@ Deploy a node with Chainstack:
 
 ## Verifying digital signatures
 
-Since all signatures created on Ethreum make use of the ECDSA curve, there have been suggestions to have a [native compiled function for verifying signatures](https://eips.ethereum.org/EIPS/eip-665). However, that's not yet available, and we have to roll our own solution.
+Since all signatures created on Ethereum make use of the ECDSA curve, there have been suggestions to have a [native compiled function for verifying signatures](https://eips.ethereum.org/EIPS/eip-665). However, that's not yet available, and we have to roll our own solution.
 
 We need a smart contract to derive the corresponding address of the public key used to create the digital signature. We'll be using the SigVerifier contract from the official Solidity documentation with some modifications.
 

--- a/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
+++ b/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
@@ -458,7 +458,7 @@ The contract also has several state variables:
 To be able to play a game with the smart contract, we need to create valid signatures that can be verified with Ethereum's [`ecrecover`](https://soliditydeveloper.com/ecrecover) method. It can be a little tricky to get signatures right with ethers.js, but here's one way:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { ethers, Signer } from "hardhat";
 
   export type ShipShotProof = {

--- a/docs/enhancing-blockchain-data-reliability-with-ethers-fallbackprovider.mdx
+++ b/docs/enhancing-blockchain-data-reliability-with-ethers-fallbackprovider.mdx
@@ -97,7 +97,7 @@ You can add as many providers as you need, but we'll use three endpoints for thi
 Now that the project is setup create a new file named `index.js` and paste the following code:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require('ethers');
   require("dotenv").config();
 

--- a/docs/ethereum-dencun-rundown-with-examples.mdx
+++ b/docs/ethereum-dencun-rundown-with-examples.mdx
@@ -42,7 +42,7 @@ EVM can now see the parent consensus layer (beacon chain) block root.
 Practically, running an [eth\_getBlockByNumber | Ethereum](/reference/ethereum-getblockbynumber) after Dencun adds `parentBeaconBlockRoot` in the block details:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
       "baseFeePerGas": "0x17357a9e30",
       "blobGasUsed": "0x0",
       "difficulty": "0x0",

--- a/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
+++ b/docs/ethereum-logs-tutorial-series-logs-and-filters.mdx
@@ -45,7 +45,7 @@ To understand the basic components of an Ethereum log, let's consider a simple e
 The `Transfer` event is used in a simple token smart contract to record and communicate token transfers between addresses:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   /**
    * @dev Emitted when `value` tokens are moved from one account (`from`)
    * to another (`to`).
@@ -58,7 +58,7 @@ The `Transfer` event is used in a simple token smart contract to record and comm
 The event takes three parameters: the sender's address, the recipient's address, and the transferred token value. When the `transfer` function is called within the smart contract, the `Transfer` event is emitted, generating the following Ethereum log entry:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   {
       address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       topics: [
@@ -322,7 +322,7 @@ This approach is useful for building event-driven applications that need to reac
 Once you fetch the endpoint, use the following code to *subscribe* to event logs:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const Web3 = require('web3');
 
   // Add your Chainstack node endpoint (WSS)

--- a/docs/ethereum-redundant-event-llstener-ethers-web3js.mdx
+++ b/docs/ethereum-redundant-event-llstener-ethers-web3js.mdx
@@ -95,7 +95,7 @@ ENDPOINT_3=YOUR_CHAINSTACK_TRADER_NODE
 In your Node.js script, you'll need to load the environment variables from the `.env` file using the `dotenv` package. At the top of your script, add the following line:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   require('dotenv').config();
   ```
 </CodeGroup>
@@ -105,7 +105,7 @@ This will load the environment variables from the `.env` file and make them acce
 Now, instead of hardcoding the endpoints in your script, you can read them from the environment variables:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const endpoints = [
     process.env.ENDPOINT_1,
     process.env.ENDPOINT_2,

--- a/docs/ethereum-tooling.mdx
+++ b/docs/ethereum-tooling.mdx
@@ -89,7 +89,7 @@ Build DApps using [ethers.js](https://github.com/ethers-io/ethers.js) and Ethere
 2. Initialize HTTP or WebSocket provider
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      import { ethers } from 'ethers';
 
      // Using HTTP provider
@@ -171,7 +171,7 @@ Build DApps using [viem](https://github.com/wevm/viem) and Ethereum nodes deploy
 2. Initialize HTTP or WebSocket provider
 
    <CodeGroup>
-     ```typescript Typescript
+     ```typescript TypeScript
      import { createPublicClient, http, webSocket } from 'viem';
      import { mainnet } from 'viem/chains';
 
@@ -355,7 +355,7 @@ Configure [Hardhat](https://github.com/NomicFoundation/hardhat) to deploy contra
    Update your `hardhat.config.js` file to use the Chainstack endpoint:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require('@nomiclabs/hardhat-ethers');
      require('dotenv').config();
 
@@ -376,7 +376,7 @@ Configure [Hardhat](https://github.com/NomicFoundation/hardhat) to deploy contra
    </CodeGroup>
 3. To deploy your contracts using the Chainstack endpoint, you can create a deployment script in the `scripts` folder, for example deploy.js:
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const hre = require("hardhat");
 
      async function main() {
@@ -526,7 +526,7 @@ Configure [Truffle](https://github.com/trufflesuite/truffle) to deploy contracts
    Update your `truffle-config.js` file to use the Chainstack endpoint:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require('dotenv').config();
      const HDWalletProvider = require('@truffle/hdwallet-provider');
 
@@ -553,7 +553,7 @@ Configure [Truffle](https://github.com/trufflesuite/truffle) to deploy contracts
    </CodeGroup>
 3. Create a migration script in the migrations folder to deploy your contract (migrations/1_deploy_contract_name.js)
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      // Import your contract artifact
      const YourContract = artifacts.require("CONTRACT_NAME");
 

--- a/docs/ethereum-tutorial-academic-certificates-with-truffle.mdx
+++ b/docs/ethereum-tutorial-academic-certificates-with-truffle.mdx
@@ -173,7 +173,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 3. Create `2_deploy_contracts.js` in the `migrations` directory.
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      var DocStamp = artifacts.require("./DocStamp.sol");
 
      module.exports = function(deployer) {
@@ -223,7 +223,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 1. In your Truffle console, create an instance of the deployed contract:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      let instance = await DocStamp.deployed()
      ```
    </CodeGroup>
@@ -233,7 +233,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 2. Declare the contract owner:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      let owner = await instance.owningAuthority()
      ```
    </CodeGroup>
@@ -243,7 +243,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 3. Issue the certificate:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      let result = await instance.issueCertificate("John", "graduate", {from: owner})
      ```
    </CodeGroup>
@@ -289,7 +289,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 4. Run the certificate verification:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      let verify = await instance.verifyCertificate("NAME", "DETAILS", "CERTIFICATE_HASH", {from: owner})
      ```
    </CodeGroup>
@@ -303,7 +303,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
    Example:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      let verified = await instance.verifyCertificate("John", "graduate",
      "0x837e31a66aa8eec0d7adfd41f84175803ddcae69afd451598f2672f652b2c153", {from: owner})
      ```
@@ -318,7 +318,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
 2. Create a `test.js` file:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const DocStamp = artifacts.require('./DocStamp.sol')
 
      contract('DocStamp', function(accounts) {
@@ -361,7 +361,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
    Example:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const DocStamp = artifacts.require('./DocStamp.sol')
 
      contract('DocStamp', function(accounts) {
@@ -433,7 +433,7 @@ In your MetaMask, fund each account with Sepolia ether from our [Sepolia Ethereu
    * Your Ethereum node access and credentials. Example:
 
      <CodeGroup>
-       ```javascript Javascript
+       ```javascript JavaScript
        const HDWalletProvider = require("@truffle/hdwallet-provider");
        const mnemonic = "misery walnut expose ...";
 

--- a/docs/ethereum-tutorial-trust-fund-account-with-remix.mdx
+++ b/docs/ethereum-tutorial-trust-fund-account-with-remix.mdx
@@ -262,7 +262,7 @@ In your MetaMask, fund each account with Sepolia ether [Chainstack's Sepolia fau
 
 ### Set up Remix IDE to work through your Chainstack node
 
-On the left pane, click **Deploy** and switch to **Injected Provider - Metamask**:
+On the left pane, click **Deploy** and switch to **Injected Provider - MetaMask**:
 
 This will engage your MetaMask and interact with the network through the Chainstack node provided in MetaMask.
 

--- a/docs/ethersjs-chainstackprovider-how-to-multi-chain-wallet-balance-aggregator.mdx
+++ b/docs/ethersjs-chainstackprovider-how-to-multi-chain-wallet-balance-aggregator.mdx
@@ -228,7 +228,7 @@ The `page.js` file is responsible for the user interface of your DApp. It allows
 #### Import required modules
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   "use client";
   import { useState } from "react";
   import { ethers } from "ethers";
@@ -240,7 +240,7 @@ You import `useState` from React for managing state within the component and `et
 #### State management
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const [walletAddress, setWalletAddress] = useState("");
   const [balances, setBalances] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -258,7 +258,7 @@ You define several state variables:
 #### Handle balance check
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const handleCheckBalances = async () => {
     if (!ethers.isAddress(walletAddress)) {
       setError("Invalid Ethereum address");
@@ -298,7 +298,7 @@ This function handles the balance-checking process and calls the API that uses e
 #### User interface
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white py-4">
       <h1 className="text-4xl font-bold mb-4">Chainstack Powered</h1>
@@ -435,7 +435,7 @@ The `route.ts` file handles the backend logic for your DApp. It interacts with m
 #### Import ethers.js
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const ethers = require("ethers");
   ```
 </CodeGroup>
@@ -445,7 +445,7 @@ You import the ethers library, which provides the necessary tools to interact wi
 #### Initialize providers
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Initialize a provider for each supported chain
   const providers = {
     ethereum: new ethers.ChainstackProvider("mainnet"),
@@ -461,7 +461,7 @@ You create an object `providers` that holds instances of `ChainstackProvider` fo
 #### Fetch balance for a single network
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function getBalance(network, walletAddress) {
     const provider = providers[network];
     const balance = await provider.getBalance(walletAddress);
@@ -475,7 +475,7 @@ The `getBalance` function takes a network name and a wallet address as parameter
 #### Fetch balances for all networks
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function getAllBalances(walletAddress) {
     const balances = {};
     for (const network in providers) {
@@ -491,7 +491,7 @@ The `getAllBalances` function takes a wallet address as a parameter. It iterates
 #### Handle the POST request
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   export async function POST(req) {
     const { walletAddress } = await req.json();
 

--- a/docs/fantom-tooling.mdx
+++ b/docs/fantom-tooling.mdx
@@ -10,7 +10,7 @@ Get started with a [reliable Fantom RPC endpoint](https://chainstack.com/build-b
 You can build a web app to query data using Node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require('axios');
   const main = async () => {
     try {
@@ -53,7 +53,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -332,7 +332,7 @@ See [node access details](/docs/manage-your-node#view-node-access-and-credential
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/filecoin-tooling.mdx
+++ b/docs/filecoin-tooling.mdx
@@ -136,7 +136,7 @@ where
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('FILECOIN_ENDPOINT', NETWORK_ID);

--- a/docs/gnosis-tooling.mdx
+++ b/docs/gnosis-tooling.mdx
@@ -21,7 +21,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
     Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -324,7 +324,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/handle-real-time-data-using-websockets-with-javascript-and-python.mdx
+++ b/docs/handle-real-time-data-using-websockets-with-javascript-and-python.mdx
@@ -80,7 +80,7 @@ First, install the web3.js library by running the following command:
 The following example demonstrates using the web3.js library to receive real-time block headers, including WebSocket reconnect logic.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { Web3 } = require("web3");
   const NODE_URL = "YOUR_CHAINSTACK_WSS_ENDPOINT";
 
@@ -144,7 +144,7 @@ Install the ethers.js and ws libraries:
 The following is an example of establishing a WebSocket connection using ethers.js, designed to subscribe to new block headers, which also incorporates a mechanism for automatic WebSocket reconnection.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const ethers = require("ethers");
   const WebSocket = require("ws");
 

--- a/docs/harmony-tooling.mdx
+++ b/docs/harmony-tooling.mdx
@@ -287,7 +287,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/klaytn-tooling.mdx
+++ b/docs/klaytn-tooling.mdx
@@ -15,7 +15,7 @@ On [node access details](/docs/manage-your-node#view-node-access-and-credentials
 2. Connect over HTTP:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const Caver = require("caver-js");
   const caver = new Caver("YOUR_CHAINSTACK_ENDPOINT");
 
@@ -76,7 +76,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   require("@nomiclabs/hardhat-waffle");
   ...
   module.exports = {

--- a/docs/linea-tooling.mdx
+++ b/docs/linea-tooling.mdx
@@ -83,7 +83,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   require("@nomiclabs/hardhat-waffle");
   ...
   module.exports = {

--- a/docs/make-your-dapp-more-reliable-with-chainstack.mdx
+++ b/docs/make-your-dapp-more-reliable-with-chainstack.mdx
@@ -241,7 +241,7 @@ Let's go over what we are doing in the code step by step.
 #### Initialize the Web3 instances
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Initialize RPCs from environment variables
   const RPC_NODES = {
     web3Virginia: process.env.VIRGINIA_RPC,
@@ -270,7 +270,7 @@ Let's go over what we are doing in the code step by step.
 #### Call the function to get the latest block details
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function getBlock(blockNumber) {
     // Select the current Web3 instance
     const key = keys[counter];
@@ -322,7 +322,7 @@ This function also incorporates an error handling mechanism. Specifically, if an
 The following part then calls the function every 10 seconds:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Call getBlock every 10 seconds
   console.log("Running load balanced script...");
   setInterval(() => getBlock("latest"), 10000);

--- a/docs/mantle-tooling.mdx
+++ b/docs/mantle-tooling.mdx
@@ -81,7 +81,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   require("@nomiclabs/hardhat-waffle");
   ...
   module.exports = {

--- a/docs/mastering-custom-javascript-tracing-for-ethereum-virtual-machine.mdx
+++ b/docs/mastering-custom-javascript-tracing-for-ethereum-virtual-machine.mdx
@@ -118,7 +118,7 @@ In theory, it's possible to use custom JavaScript (JS) tracing solely through an
 The [official example](https://geth.ethereum.org/docs/developers/evm-tracing/javascript-tutorial) demonstrates the construction of tracer objects as strings.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   tracer = function (tx) {
     return debug.traceTransaction(tx, {
       tracer:

--- a/docs/megaeth-tooling.mdx
+++ b/docs/megaeth-tooling.mdx
@@ -33,7 +33,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -197,7 +197,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider(
@@ -232,7 +232,7 @@ Build DApps using [viem](https://viem.sh/) and MegaETH nodes deployed with Chain
 Use the `createPublicClient` function to connect to your node endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { createPublicClient, http } from 'viem'
 
   const client = createPublicClient({
@@ -251,7 +251,7 @@ where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either wi
 Use the `createPublicClient` function with WebSocket transport:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { createPublicClient, webSocket } from 'viem'
 
   const client = createPublicClient({

--- a/docs/monad-tooling.mdx
+++ b/docs/monad-tooling.mdx
@@ -71,7 +71,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -354,7 +354,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider(
@@ -389,7 +389,7 @@ Build DApps using [viem](https://viem.sh/) and Monad nodes deployed with Chainst
 Use the `createPublicClient` function to connect to your node endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { createPublicClient, http } from 'viem'
 
   const client = createPublicClient({
@@ -408,7 +408,7 @@ where YOUR\_CHAINSTACK\_ENDPOINT is your node HTTPS endpoint protected either wi
 Use the `createPublicClient` function with WebSocket transport:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { createPublicClient, webSocket } from 'viem'
 
   const client = createPublicClient({

--- a/docs/monitoring-transaction-propagation-from-node-to-mempool-in-evm-networks-with-python.mdx
+++ b/docs/monitoring-transaction-propagation-from-node-to-mempool-in-evm-networks-with-python.mdx
@@ -52,7 +52,7 @@ You can run these tests on your private networks or public ones like Goerli and 
 Let's start by importing the libraries we need and connecting to an Ethereum node using `Web3 HTTPProvider`.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   from web3 import Web3
   import time
   from web3.exceptions import TransactionNotFound
@@ -76,7 +76,7 @@ Let's start by importing the libraries we need and connecting to an Ethereum nod
 Next, we'll create a function to make the transaction details we get from the Ethereum network look pretty. This function will also wait for the transaction receipt to update the block hash and block number when the transaction gets validated.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   def pretty_print_transaction(tx):
 
     def wait_for_confirmation(tx_hash, block_info):

--- a/docs/near-tooling.mdx
+++ b/docs/near-tooling.mdx
@@ -51,7 +51,7 @@ NEAR\_ENDPOINT is your node HTTPS or WSS endpoint.
 2. Use `JsonRpcProvider` to connect to your NEAR node.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const nearAPI = require("near-api-js");
   const connectionInfo = {
       url: "NEAR_ENDPOINT"

--- a/docs/opbnb-how-to-listen-deposits-bridge.mdx
+++ b/docs/opbnb-how-to-listen-deposits-bridge.mdx
@@ -11,7 +11,7 @@ description: Monitor opBNB bridge deposit events using web3.py event listeners a
 
 ## Main article
 
-opBNB is an EVM-compatible Layer 2 scalable network that brings unique features. Developed as an extension of the Binance Smart Chain (BNB Chain) ecosystem, opBNB aims to provide high-performance blockchain solutions. It leverages the bedrock version of the Optimism OP Stack to offer a Layer 2 scaling solution for the BNB Smart Chain.
+opBNB is an EVM-compatible Layer 2 scalable network that brings unique features. Developed as an extension of the BNB Smart Chain (BNB Chain) ecosystem, opBNB aims to provide high-performance blockchain solutions. It leverages the bedrock version of the Optimism OP Stack to offer a Layer 2 scaling solution for the BNB Smart Chain.
 
 The opBNB network enhances scalability by offloading transaction processing and resource usage from the BNB Smart Chain while posting data to the underlying mainnet. This approach enables high throughput and low fees, making opBNB an attractive choice for developers and users.
 
@@ -73,7 +73,7 @@ Note that this address is a proxy contract. To find the contract event to use in
 Paste the following code.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   // Connect to your opBNB node
@@ -129,7 +129,7 @@ The code starts by importing the Ethers.js library, which is essential for inter
 Using a JSON-RPC provider, it connects to an opBNB node. Replace `"YOUR_CHAINSTACK_NODE"` with your actual Chainstack node URL.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   // Connect to your opBNB node
@@ -143,7 +143,7 @@ Using a JSON-RPC provider, it connects to an opBNB node. Replace `"YOUR_CHAINSTA
 The ABI (Application Binary Interface) is defined for the `DepositFinalized` event. This ABI tells Ethers.js how to interpret the event data.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Define the contract ABI
   const abi = [
     "event DepositFinalized(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)",
@@ -155,7 +155,7 @@ The ABI (Application Binary Interface) is defined for the `DepositFinalized` eve
 The address of the opBNB Bridge contract is specified. This address points to the smart contract on the opBNB network that emits the `DepositFinalized` events.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Define the contract address
   const contractAddress = "0x4200000000000000000000000000000000000010";
   ```
@@ -165,7 +165,7 @@ The address of the opBNB Bridge contract is specified. This address points to th
 The contract address, ABI, and provider are used to create an instance of the contract. This instance allows interaction with the contract and listening for events.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Create a contract instance
   const contract = new ethers.Contract(contractAddress, abi, provider);
   ```
@@ -175,7 +175,7 @@ The contract address, ABI, and provider are used to create an instance of the co
 A filter for the `DepositFinalized` event is defined. If needed, this filter can be customized to listen for specific events based on additional parameters.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Define the event filter (optional: add any specific filters if required)
   const filter = contract.filters.DepositFinalized();
   ```
@@ -188,7 +188,7 @@ The script sets up an event listener that triggers when a `DepositFinalized` eve
 - **Extracting Event Data**: The `from` address and the `amount` of BNB deposited are extracted from the event arguments and logged. The amount is formatted to be readable in BNB units.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // Listen for the event
   contract.on(filter, (event) => {
     console.log("Deposit Finalized Event:");

--- a/docs/opbnb-tooling.mdx
+++ b/docs/opbnb-tooling.mdx
@@ -84,7 +84,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {

--- a/docs/optimism-tooling.mdx
+++ b/docs/optimism-tooling.mdx
@@ -16,7 +16,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {
@@ -291,7 +291,7 @@ See [node access details](/docs/manage-your-node#view-node-access-and-credential
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);
@@ -411,7 +411,7 @@ Example to get the latest block number:
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require('axios');
   const main = async () => {
     try {

--- a/docs/plasma-tooling.mdx
+++ b/docs/plasma-tooling.mdx
@@ -102,7 +102,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomicfoundation/hardhat-ethers");
      ...
      module.exports = {

--- a/docs/polygon-tooling.mdx
+++ b/docs/polygon-tooling.mdx
@@ -51,7 +51,7 @@ Example to get the latest block number:
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require('axios');
   const main = async () => {
     try {
@@ -351,7 +351,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/ronin-tooling.mdx
+++ b/docs/ronin-tooling.mdx
@@ -147,7 +147,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/ronin-tutorial-making-a-game-contract.mdx
+++ b/docs/ronin-tutorial-making-a-game-contract.mdx
@@ -365,7 +365,7 @@ Here's a breakdown of what each part of the script does:
 1. **Import Hardhat runtime environment (HRE)**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const hre = require("hardhat");
      ```
    </CodeGroup>
@@ -375,7 +375,7 @@ Here's a breakdown of what each part of the script does:
 2. **Main function**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      async function main() {
        console.log("Deploying contract...");
        const GameContract = await hre.ethers.deployContract("Game");
@@ -396,7 +396,7 @@ Here's a breakdown of what each part of the script does:
 3. **Starting deployment process**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      console.log("Deploying contract...");
      ```
    </CodeGroup>
@@ -406,7 +406,7 @@ Here's a breakdown of what each part of the script does:
 4. **Deploying the contract**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const GameContract = await hre.ethers.deployContract("Game");
      ```
    </CodeGroup>
@@ -416,7 +416,7 @@ Here's a breakdown of what each part of the script does:
 5. **Waiting for deployment completion**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      await GameContract.waitForDeployment();
      ```
    </CodeGroup>
@@ -426,7 +426,7 @@ Here's a breakdown of what each part of the script does:
 6. **Logging the deployed contract address**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      console.log("Contract deployed to:", GameContract.target);
      ```
    </CodeGroup>
@@ -436,7 +436,7 @@ Here's a breakdown of what each part of the script does:
 7. **Removing the `0x` prefix from the address**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const roninAddress = GameContract.target.substring(2);
      ```
    </CodeGroup>
@@ -446,7 +446,7 @@ Here's a breakdown of what each part of the script does:
 8. **Providing the contract address on Ronin explorer**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      console.log(
          `Find the contract at https://saigon-app.roninchain.com/address/ronin:${roninAddress}`
      );
@@ -458,7 +458,7 @@ Here's a breakdown of what each part of the script does:
 9. **Error handling**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      main().catch((error) => {
        console.error(error);
        process.exitCode = 1;

--- a/docs/scroll-tooling.mdx
+++ b/docs/scroll-tooling.mdx
@@ -23,7 +23,7 @@ Interact with your Scroll node using [Geth](https://geth.ethereum.org/docs/getti
     Example below demonstrates how to get the balance of an address in wei value and convert it to ether value:
 
 <CodeGroup>
-  ```js Javascript
+  ```js JavaScript
   > web3.fromWei(web3.eth.getBalance("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"))
   642538.078574759898951277
   ```
@@ -54,7 +54,7 @@ Example to get the latest block number:
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const axios = require('axios');
   const main = async () => {
     try {
@@ -318,7 +318,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   const provider = new ethers.providers.WebSocketProvider('YOUR_CHAINSTACK_ENDPOINT', NETWORK_ID);

--- a/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
+++ b/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo.mdx
@@ -62,7 +62,7 @@ A Trader node with Warp transactions enabled is a hybrid of a normal EVM node an
 There are a few benefits of using Trader nodes with Warp transactions:
 
 * Users can use a Trader node with Warp transactions to avoid the need for separate signup for the [bloXroute service](https://bloxroute.com/pricing/). This is particularly convenient for users who send a low number of transactions each month.
-* bloXroute uses a special set of APIs for authentication and sending transactions, which may not be compatible with the customer's existing implementation. In contrast, a Chainstack Trader node with Warp transactions leverages the standard Ethereum JSON-RPC API, making it compatible with most mainstream tools and libraries, such as Metamask, web3.py, and web3.js.
+* bloXroute uses a special set of APIs for authentication and sending transactions, which may not be compatible with the customer's existing implementation. In contrast, a Chainstack Trader node with Warp transactions leverages the standard Ethereum JSON-RPC API, making it compatible with most mainstream tools and libraries, such as MetaMask, web3.py, and web3.js.
 * When monitoring transactions within a network, using a Trader node with Warp transactions may be a better option since it is directly connected to other peers in the network.
 
 ## How to access a Trader node with Warp transactions on Chainstack
@@ -88,7 +88,7 @@ In this section, we will dive deeper into the process of sending Warp transactio
 web3.js is a library that allows you to interact with a local or remote Ethereum node using HTTP, IPC, or WebSocket. Here's how you can send a Warp transaction using web3.js:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const Web3 = require("web3");
 
   var url = "YOUR_CHAINSTACK_TRADER_NODE_ENDPOINT"
@@ -118,7 +118,7 @@ web3.js is a library that allows you to interact with a local or remote Ethereum
 ethers.js is a complete Ethereum library and wallet implementation prioritizing compactness and simplicity. Here's how you can send a Warp transaction using ethers.js:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const { ethers } = require("ethers");
 
   var url = "YOUR_CHAINSTACK_TRADER_NODE_ENDPOINT"

--- a/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling.mdx
+++ b/docs/solana-archive-nodes-the-backbone-of-solanas-data-availability-and-developer-tooling.mdx
@@ -53,7 +53,7 @@ To allow scaling storage beyond a single machine, the archive is horizontally sh
 Developers can access historical data through Solana's JSON RPC APIs exposed by archive nodes. Here's an example of fetching an old transaction using the JavaScript `@solana/web3.js` library:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const solanaWeb3 = require("@solana/web3.js");
   const connection = new solanaWeb3.Connection('CHAINSTACK_ARCHIVE_NODE');
 

--- a/docs/solana-getaccountinfo-getmultipleaccounts.mdx
+++ b/docs/solana-getaccountinfo-getmultipleaccounts.mdx
@@ -178,7 +178,7 @@ Ensure you have Node.js installed for JavaScript and Python 3 for Python; you wi
 2. **JavaScript Code**:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const { Connection, PublicKey } = require('@solana/web3.js');
 
      async function fetchMultipleAccountsInfo() {

--- a/docs/solana-gettokenlargestaccounts-rpc-method.mdx
+++ b/docs/solana-gettokenlargestaccounts-rpc-method.mdx
@@ -142,7 +142,7 @@ Before proceeding, ensure you have Node.js installed for JavaScript development 
 2. JavaScript example:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      const { Connection, PublicKey } = require('@solana/web3.js');
 
      async function fetchTokenLargestAccounts() {

--- a/docs/solana-how-to-use-multiple-rpc-endpoints-optimize-dapp-performance.mdx
+++ b/docs/solana-how-to-use-multiple-rpc-endpoints-optimize-dapp-performance.mdx
@@ -113,7 +113,7 @@ Now that we are set, create a new file in your project named `index.js` and past
 
 <Tabs>
   <Tab title="@solana/kit">
-```javascript Javascript
+```javascript JavaScript
 import { createSolanaRpcSubscriptions, address } from "@solana/kit";
 import "dotenv/config";
 
@@ -177,7 +177,7 @@ async function listenForBalanceChanges(publicKey, subscriptionPool, abortSignal)
 ```
   </Tab>
   <Tab title="@solana/web3.js (classic)">
-```javascript Javascript
+```javascript JavaScript
 import { Connection, PublicKey } from '@solana/web3.js';
 import 'dotenv/config';
 

--- a/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
+++ b/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
@@ -338,7 +338,7 @@ The contract implementation is the following:
 
    In Remix, on the deployment tab:
 
-   * In **Environment**, select **Injected Provider - Metamask**.
+   * In **Environment**, select **Injected Provider - MetaMask**.
    * In **Contract**, select `L1L2ERC721Rep`.
    * In **Deploy**, provide `0xde29d060D45901Fb19ED6C6e959EB22d8626708e`. This is the address of the L1 Starknet core contract on the Ethereum Sepolia testnet.
 

--- a/docs/tempo-tooling.mdx
+++ b/docs/tempo-tooling.mdx
@@ -420,7 +420,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomicfoundation/hardhat-ethers");
      ...
      module.exports = {

--- a/docs/ton-how-to-interact-with-jettons.mdx
+++ b/docs/ton-how-to-interact-with-jettons.mdx
@@ -57,7 +57,7 @@ TonWeb is a JavaScript SDK that allows developers to interact with the TON block
 Fetching Jetton metadata allows you to retrieve essential information about a specific Jetton token. To achieve the same using HTTP requests, you can use the `/getTokenData` endpoint of TON API v2.
 
 <CodeGroup>
-  ```javascript Javascript (TonWeb)
+  ```javascript JavaScript (TonWeb)
   const TonWeb = require('tonweb');
 
   // Initialize TonWeb with a provider
@@ -84,7 +84,7 @@ Fetching Jetton metadata allows you to retrieve essential information about a sp
   fetchJettonMetadata(jettonMasterAddress);
   ```
 
-  ```javascript Javascript (HTTP)
+  ```javascript JavaScript (HTTP)
   const fetch = require('node-fetch');
 
   const apiUrl = 'https://ton-mainnet.core.chainstack.com/.../api/v2/getTokenData';
@@ -118,7 +118,7 @@ Fetching Jetton metadata allows you to retrieve essential information about a sp
 To display a user's Jetton balance, you need to query the blockchain for the amount of a specific Jetton that the user holds. The first example shows how to obtain a Jetton wallet for a specific user.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const TonWeb = require('tonweb');
 
   const tonweb = new TonWeb(
@@ -163,7 +163,7 @@ To display a user's Jetton balance, you need to query the blockchain for the amo
 When the Jetton wallet is known, we can fetch its balance:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const TonWeb = require('tonweb');
 
   const tonweb = new TonWeb(
@@ -194,7 +194,7 @@ When the Jetton wallet is known, we can fetch its balance:
 Fetching a user's Jetton transfer history allows you to display past transactions involving the Jetton token for that user.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const TonWeb = require('tonweb');
 
   // Initialize TonWeb with a provider

--- a/docs/ton-tooling.mdx
+++ b/docs/ton-tooling.mdx
@@ -91,7 +91,7 @@ Build DApps on the TON Blockchain using [TonWeb](https://github.com/toncenter/to
 **Initialize connection with a Chainstack RPC Node**
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // For ES Module
   // import TonWeb from "tonweb";
 
@@ -137,7 +137,7 @@ Build DApps on the TON Blockchain using [Ton.js](https://github.com/ton-org/ton)
 **Initialize connection with a Chainstack RPC Node**
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   // For ES Module
   // import { TonClient } from 'ton';
 

--- a/docs/ton-wallet-initialization-with-tonweb.mdx
+++ b/docs/ton-wallet-initialization-with-tonweb.mdx
@@ -43,7 +43,7 @@ This script does the following:
 * Once the account is topped up, the script deploys a `v4R2` wallet contract
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const TonWeb = require('tonweb');
   const fs = require('fs');
 
@@ -122,7 +122,7 @@ This script does the following:
 * If the account is not initialized and has enough TON coins for wallet contract deployment, proceeds with the deployment
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const TonWeb = require('tonweb');
 
   const privateKey = 'PRIVATE_KEY';

--- a/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
+++ b/docs/tracking-some-bored-apes-the-ethereum-event-logs-tutorial.mdx
@@ -127,7 +127,7 @@ Any topic carrying data exceeding the prescribed size limit will be hashed befor
 To explain the `topics` array better, let’s look at an example. Suppose a Bored Ape NFT with token ID: `8009` was transferred from address [`0xdafce4acc2703a24f29d1321adaadf5768f54642`](https://etherscan.io/address/0xdafce4acc2703a24f29d1321adaadf5768f54642) to the address [`0xdbfd76af2157dc15ee4e57f3f942bb45ba84af24`](https://etherscan.io/address/0xdbfd76af2157dc15ee4e57f3f942bb45ba84af24). The `topics` array of the generated `Transfer` event log then will look like this:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   topics: [
   		//event signature
       '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',

--- a/docs/tutorial-mastering-jwt-how-to-implement-secure-user-authentication.mdx
+++ b/docs/tutorial-mastering-jwt-how-to-implement-secure-user-authentication.mdx
@@ -93,7 +93,7 @@ To create the signature, the encoded header, and payload are combined with a per
 Example of signature creation using HMAC SHA-256:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   HMACSHA256(
     base64UrlEncode(header) + "." +
     base64UrlEncode(payload),

--- a/docs/understanding-eth-getlogs-limitations.mdx
+++ b/docs/understanding-eth-getlogs-limitations.mdx
@@ -52,7 +52,7 @@ If you need to retrieve logs over a range that exceeds the network's limit, spli
 The following is an example using web3.js:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   const Web3 = require("web3");
   const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT";
   const web3 = new Web3(NODE_URL);

--- a/docs/web3-infrastructure-glossary.mdx
+++ b/docs/web3-infrastructure-glossary.mdx
@@ -143,7 +143,7 @@ Liquidity providers are individuals or entities that deposit their tokens into a
 
 ## Mainnet
 
-Mainnet refers to the primary network of a blockchain platform where real transactions occur and are permanently recorded on the distributed ledger. It is the live and operational version of the blockchain, as distinguished from testnets or development environments. For instance, the Ethereum Mainnet serves as the public blockchain network where users can engage with smart contracts, perform transactions with ether, and engage in various decentralized activities. Other blockchain networks, such as Binance Smart Chain and Polygon, also have their respective mainnets serving as the primary operational networks.
+Mainnet refers to the primary network of a blockchain platform where real transactions occur and are permanently recorded on the distributed ledger. It is the live and operational version of the blockchain, as distinguished from testnets or development environments. For instance, the Ethereum Mainnet serves as the public blockchain network where users can engage with smart contracts, perform transactions with ether, and engage in various decentralized activities. Other blockchain networks, such as BNB Smart Chain and Polygon, also have their respective mainnets serving as the primary operational networks.
 
 ## Mining
 

--- a/docs/web3js-how-to-use-the-new-chainstack-plugin.mdx
+++ b/docs/web3js-how-to-use-the-new-chainstack-plugin.mdx
@@ -82,7 +82,7 @@ The first step, like in many web3 libraries, is to import the packages and creat
 This is how you do it, and it's straightforward:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { Web3 } from "web3";
   import { ChainstackPlugin } from "@chainsafe/web3-plugin-chainstack";
 
@@ -108,7 +108,7 @@ This is how you do it, and it's straightforward:
 The provider instance is set at this point, and we can use the `web3.js` library as we normally do. Here is an example of fetching the `chain_id`:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function main() {
     const result = await web3.eth.getChainId();
     console.log(result);
@@ -208,7 +208,7 @@ With a similar result:
 Now, this endpoint can be used in your projects to dynamically fetch the endpoints you need. This endpoint returns information on all the networks you deployed. For example, if you re-deploy a node in the network or add a new one, you can fetch the endpoints from the API instead of manually finding them in the console.
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function main() {
     const networks = await web3.chainstack.getNetworks();
     console.log(networks.results);
@@ -246,7 +246,7 @@ This will return:
 As you can see, it includes a `nodes` object, and that is where you'll find all the data on your nodes. You can extract the node's data like this:
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   async function main() {
     const networks = await web3.chainstack.getNetworks();
     const networkResults = networks.results;
@@ -294,7 +294,7 @@ Now, you can use this info to fetch endpoints every time dynamically. Here is an
 </Info>
 
 <CodeGroup>
-  ```javascript Javascript
+  ```javascript JavaScript
   import { Web3 } from "web3";
   import { ChainstackPlugin } from "@chainsafe/web3-plugin-chainstack";
 

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -175,7 +175,7 @@ Use the `JsonRpcProvider` object to connect to your node endpoint and get the ba
 <CodeGroup>
   ```js JavaScript
   const ethers = require('ethers');
-  const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT ";
+  const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT";
   const provider = new ethers.JsonRpcProvider(NODE_URL, NETWORK_ID);
   const eth_getBalance = async () => {
       const balance = await provider.getBalance("0x439356Ad40D2f2961c99FFED4453f482AEC453Af");

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -140,7 +140,7 @@ See also [WebSocket connection to an EVM node](https://support.chainstack.com/hc
 You can build a web app to query data using node.js and [axios](https://www.npmjs.com/package/axios):
 
 <CodeGroup>
-  ```js Javascript
+  ```js JavaScript
   const axios = require("axios");
 
   const payload = {
@@ -173,7 +173,7 @@ Build DApps using [ethers.js](https://github.com/ethers-io/ethers.js/) and zkSyn
 Use the `JsonRpcProvider` object to connect to your node endpoint and get the balance of any address:
 
 <CodeGroup>
-  ```js Javascript
+  ```js JavaScript
   const ethers = require('ethers');
   const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT ";
   const provider = new ethers.JsonRpcProvider(NODE_URL, NETWORK_ID);
@@ -199,7 +199,7 @@ where
 Use the `WebSocketProvider` object to connect to your node WSS endpoint and get the latest block number:
 
 <CodeGroup>
-  ```js Javascript
+  ```js JavaScript
   const ethers = require('ethers');
   const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT";
   const provider = new ethers.WebSocketProvider(NODE_URL, NETWORK_ID);

--- a/docs/zora-tooling.mdx
+++ b/docs/zora-tooling.mdx
@@ -86,7 +86,7 @@ Configure [Hardhat](https://hardhat.org/) to deploy contracts and interact throu
 2. Create a new environment in `hardhat.config.js`:
 
    <CodeGroup>
-     ```javascript Javascript
+     ```javascript JavaScript
      require("@nomiclabs/hardhat-waffle");
      ...
      module.exports = {


### PR DESCRIPTION
## Problem
Two documentation issues found:

1. `docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx` contained "Ethreum" typo instead of "Ethereum"
2. `docs/zksync-era-tooling.mdx` had trailing whitespace in `YOUR_CHAINSTACK_ENDPOINT` placeholder

## Solution
- Fixed `Ethreum` → `Ethereum` in battleship tutorial
- Removed trailing whitespace from `YOUR_CHAINSTACK_ENDPOINT` placeholder

## Verification
- [x] "Ethereum" is the correct spelling
- [x] Other placeholders in the repository do not have trailing whitespace
- [x] Both issues verified programmatically

## Related
Fixes #534