### PR TITLE
docs: address CodeRabbit findings from #552 (doc-quality cleanup)

### DIFF
--- a/docs/bnb-trader-nodes.mdx
+++ b/docs/bnb-trader-nodes.mdx
@@ -31,4 +31,4 @@ To enable Warp transactions, install the [Warp transactions](/docs/warp-transact
 * Only `eth_sendRawTransaction` calls are consumed as Warp transactions.
 * Deploy nodes close to your bot for best performance.
 
-See also [Sending Trader Node warp transaction with web3.js, ethers.js, web3.py, and ethClient.go](/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo).
+See also [Sending Trader Node Warp transaction with web3.js, ethers.js, web3.py, and ethClient.go](/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo).

--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -19,7 +19,7 @@ By using debug and trace APIs, developers can build more reliable and secure DAp
 
 ### Ethereum
 
-To enable debug and trace APIs on your Ethereum node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Ethereum node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 #### Dedicated Nodes
 
@@ -39,7 +39,7 @@ For the full list of the available debug and trace API methods, see:
 
 ### Polygon
 
-To enable debug and trace APIs on your Polygon node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Polygon node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 #### Dedicated Nodes
 
@@ -52,7 +52,7 @@ For the full list of the available debug and trace API methods, see: [Erigon: RP
 
 ### BNB Smart Chain
 
-To enable debug and trace APIs on your BNB Smart Chain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your BNB Smart Chain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 #### Dedicated Nodes
 
@@ -70,7 +70,7 @@ For the full list of the available debug and trace API methods, see:
 
 ### Base
 
-To enable debug and trace APIs on your Base node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Base node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 ### Avalanche
 
@@ -82,7 +82,7 @@ You can deploy a dedicated Avalanche node starting from a [paid plan](https://ch
 
 ### Arbitrum
 
-To enable debug and trace APIs on your Arbitrum node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Arbitrum node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 #### Dedicated Nodes
 
@@ -128,11 +128,11 @@ For the full list of the available debug and trace API methods, see [Debug names
 
 ### Scroll
 
-To enable debug and trace APIs on your Optimism node, deploy a [Global Node](/docs/global-elastic-node) with the debug & trace APIs enabled.
+To enable debug and trace APIs on your Scroll node, deploy a [Global Node](/docs/global-elastic-node) with the debug & trace APIs enabled.
 
 ### Ronin
 
-To enable debug and trace APIs on your Optimism node, deploy a [Global Node](/docs/global-elastic-node) with the debug & trace APIs enabled.
+To enable debug and trace APIs on your Ronin node, deploy a [Global Node](/docs/global-elastic-node) with the debug & trace APIs enabled.
 
 ### Gnosis Chain
 
@@ -158,67 +158,67 @@ For the full list of the available debug and trace API methods, see [Debug names
 
 ### Sonic
 
-To enable debug and trace APIs on your Sonic node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Sonic node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Unichain
 
-To enable debug and trace APIs on your Unichain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Unichain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Berachain
 
-To enable debug and trace APIs on your Berachain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Berachain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Robinhood Chain
 
-To enable debug and trace APIs on your Robinhood Chain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Robinhood Chain node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Linea
 
-To enable debug and trace APIs on your Linea node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Linea node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Mantle
 
-To enable debug and trace APIs on your Mantle node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Mantle node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Zora
 
-To enable debug and trace APIs on your Zora node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Zora node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Blast
 
-To enable debug and trace APIs on your Blast node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Blast node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Celo
 
-To enable debug and trace APIs on your Celo node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Celo node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### Kaia
 
-To enable debug and trace APIs on your Kaia node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your Kaia node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
 ### opBNB
 
-To enable debug and trace APIs on your opBNB node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node.](/docs/global-elastic-node)
+To enable debug and trace APIs on your opBNB node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 

--- a/docs/dedicated-node.mdx
+++ b/docs/dedicated-node.mdx
@@ -5,7 +5,7 @@ description: "Learn about Chainstack Dedicated Nodes with exclusive compute reso
 
 ## What is a Dedicated Node?
 
-A Dedicated Node is a node that exclusively deployed for and belongs to a particular customer, with its compute resources are not being shared with anybody else. Such nodes are highly customizable and can offer more additional services than other node types. This means that each Dedicated Node can be configured to perfectly match the case and needs of a particular customer.
+A Dedicated Node is a node that is exclusively deployed for and belongs to a particular customer, and its compute resources are not shared with anybody else. Such nodes are highly customizable and can offer more additional services than other node types. This means that each Dedicated Node can be configured to perfectly match the case and needs of a particular customer.
 
 For the full list of chains available as Dedicated Nodes, see [Networks](/docs/protocols-networks).
 

--- a/docs/ethereum-trader-nodes.mdx
+++ b/docs/ethereum-trader-nodes.mdx
@@ -31,4 +31,4 @@ To enable Warp transactions, install the [Warp transactions](/docs/warp-transact
 * Only `eth_sendRawTransaction` calls are consumed as Warp transactions.
 * Deploy nodes close to your bot for best performance.
 
-See also [Sending Trader Node warp transaction with web3.js, ethers.js, web3.py, and ethClient.go](/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo).
+See also [Sending Trader Node Warp transaction with web3.js, ethers.js, web3.py, and ethClient.go](/docs/sending-warp-transaction-with-web3js-ethersjs-web3py-and-ethclientgo).

--- a/docs/make-your-dapp-more-reliable-with-chainstack.mdx
+++ b/docs/make-your-dapp-more-reliable-with-chainstack.mdx
@@ -41,7 +41,7 @@ The main advantages of Global Nodes are the following:
 * **Instant deployment** — unlike Trader Nodes, which take 3-6 minutes to deploy, the Global Node is ready in seconds. This leads to significant time savings.
 
 <Info>
-  Check modes and protocols available for [globa nodes](/docs/global-elastic-node).
+  Check modes and protocols available for [Global Nodes](/docs/global-elastic-node).
 </Info>
 
 Opting for a Global Node is generally the preferred choice. However, what if you require a protocol or mode that isn't currently supported? For such cases, we can BUIDL a simple load-balancing script using JavaScript.

--- a/docs/protocols-clients.mdx
+++ b/docs/protocols-clients.mdx
@@ -21,15 +21,15 @@ Ethereum node can have one of the following implementations of the execution lay
 
 Polygon node can have one of the following client implementations:
 
-* Bor — the native Polygon client. It can be interacted with by using [JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Bor client on your trader or Dedicated Node, you must deploy it in the full mode.
-* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your trader or Dedicated Node, you must deploy it in the archive mode.
+* Bor — the native Polygon client. It can be interacted with by using [JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Bor client on your Trader Node or Dedicated Node, you must deploy it in the full mode.
+* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your Trader Node or Dedicated Node, you must deploy it in the archive mode.
 
 ## BNB Smart Chain clients
 
 BNB Smart Chain node can have one of the following client implementations:
 
-* Geth — the [Go Ethereum](https://github.com/bnb-chain/bsc) implementation. It's bigger in size and can be interacted with by using [Geth JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Geth client on your trader or Dedicated Node, you must deploy in the full mode.
-* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It's smaller in size and can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your trader or Dedicated Node, you must deploy it in the archive mode.
+* Geth — the [Go Ethereum](https://github.com/bnb-chain/bsc) implementation. It's bigger in size and can be interacted with by using [Geth JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Geth client on your Trader Node or Dedicated Node, you must deploy in the full mode.
+* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It's smaller in size and can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your Trader Node or Dedicated Node, you must deploy it in the archive mode.
 
 ## Base client
 

--- a/reference/custom-js-tracer-fantom.mdx
+++ b/reference/custom-js-tracer-fantom.mdx
@@ -97,7 +97,7 @@ Here you can find a summary of the steps to create a custom JavaScript tracer an
 
 To run a custom JavaScript tracer using curl, you need to make an HTTP POST request to your Ethereum client with the appropriate JSON-RPC payload.
 
-Create a JSON object that includes the JSON-RPC version, method, and tracer object (converted to a string).For example, using the previous tracer example for `the debug_traceTransaction` method:
+Create a JSON object that includes the JSON-RPC version, method, and tracer object (converted to a string). For example, using the previous tracer example for the `debug_traceTransaction` method:
 
 <CodeGroup>
   ```shell JSON object

--- a/reference/custom-js-tracing-ethereum.mdx
+++ b/reference/custom-js-tracing-ethereum.mdx
@@ -91,7 +91,7 @@ tracer: '{gasUsed: [], step: function(log) { this.gasUsed.push(log.getGas()); },
 
 To run a custom JavaScript tracer using curl, you need to make an HTTP POST request to your Ethereum client with the appropriate JSON-RPC payload.
 
-Create a JSON object that includes the JSON-RPC version, method, and tracer object (converted to a string).For example, using the previous tracer example for `the debug_traceTransaction` method:
+Create a JSON object that includes the JSON-RPC version, method, and tracer object (converted to a string). For example, using the previous tracer example for the `debug_traceTransaction` method:
 
 ```shell JSON object
 {


### PR DESCRIPTION
Verified and fixed the genuine defects CodeRabbit surfaced in the #552 review (most were pre-existing, not sweep regressions).

## Fixed
- **`debug-and-trace-apis.mdx`** — the **Scroll** and **Ronin** sections both said "your **Optimism** node" (copy-paste); corrected to the right networks. Also moved sentence-final periods outside the `[Global Node]` link text (16 lines).
- **`dedicated-node.mdx`** — grammar: "that exclusively deployed" → "that is exclusively deployed"; "with its compute resources are not being shared" → "and its compute resources are not shared".
- **`make-your-dapp-more-reliable-with-chainstack.mdx`** — typo `globa nodes` → `Global Nodes`.
- **`protocols-clients.mdx`** — `trader or Dedicated Node` → `Trader Node or Dedicated Node` (4×; a lowercase `trader` straggler the #552 sweep's `trader node` pattern didn't catch).
- **`custom-js-tracer-fantom.mdx` / `custom-js-tracing-ethereum.mdx`** — `.For example` → `. For example`, and backtick only the method name (`` the `debug_traceTransaction` `` not `` `the debug_traceTransaction` ``).
- **`bnb-trader-nodes.mdx` / `ethereum-trader-nodes.mdx`** — `warp transaction` → `Warp transaction` in the See-also link (matches the "Warp transactions" feature name used everywhere else).

## Deliberately skipped (with reason)
- **Steps/Step conversion** (`rps-plan-limits`, `custom-js-tracing-ethereum`) and **ParamField/ResponseField restructure** (`arbitrum-tracetransaction`) — opinionated structural refactors, out of scope for a quality cleanup.
- **`warp-transactions.mdx` line 36** ("…for any validator node to pick it up") — this is a **factual** routing claim (bloXroute → current leader vs "any validator"); needs verification before rewording, not a blind edit.
- **`warp-transactions.mdx` line 49** ("Warp transactions is a node add-on") — "Warp transactions" reads as a singular feature name; the plural-verb change is debatable.

Gates: `mint broken-links` ✅ · `mint validate` ✅