### PR TITLE
docs: fix 'Global Global Nodes' typo from #552

### DIFF
--- a/changelog/chainstack-updates-august-15-2024.mdx
+++ b/changelog/chainstack-updates-august-15-2024.mdx
@@ -2,7 +2,7 @@
 title: "Chainstack updates: August 15, 2024"
 description: "Fantom Mainnet Global Nodes gain debug & trace APIs, and Solana adds blockSubscribe support on Mainnet and Devnet for real-time block streaming."
 ---
-**Global Global Nodes**. Debug & trace on Fantom and `blockSubscribe` on Solana.
+**Global Nodes**. Debug & trace on Fantom and `blockSubscribe` on Solana.
 
 - Fantom — you can now deploy Global Nodes with debug & trace APIs for Fantom Mainnet. See the [debug & trace API reference](/reference/debug_traceblockbyhash-fantom-chain).
 - Solana — you now do the `blockSubcribe` on the Solana Mainnet & Devnet. See the [blockSubscribe API reference](/reference/blocksubscribe-solana).


### PR DESCRIPTION
Fixes a double-word typo the node-naming sweep (#552) introduced, caught by @easeev in review on `changelog/chainstack-updates-august-15-2024.mdx`:

> **Global Global Nodes**? 

The bold heading `**Global elastic nodes**` became `**Global Global Nodes**` — the sweep's lowercase `global elastic nodes` pattern didn't match the capitalized heading, but the `elastic nodes` sub-pattern still fired (`elastic nodes` → `Global Nodes`), leaving an orphaned "Global."

Scan confirms this is the **only** occurrence repo-wide (`Global Global`, `Dedicated Dedicated`, `Trader Trader` all otherwise clean). The remaining `Global elastic` references are all in pre-cutoff historical changelog entries that #552 intentionally left untouched, so they're correct-as-original.

`mint broken-links` ✅ · `mint validate` ✅