### PR TITLE
docs(changelog): announce Robinhood Chain protocol support (July 17, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 17, 2026" description=" by Ake">
+
+**Protocols**. Chainstack now supports Robinhood Chain — an Ethereum L2 (Arbitrum Orbit, Nitro client) for tokenized stocks and real-world assets. You can deploy [Global Nodes](/docs/global-elastic-node) and [dedicated nodes](/docs/dedicated-node) for Robinhood Chain Mainnet and Testnet, in Full and Archive modes with debug and trace.
+
+<Button href="/changelog/chainstack-updates-july-17-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 6, 2026" description=" by Ake">
 
 **MCP Server**. Migrating from Alchemy now reads your usage via the [Alchemy CLI](https://www.alchemy.com/docs/alchemy-cli) (`alchemy usage summary`) — the agent pulls your spend and compute-unit volume to estimate your Chainstack savings.

--- a/changelog/chainstack-updates-july-17-2026.mdx
+++ b/changelog/chainstack-updates-july-17-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: July 17, 2026"
+description: "Robinhood Chain — an Ethereum L2 for tokenized stocks and real-world assets — is now supported on Chainstack across Global Nodes and dedicated nodes, Mainnet and Testnet, in Full and Archive modes."
+---
+
+**Protocols**. Chainstack now supports Robinhood Chain — an Ethereum L2 (Arbitrum Orbit, Nitro client) for tokenized stocks and real-world assets. You can deploy [Global Nodes](/docs/global-elastic-node) and [dedicated nodes](/docs/dedicated-node) for Robinhood Chain Mainnet and Testnet, in Full and Archive modes with debug and trace.

--- a/docs.json
+++ b/docs.json
@@ -3091,6 +3091,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-17-2026",
           "changelog/chainstack-updates-july-6-2026",
           "changelog/chainstack-updates-june-17-2026",
           "changelog/chainstack-updates-june-11-2026",


### PR DESCRIPTION
## What

Adds the **July 17, 2026** Cloud release note announcing **Robinhood Chain** support.

Robinhood Chain — an Ethereum L2 (Arbitrum Orbit, Nitro client) for tokenized stocks and real-world assets — is now deployable on Chainstack as [Global Nodes](/docs/global-elastic-node) and [dedicated nodes](/docs/dedicated-node), Mainnet and Testnet, in Full and Archive modes with debug and trace.

## Changes

- `changelog.mdx` — new `<Update>` entry at the top.
- `changelog/chainstack-updates-july-17-2026.mdx` — standalone release note page.
- `docs.json` — page added to the Release notes tab.

## Local validation

- `docs.json` — valid JSON.
- `mintlify broken-links` — no new broken links introduced (the two `/docs/...` links resolve).

> Note: the protocol reference pages (master list + networks/locations tables) ship in a separate docs PR.