### PR TITLE
fix(docs): correct Ethereum typo and endpoint placeholder

### DIFF
--- a/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
+++ b/docs/develop-a-battleship-game-using-zero-knowledge-concepts-on-ethereum.mdx
@@ -117,7 +117,7 @@ Deploy a node with Chainstack:
 
 ## Verifying digital signatures
 
-Since all signatures created on Ethreum make use of the ECDSA curve, there have been suggestions to have a [native compiled function for verifying signatures](https://eips.ethereum.org/EIPS/eip-665). However, that's not yet available, and we have to roll our own solution.
+Since all signatures created on Ethereum make use of the ECDSA curve, there have been suggestions to have a [native compiled function for verifying signatures](https://eips.ethereum.org/EIPS/eip-665). However, that's not yet available, and we have to roll our own solution.
 
 We need a smart contract to derive the corresponding address of the public key used to create the digital signature. We'll be using the SigVerifier contract from the official Solidity documentation with some modifications.
 

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -175,7 +175,7 @@ Use the `JsonRpcProvider` object to connect to your node endpoint and get the ba
 <CodeGroup>
   ```js Javascript
   const ethers = require('ethers');
-  const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT ";
+  const NODE_URL = "YOUR_CHAINSTACK_ENDPOINT";
   const provider = new ethers.JsonRpcProvider(NODE_URL, NETWORK_ID);
   const eth_getBalance = async () => {
       const balance = await provider.getBalance("0x439356Ad40D2f2961c99FFED4453f482AEC453Af");


### PR DESCRIPTION
Fixes #534

Correct the `Ethreum` typo and remove the trailing space from the `YOUR_CHAINSTACK_ENDPOINT` placeholder.