### PR TITLE
docs: fix stale clouds/regions — Virtuozzo→Frankfurt, Unichain+Sui→Global Network (interim)

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -100,8 +100,8 @@ description: Browse available cloud providers, regions, and geographic locations
 
 | Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
 | ------- | -------------------------- | ------- | --------- | ------- | ------------- |
-| Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
-| Testnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
+| Mainnet | Chainstack Global Network  | global1 | Worldwide | Archive | Available     |
+| Testnet | Chainstack Global Network  | global1 | Worldwide | Archive | Available     |
 
 ## Sonic
 
@@ -160,7 +160,7 @@ description: Browse available cloud providers, regions, and geographic locations
 
 | Network | Cloud                      | Region    | Location  | Mode      |
 | ------- | -------------------------- | --------- | --------- | --------- |
-| Mainnet | Chainstack Partner Network | global2   | Worldwide | Full      |
+| Mainnet | Chainstack Global Network  | global1   | Worldwide | Full      |
 | Testnet | Chainstack Global Network  | global1   | Worldwide | Archive   |
 
 ## Berachain

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -30,7 +30,7 @@ description: Browse available cloud providers, regions, and geographic locations
 | Mainnet         | Chainstack Cloud          | ash1    | Ashburn            | Full    | NA            | NA                |
 | Mainnet         | Chainstack Cloud          | ash1    | Ashburn            | Full    | NA            | Available         |
 | Sepolia Testnet | Chainstack Global Network | global1 | Worldwide          | Archive | Available     | NA                |
-| Sepolia Testnet | Virtuozzo                 | eu3     | Amsterdam          | Full    | NA            | NA                |
+| Sepolia Testnet | Virtuozzo                 | fra1     | Frankfurt          | Full    | NA            | NA                |
 | Hoodi Testnet   | Chainstack Global Network | global1 | Worldwide          | Archive | Available     | NA                |
 
 ## Solana
@@ -140,7 +140,7 @@ description: Browse available cloud providers, regions, and geographic locations
 | Mainnet      | Chainstack Cloud           | lax1        | Los Angeles | Full    | NA            |
 | Mainnet      | Chainstack Cloud           | fra1        | Frankfurt   | Full    | NA            |
 | Fuji Testnet | Chainstack Global Network  | global1     | Worldwide   | Archive | Available     |
-| Fuji Testnet | Virtuozzo                  | ams1        | Amsterdam   | Full    | NA            |
+| Fuji Testnet | Virtuozzo                  | fra1        | Frankfurt   | Full    | NA            |
 
 ## Ronin
 
@@ -262,10 +262,10 @@ description: Browse available cloud providers, regions, and geographic locations
 | Network | Cloud                     | Region  | Location  | Mode    |
 | ------- | ------------------------- | ------- | --------- | ------- |
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive |
-| Mainnet | Virtuozzo                 | ams1    | Amsterdam | Archive |
-| Mainnet | Virtuozzo                 | ams1    | Amsterdam | Full    |
+| Mainnet | Virtuozzo                 | fra1    | Frankfurt | Archive |
+| Mainnet | Virtuozzo                 | fra1    | Frankfurt | Full    |
 | Testnet | Chainstack Global Network | global1 | Worldwide | Full    |
-| Testnet | Virtuozzo                 | ams1    | Amsterdam | Full    |
+| Testnet | Virtuozzo                 | fra1    | Frankfurt | Full    |
 
 ## Cronos
 
@@ -283,7 +283,7 @@ description: Browse available cloud providers, regions, and geographic locations
 | Mainnet | Chainstack Cloud           | lon1      | London    | Archive | Available     |
 | Mainnet | Chainstack Cloud           | lon1      | London    | Full    | NA            |
 | Testnet | Chainstack Cloud           | global1   | Worldwide | Full    | Available     |
-| Testnet | Virtuozzo                  | eu3       | Amsterdam | Full    | NA            |
+| Testnet | Virtuozzo                  | fra1       | Frankfurt | Full    | NA            |
 
 ## Hyperliquid
 
@@ -323,11 +323,11 @@ description: Browse available cloud providers, regions, and geographic locations
 | Mainnet | Chainstack Global Network | global1 | Worldwide   | Full |
 | Mainnet | Chainstack Cloud          | lax1    | Los Angeles | Full |
 | Mainnet | Chainstack Global Network | fra1    | Frankfurt   | Full |
-| Testnet | Virtuozzo                 | ams1    | Amsterdam   | Full |
+| Testnet | Virtuozzo                 | fra1    | Frankfurt   | Full |
 | Signet  | Chainstack Global Network | global1 | Worldwide   | Full |
 
 ## Harmony
 
 | Network | Mode | Cloud     | Region | Location  |
 | ------- | ---- | --------- | ------ | --------- |
-| Mainnet | Full | Virtuozzo | ams1   | Amsterdam |
+| Mainnet | Full | Virtuozzo | fra1   | Frankfurt |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -701,9 +701,9 @@
         "faucet_url": "N/A",
         "locations": [
           {
-            "cloud": "Chainstack Partner Network",
+            "cloud": "Chainstack Global Network",
             "node_type": "Global Node",
-            "region": "global2",
+            "region": "global1",
             "location": "Worldwide",
             "deployment_options": [
               {
@@ -721,9 +721,9 @@
           "faucet_url": "N/A",
           "locations": [
             {
-              "cloud": "Chainstack Partner Network",
+              "cloud": "Chainstack Global Network",
               "node_type": "Global Node",
-              "region": "global2",
+              "region": "global1",
               "location": "Worldwide",
               "deployment_options": [
                 {
@@ -1223,9 +1223,9 @@
         "faucet_url": "https://faucet.sui.io/",
         "locations": [
           {
-            "cloud": "Chainstack Partner Network",
+            "cloud": "Chainstack Global Network",
             "node_type": "Global Node",
-            "region": "global2",
+            "region": "global1",
             "location": "Worldwide",
             "deployment_options": [
               {

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -145,8 +145,8 @@
             {
               "cloud": "Virtuozzo",
               "node_type": "Trader Node",
-              "region": "eu3",
-              "location": "Amsterdam",
+              "region": "fra1",
+              "location": "Frankfurt",
               "deployment_options": [
                 {
                   "mode": "Full",
@@ -1038,8 +1038,8 @@
             {
               "cloud": "Virtuozzo",
               "node_type": "Trader Node",
-              "region": "ams1",
-              "location": "Amsterdam",
+              "region": "fra1",
+              "location": "Frankfurt",
               "deployment_options": [
                 {
                   "mode": "Full",
@@ -1903,8 +1903,8 @@
           {
             "cloud": "Virtuozzo",
             "node_type": "Trader Node",
-            "region": "ams1",
-            "location": "Amsterdam",
+            "region": "fra1",
+            "location": "Frankfurt",
             "deployment_options": [
               {
                 "mode": "Archive",
@@ -1941,8 +1941,8 @@
             {
               "cloud": "Virtuozzo",
               "node_type": "Trader Node",
-              "region": "ams1",
-              "location": "Amsterdam",
+              "region": "fra1",
+              "location": "Frankfurt",
               "deployment_options": [
                 {
                   "mode": "Full",
@@ -2076,8 +2076,8 @@
             {
               "cloud": "Virtuozzo",
               "node_type": "Trader Node",
-              "region": "eu3",
-              "location": "Amsterdam",
+              "region": "fra1",
+              "location": "Frankfurt",
               "deployment_options": [
                 {
                   "mode": "Full",
@@ -2259,8 +2259,8 @@
             {
               "cloud": "Virtuozzo",
               "node_type": "Trader Node",
-              "region": "ams1",
-              "location": "Amsterdam",
+              "region": "fra1",
+              "location": "Frankfurt",
               "deployment_options": [
                 {
                   "mode": "Full",
@@ -2310,8 +2310,8 @@
           {
             "cloud": "Virtuozzo",
             "node_type": "Trader Node",
-            "region": "ams1",
-            "location": "Amsterdam",
+            "region": "fra1",
+            "location": "Frankfurt",
             "deployment_options": [
               {
                 "mode": "Full",


### PR DESCRIPTION
Interim corrections for the stale **Available clouds, regions, & locations** page flagged in #product-docs. All changes verified against authoritative sources (live nodes + the deployment wizard); scoped to what's confirmed, not a full rebuild.

## 1. Virtuozzo: Amsterdam → Frankfurt
VZO Amsterdam is retired (no live nodes serve any `ams` region). Virtuozzo now runs from Frankfurt (`fra1`) — confirmed live for Harmony Mainnet + Bitcoin Testnet. Relabels all **7** Virtuozzo entries `ams1`/`eu3` Amsterdam → `fra1` Frankfurt.

## 2. Unichain + Sui: Partner Network → Global Network
Per the deployment wizard (authoritative): **Unichain** (mainnet + testnet) and **Sui** mainnet now serve on the **Chainstack Global Network** (`global1`), no longer the Partner Network (`global2`). Sui testnet was already `global1`. **3 entries** relabeled `Chainstack Partner Network / global2` → `Chainstack Global Network / global1`.

**Blast, Linea, Mantle, MegaETH, Polkadot, Zora, opBNB** remain on the Partner Network (`global2`) — confirmed still correct, unchanged.

## 3. Drop the stale "AWS, Google Cloud, and Azure" claim
The page's meta description said nodes deploy "across AWS, Google Cloud, and Azure" — Chainstack managed nodes no longer run on any of those (zero nodes there now). Removed the big-3 claim from the description (it was surfacing in link unfurls and search results). This was the only page with that false claim; other AWS/GCP/Azure mentions in the docs are legitimate (the Google BNE migration guide, a secrets-manager tools list, GCP-KMS signing).

## Files
- `node-options-master-list.json` — 10 location entries corrected
- `docs/nodes-clouds-regions-and-locations.mdx` — table rows regenerated + description fixed

## Scope
Interim, targeting the confirmed staleness. The tables are hand-maintained and have drifted from the source of truth in other places too (duplicate region generations like `lon1`/`lon2`, `fra1`/`fra2`); a full reconciliation against the source of truth is a separate follow-up. `Chainstack Cloud / ams1` left as-is (that cluster is still valid).

Gates: `mint broken-links` ✅ · `mint validate` ✅