### PR TITLE
docs: list Robinhood Chain on debug-and-trace-apis + request-units

### DIFF
--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -174,6 +174,12 @@ To enable debug and trace APIs on your Berachain node, you must have a [paid pla
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
+### Robinhood Chain
+
+To enable debug and trace APIs on your Robinhood Chain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [global node.](/docs/global-elastic-node)
+
+For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
+
 ### Linea
 
 To enable debug and trace APIs on your Linea node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [global node.](/docs/global-elastic-node)

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -22,7 +22,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 | Protocols | Classification |
 | --- | --- |
-| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
+| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo, Robinhood Chain | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |


### PR DESCRIPTION
Follow-up to #548 (Robinhood Chain protocol add). #548 updated the master list and the two auto-generated tables (`protocols-networks`, `nodes-clouds-regions`), but two **hand-maintained** pages enumerate protocols separately and were missed:

- **`docs/debug-and-trace-apis.mdx`** — added a `### Robinhood Chain` section (debug & trace on global nodes, paid plan), mirroring the Unichain/Berachain entries. Robinhood Global Nodes include Debug & Trace (verified in the console).
- **`docs/request-units.mdx`** — added `Robinhood Chain` to the full/archive-by-block-age protocol list (its full-node query limit is the latest ~128 blocks, same model as the others).

Found by diffing Robinhood's page coverage against Berachain/Unichain (comparable GEN Full+Archive+D&T protocols).

Not needed: `llms.txt` (CI-auto-synced page index; Robinhood has no standalone pages yet). Optional future work: a Robinhood Chain tooling/getting-started page + tutorial (like Berachain/Unichain have).

Gates: `mint broken-links` ✅ · `mint validate` ✅