### PR TITLE
docs: refresh the Clients page — verified clients, retire Polygon Erigon, broaden coverage

### DIFF
--- a/docs/protocols-clients.mdx
+++ b/docs/protocols-clients.mdx
@@ -1,45 +1,68 @@
 ---
 title: "Clients"
-description: View all supported blockchain protocol execution clients available on Chainstack, including Geth, Erigon, Reth, Agave, and other node implementations.
+description: The node client Chainstack runs for each major protocol — Geth, Reth, Erigon, Bor, Nitro, AvalancheGo, Agave, and more — and why the client determines which RPC methods are available.
 ---
 
-## Ethereum clients
+Chainstack selects the **node client** for each protocol, and often per **mode** (full vs archive) and **node type** (Global Node, Trader Node, Dedicated Node). Clients evolve as protocols upgrade — so treat this page as the current picture for the major protocols, not a frozen contract.
 
-### Consensus layer
+<Info>
+  The client determines which **RPC namespaces** you can call. For example, Geth exposes `debug_*` while Erigon adds the Parity `trace_*` namespace, and Bor (Polygon) does not implement `trace_*` at all. See [Debug and trace APIs](/docs/debug-and-trace-apis) for the per-protocol breakdown and [Request units](/docs/request-units) for how calls are billed.
+</Info>
+
+This page lists the primary protocols. For a protocol not covered here, see its entry on the [Networks](/docs/protocols-networks) page or contact [support](https://chainstack.com/contact/) — the client can also be confirmed at runtime with `web3_clientVersion` (EVM) or the chain's equivalent.
+
+## Ethereum
+
+**Execution layer:**
+
+* Geth — the [Go Ethereum](https://github.com/ethereum/go-ethereum) implementation; exposes the `eth_*` and `debug_*` namespaces.
+* Reth — the [Reth](https://github.com/paradigmxyz/reth) implementation, used for archive nodes.
+* Erigon — the [Erigon](https://github.com/erigontech/erigon) implementation, available on [Dedicated Nodes](/docs/dedicated-node); adds the Parity `trace_*` namespace on top of `debug_*`.
+
+**Consensus layer:**
 
 * Lighthouse — the [Rust](https://github.com/sigp/lighthouse) implementation of the Ethereum Beacon Chain client.
 
-### Execution layer
+See [Debug and trace APIs](/docs/debug-and-trace-apis#ethereum) for how the execution client affects available tracing methods.
 
-Ethereum node can have one of the following implementations of the execution layer client:
+## Polygon
 
-* Geth — the [Go Ethereum](https://github.com/ethereum/go-ethereum) implementation. It's bigger in size and can be interacted with by using [Geth JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Geth client on your node, you must deploy a Dedicated Node in the full or archive mode.
-* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It's smaller in size and can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your node, you must deploy a Trader Node in the archive mode or a Dedicated Node in the archive mode.
-* Reth — available as a [Dedicated Node](/docs/dedicated-node).
+Polygon runs the **Bor** client — the [native Polygon client](https://github.com/0xPolygon/bor). It is interacted with using the [standard Ethereum JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 
-## Polygon clients
+<Warning>
+  Chainstack has **retired the Erigon client for Polygon** — archive nodes now run Bor. Because Bor does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces, use the `debug_*` methods (with `callTracer`) instead. See [Polygon methods](/docs/polygon-methods) and [Debug and trace APIs](/docs/debug-and-trace-apis).
+</Warning>
 
-Polygon node can have one of the following client implementations:
+## BNB Smart Chain
 
-* Bor — the native Polygon client. It can be interacted with by using [JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Bor client on your Trader Node or Dedicated Node, you must deploy it in the full mode.
-* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your Trader Node or Dedicated Node, you must deploy it in the archive mode.
+Archive nodes run **Reth** (the [`reth-bsc`](https://github.com/paradigmxyz/reth) implementation) — Chainstack migrated the BNB Smart Chain archive client from Erigon to Reth. It is interacted with using the [standard Ethereum JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 
-## BNB Smart Chain clients
+## Avalanche
 
-BNB Smart Chain node can have one of the following client implementations:
+[AvalancheGo](https://github.com/ava-labs/avalanchego) is the Go implementation of an Avalanche node. It exposes a Geth-compatible C-Chain API with a limited set of `debug_trace*` methods. See the [Chainstack Avalanche API reference](/reference/avalanche-getting-started).
 
-* Geth — the [Go Ethereum](https://github.com/bnb-chain/bsc) implementation. It's bigger in size and can be interacted with by using [Geth JSON-RPC methods](https://eth.wiki/json-rpc/API). To get the Geth client on your Trader Node or Dedicated Node, you must deploy in the full mode.
-* Erigon — the [Erigon](https://github.com/ledgerwatch/erigon) implementation. It's smaller in size and can be interacted with by using [Erigon RPC methods](https://github.com/ledgerwatch/erigon/blob/devel/cmd/rpcdaemon/README.md#rpc-implementation-status). To get the Erigon client on your Trader Node or Dedicated Node, you must deploy it in the archive mode.
+## Cronos
 
-## Base client
+[Cronos](https://github.com/crypto-org-chain/cronos) is a fully EVM-compatible chain. Connect via the [standard Ethereum JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/) or libraries like ethers.js, web3.js, and web3.py.
 
-The execution client is [`base-reth-node`](https://github.com/base/base) (built on [Reth](https://github.com/paradigmxyz/reth)) and the consensus client is [`base-consensus`](https://github.com/base/base). Base introduced this native stack with the Azul upgrade (mainnet May 28, 2026), replacing op-geth and op-node.
+## Gnosis Chain
 
-## Avalanche client
+* **Execution layer** — [Nethermind](https://github.com/NethermindEth/nethermind), the .NET implementation. See the JSON-RPC reference in the [Nethermind documentation](https://docs.nethermind.io/).
+* **Consensus layer** — [Lighthouse](https://github.com/sigp/lighthouse).
 
-[AvalancheGo](https://github.com/ava-labs/avalanchego) is the node implementation for the Avalanche network in Golang. You can find API documentation in the [Chainstack Avalanche API reference](/reference/avalanche-getting-started).
+## Harmony
 
-## Arbitrum client
+The client is the [Harmony](https://github.com/harmony-one/harmony) Go implementation, interacted with using [Geth-style JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+
+## Fantom and Sonic
+
+Both Fantom and Sonic run the **[Sonic](https://github.com/0xsoniclabs/sonic)** client (Sonic is the successor network to Fantom Opera). It is EVM-compatible and accessed via the [standard Ethereum JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+
+## Ronin
+
+The client is [Ronin](https://github.com/axieinfinity/ronin) — a Go Ethereum fork — interacted with using [Geth-style JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+
+## Arbitrum
 
 <Info>
   ### Stylus is supported
@@ -47,66 +70,68 @@ The execution client is [`base-reth-node`](https://github.com/base/base) (built 
   Arbitrum nodes on Chainstack support Stylus.
 </Info>
 
-[Nitro](https://github.com/OffchainLabs/nitro) is the official node for the Arbitrum protocol. It is a fully integrated, complete layer 2 optimistic rollup system that includes fraud proofs, the sequencer, token bridges, advanced calldata compression, and more. For available methods, see [Chainstack Arbitrum API reference](/reference/arbitrum-getting-started) and the [official Arbitrum documentation](https://developer.arbitrum.io/).
+[Nitro](https://github.com/OffchainLabs/nitro) is the official Arbitrum node — a fully integrated layer-2 optimistic rollup stack (fraud proofs, sequencer, token bridges, calldata compression). Arbitrum uses `arbtrace_*` for pre-Nitro blocks and `debug_*` for post-Nitro blocks. See the [Chainstack Arbitrum API reference](/reference/arbitrum-getting-started) and the [official Arbitrum docs](https://developer.arbitrum.io/).
+
+## Base
+
+The execution client is [`base-reth-node`](https://github.com/base/node) (built on [Reth](https://github.com/paradigmxyz/reth)) and the consensus client is [`base-consensus`](https://github.com/base/node). Base introduced this native stack with the Azul upgrade (mainnet May 28, 2026), replacing op-geth and op-node.
+
+## Optimism
+
+[Global Nodes](/docs/global-elastic-node) and [Trader Nodes](/docs/trader-node) run **op-reth** (built on [Reth](https://github.com/paradigmxyz/reth)). See the [Chainstack Optimism API reference](/reference/optimism-api-reference).
 
 ## zkSync Era
 
-The client is [zkSync Era](https://github.com/matter-labs/zksync-era).
-
-## Optimism client
-
-[Global Nodes](/docs/global-elastic-node) and [Trader Nodes](/docs/trader-node) run op-reth (built on [Reth](https://github.com/paradigmxyz/reth)).
-
-## Solana client
-
-Solana — Solana's [official client](https://github.com/solana-labs/solana) is developed in Rust. JSON-RPC methods are available and can be found in the official [Solana documentation](https://docs.solana.com/api/http). For JavaScript applications, use the [@solana/web3.js](https://github.com/solana-labs/solana-web3.js) library as a convenient interface for interacting with a Solana node using RPC methods.
+The client is [zkSync Era](https://github.com/matter-labs/zksync-era). Tracing is served through the `debug_*` namespace on archive nodes.
 
 ## Scroll
 
-The client is [Geth-based](https://github.com/scroll-tech/scroll).
+The client is [Geth-based](https://github.com/scroll-tech/go-ethereum) (`l2geth`), accessed via the [standard Ethereum JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 
-## Ronin client
+## Solana
 
-Go Ronin — the [Go Ethereum](https://github.com/bnb-chain/bsc) implementation that can be interacted with by using [Geth JSON-RPC methods](https://eth.wiki/json-rpc/API).
+Solana runs **[Agave](https://github.com/anza-xyz/agave)** (the Anza validator client; reports as `solana-core` via `getVersion`). JSON-RPC methods are documented in the [Solana docs](https://solana.com/docs/rpc). For clients, use [`@solana/kit`](https://github.com/anza-xyz/kit) or the classic [`@solana/web3.js`](https://github.com/solana-labs/solana-web3.js) — both are maintained.
 
-## Aptos client
+## TON
 
-[Aptos-core](https://github.com/aptos-labs/aptos-core) is the official client for the Aptos protocol. Developers can interact with Aptos via its various SDKs, including the [TypeScript SDK](https://aptos.dev/sdks/ts-sdk/index), [Python SDK](https://aptos.dev/sdks/python-sdk), [Rust SDK](https://aptos.dev/sdks/rust-sdk), and [Unity SDK](https://aptos.dev/sdks/unity-sdk), or through its [REST API](https://aptos.dev/nodes/aptos-api-spec/#/).
+TON runs the official [TON node](https://github.com/ton-blockchain/ton). Chainstack exposes both the v2 and v3 APIs — see [Choosing TON API v2 or v3](/docs/ton-choosing-v2-or-v3).
 
-## Gnosis clients
+## Sui
 
-### Consensus layer
+Sui runs the official [Sui full node](https://github.com/MystenLabs/sui). Chainstack serves Sui over both JSON-RPC and gRPC — see the [Sui gRPC endpoint](/docs/sui-grpc-endpoint).
 
-Lighthouse — the [Rust](https://github.com/sigp/lighthouse) implementation of the Beacon Chain client.
+## Aptos
 
-### Execution layer
+[Aptos-core](https://github.com/aptos-labs/aptos-core) is the official Aptos client, accessed through its [REST API](https://aptos.dev/en/build/apis) and SDKs (TypeScript, Python, Rust).
 
-Nethermind — the [Nethermind](https://github.com/NethermindEth/nethermind) implementation. See the JSON-RPC methods reference in the official [Nethermind documentation](https://docs.nethermind.io/nethermind/ethereum-client/json-rpc).
+## TRON
 
-## Cronos client
+[java-tron](https://github.com/tronprotocol/java-tron) is the client. See the [TRON API reference](https://developers.tron.network/reference/background).
 
-[Cronos](https://github.com/crypto-org-chain/cronos) is a fully EVM-compatible chain. Developers can connect to it through the [standard JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/) or via libraries like [ethers.js](https://docs.ethers.io/v5/), [web3.js](https://web3js.readthedocs.io/), and [web3.py](https://github.com/ethereum/web3.py).
+## Starknet
 
-## Sonic client
+Chainstack's Starknet nodes implement the [Starknet JSON-RPC specification](https://github.com/starkware-libs/starknet-specs) **v0.8.1** (confirmed via `starknet_specVersion`).
 
-[Sonic](https://www.soniclabs.com/) is the mainnet for Fantom and an EVM-compatible node client for Fantom's network. It can be accessed via [standard JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+## NEAR
 
-## Fantom client
+NEAR runs the official [nearcore](https://github.com/near/nearcore) client, accessed via the [NEAR JSON-RPC API](https://docs.near.org/api/rpc/introduction).
 
-[Sonic](https://www.soniclabs.com/) is the mainnet for Fantom and an EVM-compatible node client for Fantom's network. It can be accessed via [standard JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+## Tezos
 
-## TRON client
+Tezos runs [Octez](https://gitlab.com/tezos/tezos), the reference implementation, accessed through its RPC interface.
 
-[java-tron](https://github.com/tronprotocol/java-tron) is the client. See also the [TRON API reference](https://developers.tron.network/reference/background).
+## Cardano
 
-## Starknet client
+Cardano runs [cardano-node](https://github.com/IntersectMBO/cardano-node), the reference implementation.
 
-[Pathfinder](https://docs.starknet.io/documentation/starknet_versions/pathfinder_versions/) is the node implementation for the Starknet protocol. It supports version `v0.2.1` of the Starknet JSON-RPC [specification](https://github.com/starkware-libs/starknet-specs/blob/v0.2.1/api/starknet_api_openrpc.json) with some minor [differences](https://github.com/eqlabs/pathfinder#api-v021).
+## Stellar
 
-## Harmony
+Stellar runs [Stellar Core](https://github.com/stellar/stellar-core), accessed through the Horizon and RPC APIs.
 
-The client is [Geth-based](https://github.com/harmony-one/harmony).
+## Filecoin
 
-## Bitcoin client
+Filecoin runs [Lotus](https://github.com/filecoin-project/lotus), the reference implementation, which exposes a JSON-RPC API.
 
-[Bitcoin Core](https://bitcoin.org/en/download) connects to the Bitcoin peer-to-peer network to download and validate blocks and transactions. See available JSON-RPC API methods in the [Bitcoin Postman collection](/reference/bitcoin-rpc-methods-postman-collection).
+## Bitcoin
+
+[Bitcoin Core](https://bitcoincore.org/) connects to the Bitcoin peer-to-peer network to download and validate blocks and transactions. See the available methods in the [Bitcoin RPC methods reference](/reference/bitcoin-rpc-methods-postman-collection). The same Bitcoin Core lineage serves the other UTXO chains on Chainstack (for example, Litecoin, Dogecoin, and Zcash via their respective Core clients).


### PR DESCRIPTION
Full rewrite of `docs/protocols-clients` (`/docs/protocols-clients`). The page was imported at the 2025 readme→Mintlify migration and only spot-patched since — 20/91 protocols with several stale entries. It's low-volume in absolute terms but **top-2% of pages** and **AI-dominant (247 AI / 86 human over 90 days)**, so stale content was actively feeding wrong client info into AI answers.

## How the clients were verified
Live-probed `web3_clientVersion` (and `starknet_specVersion` / `getVersion` / `getnetworkinfo`) on running Chainstack nodes:

| Protocol | Was | Now (verified) |
|---|---|---|
| BNB Smart Chain | Geth / Erigon | **Reth (`reth-bsc`)** — archive migrated off Erigon |
| Polygon | Bor + Erigon | **Bor only — Erigon retired** (Jul 29 cutover); `trace_*`/`erigon_*` gone → use `debug_*` |
| Starknet | JSON-RPC spec **v0.2.1** | spec **v0.8.1** |
| Solana | `solana-labs/solana` | **Agave** (`solana-core 4.1.0`) + `@solana/kit`/`web3.js` |
| Ethereum / Avalanche / Gnosis / Cronos / Harmony / Fantom(Sonic) / Arbitrum / Bitcoin | — | confirmed (Geth, AvalancheGo, Nethermind, Cronos, harmony, Sonic, Nitro v3.11, Bitcoin Core 29.x) |

Also fixed: Ronin's client link pointed at `bnb-chain/bsc` → `axieinfinity/ronin`; Erigon org link `ledgerwatch` → `erigontech`; deduped the identical Fantom/Sonic sections.

## Structure
- Reframed around the evergreen point: **the client determines available RPC namespaces** (Geth `debug_*` vs Erigon `trace_*`; Bor has no `trace_*`) — links to [Debug and trace APIs](/docs/debug-and-trace-apis) + [Request units](/docs/request-units).
- **Broadened** 20 → 26 sections (added TON, Sui, NEAR, Tezos, Cardano, Stellar, Filecoin, richer Aptos, and a UTXO-family note) — limited to protocols I could **verify** or that have a **single canonical client**, rather than guessing.
- **Honestly scoped**: intro states it's the primary protocols and points anything else to [Networks](/docs/protocols-networks) / support.

Per your call, this is *not* driven from the master list (kept out to avoid complicating it).

Gates: `mint broken-links` ✅ · `mint validate` ✅