### PR TITLE
docs: drop stale 'AWS, Google Cloud, and Azure' claim from clouds/regions description

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Available clouds, regions, & locations"
-description: Browse available cloud providers, regions, and geographic locations for deploying Chainstack blockchain nodes across AWS, Google Cloud, and Azure.
+description: Browse the cloud providers, regions, and geographic locations available for deploying Chainstack blockchain nodes.
 ---
 
 <Info>


### PR DESCRIPTION
The **Available clouds, regions, & locations** page's meta description claimed Chainstack nodes deploy "across AWS, Google Cloud, and Azure." Chainstack managed nodes no longer run on any of those (zero nodes there), so the claim is false and was surfacing in link unfurls and search results.

## Change
`docs/nodes-clouds-regions-and-locations.mdx` — description:
- before: "…for deploying Chainstack blockchain nodes across AWS, Google Cloud, and Azure."
- after: "Browse the cloud providers, regions, and geographic locations available for deploying Chainstack blockchain nodes."

This is the only page carrying the false big-3 claim — other AWS/GCP/Azure mentions in the docs are legitimate (the Google BNE migration guide, a secrets-manager tools list, GCP-KMS signing) and are untouched.

Split out from #545 (the clouds/regions data corrections) per review — this is the description/SEO half.

Gates: `mint validate` ✅