### PR TITLE
docs: table-gen guidance — emit 'Global Node', not 'Elastic'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,8 @@ When updating:
 2. Regenerate dependent tables
 3. Verify changes display correctly
 
+**Node-type naming in the generated tables:** use the current product names — **Global Node** (the `global` node type), **Dedicated Node**, and **Trader Node**. Do **not** emit **Elastic** (the deprecated name for Global Node). In `protocols-networks.mdx` the **Support** column reads `Global Node, Dedicated` and the availability headers are `Global Node Mainnet Support` / `Global Node Testnet Support`.
+
 ## 13. Quality checklist
 
 Before submitting changes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,8 @@ When updating the master list:
 2. Regenerate dependent tables
 3. Verify changes display correctly
 
+**Node-type naming in the generated tables:** use the current product names — **Global Node** (the `global` node type), **Dedicated Node**, and **Trader Node**. Do **not** emit **Elastic** (the deprecated name for Global Node). In `protocols-networks.mdx` the **Support** column reads `Global Node, Dedicated` and the availability headers are `Global Node Mainnet Support` / `Global Node Testnet Support`.
+
 ## Self-Hosted deployments master list
 
 `self-hosted-deployments.json` is the single source of truth for every Chainstack Self-Hosted deployment — protocols, networks, clients, client versions, CPU/RAM/storage, presets, and exposed ports. It is hand-maintained from the upstream sources:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Relevant tables (updated on every master list change):
 * `nodes-clouds-regions-and-locations.mdx`
 * `protocols-networks.mdx`
 
+When regenerating the tables, use the current product node-type names — **Global Node** (the `global` node type), **Dedicated Node**, and **Trader Node**. Do **not** emit **Elastic** (the deprecated name for Global Node): in `protocols-networks.mdx` the **Support** column reads `Global Node, Dedicated` and the availability headers are `Global Node Mainnet Support` / `Global Node Testnet Support`.
+
 ### CLI commands
 
 | Command | Purpose |


### PR DESCRIPTION
Follow-up to #552. The `protocols-networks.mdx` / `nodes-clouds-regions.mdx` tables are **LLM-generated** from `node-options-master-list.json` (there's no generation script — only `scripts/generate_llms_txt.py`, for llms.txt). "Elastic" appears **nowhere** in the master list or any tooling — the node types are `global` / `dedicated` / `trader` (described as "Global Node", etc.). So "Elastic" was a generation-time convention, now retired in #552.

To stop a future regen from reintroducing it, this adds explicit node-type-naming guidance to the master-list sections of **CLAUDE.md**, **AGENTS.md**, and **README.md**:

> Use the current product names — **Global Node** (the `global` node type), **Dedicated Node**, **Trader Node**. Do **not** emit **Elastic**. In `protocols-networks.mdx` the Support column reads `Global Node, Dedicated` and the headers are `Global Node Mainnet/Testnet Support`.

Instruction-file only — no rendered docs change. `mint validate` ✅