### PR TITLE
docs: add Robinhood Chain as a new protocol

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -146,7 +146,9 @@ description: Browse the cloud providers, regions, and geographic locations avail
 
 | Network | Cloud                     | Region  | Location  | Mode    | Debug & trace |
 | ------- | ------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 | Testnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 
 ## Ronin

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -142,6 +142,15 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | Fuji Testnet | Chainstack Global Network  | global1     | Worldwide   | Archive | Available     |
 | Fuji Testnet | Virtuozzo                  | fra1        | Frankfurt   | Full    | NA            |
 
+## Robinhood Chain
+
+| Network | Cloud                     | Region  | Location  | Mode    | Debug & trace |
+| ------- | ------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
+| Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
+
 ## Ronin
 
 | Network | Cloud                     | Region  | Location  | Mode    | Debug & trace |

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -146,9 +146,7 @@ description: Browse the cloud providers, regions, and geographic locations avail
 
 | Network | Cloud                     | Region  | Location  | Mode    | Debug & trace |
 | ------- | ------------------------- | ------- | --------- | ------- | ------------- |
-| Mainnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
-| Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 | Testnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 
 ## Ronin

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -76,6 +76,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Plume | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-plume/#request) |
 | Polkadot | Elastic, Dedicated | Full, Archive | - | - | No | [Deploy through platform](https://console.chainstack.com) |
 | Polygon | Elastic, Dedicated | Full, Archive | Full, Archive | Amoy Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Robinhood Chain | Elastic, Dedicated | Full, Archive | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Ronin | Elastic, Dedicated | Full, Archive | Full, Archive | Saigon Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Scroll | Elastic, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Shibarium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-shibarium/#request) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1116,6 +1116,69 @@
       ],
       "additional_notes": "N/A"
     },
+    "Robinhood Chain": {
+      "protocol_name": "Robinhood Chain",
+      "supported_modes": [
+        "Full",
+        "Archive"
+      ],
+      "full_mode_query_limit": "Latest 128 blocks",
+      "archive_mode_available": true,
+      "debug_trace_available": true,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Platform",
+      "mainnet": {
+        "network_name": "Mainnet",
+        "faucet_url": "N/A",
+        "locations": [
+          {
+            "cloud": "Chainstack Global Network",
+            "node_type": "Global Node",
+            "region": "global1",
+            "location": "Worldwide",
+            "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
+              {
+                "mode": "Archive",
+                "debug_trace": true,
+                "warp_transactions": false
+              }
+            ]
+          }
+        ]
+      },
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "N/A",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Full",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                },
+                {
+                  "mode": "Archive",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "additional_notes": "N/A"
+    },
     "Ronin": {
       "protocol_name": "Ronin",
       "supported_modes": [

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1138,6 +1138,11 @@
             "location": "Worldwide",
             "deployment_options": [
               {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
+              {
                 "mode": "Archive",
                 "debug_trace": true,
                 "warp_transactions": false
@@ -1157,6 +1162,11 @@
               "region": "global1",
               "location": "Worldwide",
               "deployment_options": [
+                {
+                  "mode": "Full",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                },
                 {
                   "mode": "Archive",
                   "debug_trace": true,

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1138,11 +1138,6 @@
             "location": "Worldwide",
             "deployment_options": [
               {
-                "mode": "Full",
-                "debug_trace": true,
-                "warp_transactions": false
-              },
-              {
                 "mode": "Archive",
                 "debug_trace": true,
                 "warp_transactions": false
@@ -1162,11 +1157,6 @@
               "region": "global1",
               "location": "Worldwide",
               "deployment_options": [
-                {
-                  "mode": "Full",
-                  "debug_trace": true,
-                  "warp_transactions": false
-                },
                 {
                   "mode": "Archive",
                   "debug_trace": true,


### PR DESCRIPTION
## What

Adds **Robinhood Chain** — an Ethereum L2 on Arbitrum Orbit (Arbitrum Nitro client) for tokenized stocks and real-world assets — as a supported protocol.

- **Networks** — Mainnet, Testnet
- **Node types** — Global Nodes (Chainstack Global Network, `global1`, Worldwide) and dedicated nodes
- **Modes** — Full and Archive (both networks)
- **Debug & trace** — available; warp transactions — no
- **Gas** — ETH; EVM-compatible

## Changes

- `node-options-master-list.json` — new Robinhood Chain entry (source of truth), mirroring the Arbitrum Nitro profile (`Latest 128 blocks` full-mode query limit, dedicated `Platform`).
- `docs/protocols-networks.mdx` — regenerated Robinhood Chain row (alphabetical, between Polygon and Ronin).
- `docs/nodes-clouds-regions-and-locations.mdx` — regenerated Robinhood Chain section (Mainnet + Testnet, each with Full and Archive on `global1`).

## Local validation

- `node-options-master-list.json` — valid JSON, entry parses.
- `mintlify broken-links` — no new broken links introduced.

> The release-note announcing this protocol ships in a separate PR (#547).