### PR TITLE
docs: label RPC namespace overviews by namespace in the sidebar

### DIFF
--- a/reference/avalanche-accounts-info-rpc-methods.mdx
+++ b/reference/avalanche-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Avalanche"
 description: "Avalanche account information JSON-RPC methods — retrieve balances, nonces, contract code, and storage data for accounts on the C-Chain network."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 

--- a/reference/avalanche-blocks-rpc-methods.mdx
+++ b/reference/avalanche-blocks-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Avalanche"
 description: "Avalanche block information JSON-RPC methods — query block details including transactions, timestamps, height, headers, and uncle counts on C-Chain."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 

--- a/reference/avalanche-chain-data-rpc-methods.mdx
+++ b/reference/avalanche-chain-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Avalanche"
 description: Avalanche C-Chain data RPC methods for querying network details like chain ID, syncing status, and protocol version through Chainstack endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 For example, if a developer wants to build a DApp on Avalanche, they would use these methods to get information about the network they are connecting to. They could use the chain ID information to make sure they are connecting to the right network and to ensure the security of their DApp; for example, distinguishing between the main network and a test network.

--- a/reference/avalanche-client-data-rpc-methods.mdx
+++ b/reference/avalanche-client-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client information | Avalanche"
 description: "Avalanche client information JSON-RPC methods — check client version, network ID, chain ID, listening status, and peer count for your C-Chain node."
-sidebarTitle: Overview
+sidebarTitle: "Client information"
 ---
 
 

--- a/reference/avalanche-debug-trace-rpc-methods.mdx
+++ b/reference/avalanche-debug-trace-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug and Trace | Avalanche"
 description: Avalanche debug and trace API methods for inspecting smart contract execution, analyzing gas usage, and tracing transactions on Chainstack nodes.
-sidebarTitle: Overview
+sidebarTitle: "Debug and Trace"
 ---
 
 <Visibility for="humans">

--- a/reference/avalanche-execution-rpc-methods.mdx
+++ b/reference/avalanche-execution-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Executing transactions | Avalanche"
 description: "Avalanche transaction execution JSON-RPC methods — call smart contracts, sign transactions, send raw transactions, and estimate gas on the C-Chain."
-sidebarTitle: Overview
+sidebarTitle: "Executing transactions"
 ---
 
 Executing and simulating transactions on the Avalanche blockchain can be done by using the following methods:

--- a/reference/avalanche-filters-rpc-methods.mdx
+++ b/reference/avalanche-filters-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Filter handling | Avalanche"
 description: "Avalanche filter JSON-RPC methods — create event and block filters, poll for changes, retrieve filter logs, and manage subscriptions on the C-Chain."
-sidebarTitle: Overview
+sidebarTitle: "Filter handling"
 ---
 
 Filters are a mechanism for clients to receive notifications of changes to the Avalanche blockchain. The methods described in this section allow developers to retrieve the changes that happened since the filter was last polled or allow them to delete it.

--- a/reference/avalanche-gas-data-rpc-methods.mdx
+++ b/reference/avalanche-gas-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gas data | Avalanche"
 description: "Avalanche gas data JSON-RPC methods — query current gas prices and estimate gas costs for transactions to build cost-effective dapps on the C-Chain."
-sidebarTitle: Overview
+sidebarTitle: "Gas data"
 ---
 
 Retrieving gas information from the Avalanche blockchain can be done by using the following methods:

--- a/reference/avalanche-logs-rpc-methods.mdx
+++ b/reference/avalanche-logs-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs and events | Avalanche"
 description: Avalanche C-Chain event log methods for querying smart contract events, applying log filters, and tracking on-chain activity via Chainstack endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Logs and events"
 ---
 
 

--- a/reference/avalanche-transactions-rpc-methods.mdx
+++ b/reference/avalanche-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions info | Avalanche"
 description: "Avalanche transaction info JSON-RPC methods — retrieve transaction data, receipts, and status for monitoring and analyzing on-chain C-Chain activity."
-sidebarTitle: Overview
+sidebarTitle: "Transactions info"
 ---
 
 <Visibility for="humans">

--- a/reference/avalanche-web3js-subscriptions-methods.mdx
+++ b/reference/avalanche-web3js-subscriptions-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Subscriptions | Avalanche"
 description: "Avalanche web3.js subscription methods — subscribe to new block headers, pending transactions, contract events, and other real-time C-Chain updates."
-sidebarTitle: Overview
+sidebarTitle: "Subscriptions"
 ---
 
 <Info>

--- a/reference/beacon-chain-configuration.mdx
+++ b/reference/beacon-chain-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Beacon Chain configuration info"
-sidebarTitle: Overview
+sidebarTitle: "Beacon Chain configuration info"
 description: "This section delves into the details of retrieving the Beacon Chain configuration:. Beacon Chain configuration info on Chainstack via Chainstack."
 ---
 

--- a/reference/beacon-chain-events.mdx
+++ b/reference/beacon-chain-events.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Beacon Chain events"
 description: "Subscribe to Beacon Chain event streams via Server-Sent Events. Get real-time head updates, block notifications, and attestation data from the consensus layer."
-sidebarTitle: Overview
+sidebarTitle: "Beacon Chain events"
 ---
 
 <CardGroup>

--- a/reference/beacon-chain-node.mdx
+++ b/reference/beacon-chain-node.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Beacon Chain validators info"
-sidebarTitle: Overview
+sidebarTitle: "Beacon Chain validators info"
 description: "Retrieve all the necessary information related to the Ethereum validators:. Beacon Chain validators info on Chainstack via Chainstack."
 ---
 

--- a/reference/beacon-chain-state.mdx
+++ b/reference/beacon-chain-state.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Beacon Chain state"
 description: "Query the Ethereum Beacon Chain state — retrieve validator sets, committee assignments, epoch data, and finality checkpoints from the consensus layer."
-sidebarTitle: Overview
+sidebarTitle: "Beacon Chain state"
 ---
 
 <CardGroup>

--- a/reference/ethereum-accounts-info-rpc-methods.mdx
+++ b/reference/ethereum-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Ethereum"
 description: "Ethereum account information JSON-RPC methods — retrieve balances, nonces, contract code, and storage data for accounts on the Ethereum network."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 

--- a/reference/ethereum-blocks-rpc-methods.mdx
+++ b/reference/ethereum-blocks-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Ethereum"
 description: "Ethereum block information JSON-RPC methods — query block details including transactions, timestamps, block number, headers, and uncle counts."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 <Visibility for="humans">

--- a/reference/ethereum-chain-data-rpc-methods.mdx
+++ b/reference/ethereum-chain-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Ethereum"
 description: Ethereum chain data RPC methods for querying network details like chain ID, syncing status, and protocol version through Chainstack node endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 <Visibility for="humans">

--- a/reference/ethereum-client-data-rpc-methods.mdx
+++ b/reference/ethereum-client-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client information | Ethereum"
 description: "Ethereum client information JSON-RPC methods — check client version, network ID, chain ID, listening status, and peer count for your node."
-sidebarTitle: Overview
+sidebarTitle: "Client information"
 ---
 
 <Visibility for="humans">

--- a/reference/ethereum-debug-trace-rpc-methods.mdx
+++ b/reference/ethereum-debug-trace-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug and Trace | Ethereum"
 description: Ethereum debug and trace API methods for inspecting smart contract execution, analyzing gas usage, and tracing transactions on Chainstack nodes.
-sidebarTitle: Overview
+sidebarTitle: "Debug and Trace"
 ---
 
 

--- a/reference/ethereum-execution-rpc-methods.mdx
+++ b/reference/ethereum-execution-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Executing transactions | Ethereum"
 description: "Ethereum transaction execution JSON-RPC methods — call smart contracts, sign transactions, send raw transactions, and estimate gas on the network."
-sidebarTitle: Overview
+sidebarTitle: "Executing transactions"
 ---
 
 

--- a/reference/ethereum-filters-rpc-methods.mdx
+++ b/reference/ethereum-filters-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Filter handling | Ethereum"
 description: "Ethereum filter JSON-RPC methods — create event and block filters, poll for changes, retrieve filter logs, and manage on-chain event subscriptions."
-sidebarTitle: Overview
+sidebarTitle: "Filter handling"
 ---
 
 <Visibility for="humans">

--- a/reference/ethereum-transactions-rpc-methods.mdx
+++ b/reference/ethereum-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions info | Ethereum"
 description: "Ethereum transaction info JSON-RPC methods — retrieve transaction data, receipts, and status for monitoring and analyzing on-chain network activity."
-sidebarTitle: Overview
+sidebarTitle: "Transactions info"
 ---
 
 <Visibility for="humans">

--- a/reference/ethereum-web3js-subscriptions-methods.mdx
+++ b/reference/ethereum-web3js-subscriptions-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Subscriptions | Ethereum"
 description: "Ethereum web3.js subscription methods — subscribe to new block headers, pending transactions, contract events, and other real-time blockchain updates."
-sidebarTitle: Overview
+sidebarTitle: "Subscriptions"
 ---
 
 <Info>

--- a/reference/gnosis-accounts-info-rpc-methods.mdx
+++ b/reference/gnosis-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Gnosis"
 description: "Gnosis Chain account information JSON-RPC methods — retrieve balances, nonces, contract code, and storage data for accounts on the Gnosis network."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 Retrieving account information from the Gnosis Chain can be done by using the following methods:

--- a/reference/gnosis-blocks-rpc-methods.mdx
+++ b/reference/gnosis-blocks-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Gnosis"
 description: "Gnosis Chain block information JSON-RPC methods — query block details including transactions, timestamps, height, and headers on the Gnosis network."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 

--- a/reference/gnosis-chain-data-rpc-methods.mdx
+++ b/reference/gnosis-chain-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Gnosis"
 description: Gnosis Chain data RPC methods for querying network details like chain ID, syncing status, and protocol version through Chainstack node endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 For example, if a developer wants to build a DApp on Gnosis Chain, they would use these methods to get information about the network they are connecting to. They could use the chain ID information to make sure they are connecting to the right network and to ensure the security of their DApp; for example, distinguishing between the main network and a test network.

--- a/reference/gnosis-client-data-rpc-methods.mdx
+++ b/reference/gnosis-client-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client information | Gnosis"
 description: "Gnosis Chain client information JSON-RPC methods — check client version, network ID, chain ID, listening status, and peer count for your node."
-sidebarTitle: Overview
+sidebarTitle: "Client information"
 ---
 
 Retrieving blockchain client information from a Gnosis Chain node can be done by using the following methods:

--- a/reference/gnosis-excecution-rpc-methods.mdx
+++ b/reference/gnosis-excecution-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Executing transactions | Gnosis"
 description: "Gnosis Chain transaction execution JSON-RPC methods — call smart contracts, sign transactions, send raw transactions, and estimate gas on the network."
-sidebarTitle: Overview
+sidebarTitle: "Executing transactions"
 ---
 
 Executing and simulating transactions on the Gnosis Chain can be done by using the following methods:

--- a/reference/gnosis-filters-rpc-methods.mdx
+++ b/reference/gnosis-filters-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Filter handling | Gnosis"
 description: "Gnosis Chain filter JSON-RPC methods — create event and block filters, poll for changes, retrieve filter logs, and manage on-chain subscriptions."
-sidebarTitle: Overview
+sidebarTitle: "Filter handling"
 ---
 
 

--- a/reference/gnosis-gas-data-rpc-methods.mdx
+++ b/reference/gnosis-gas-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gas data | Gnosis"
 description: "Gnosis Chain gas data JSON-RPC methods — query current gas prices and estimate gas costs for transactions on the xDAI-based Gnosis Chain network."
-sidebarTitle: Overview
+sidebarTitle: "Gas data"
 ---
 
 Retrieving gas information from the Gnosis Chain can be done by using the following methods:

--- a/reference/gnosis-logs-rpc-methods.mdx
+++ b/reference/gnosis-logs-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs and events | Gnosis"
 description: Gnosis Chain event log RPC methods for retrieving smart contract events, transaction logs, and filter-based data from your Chainstack node endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Logs and events"
 ---
 
 Retrieving logs information from the Gnosis Chain can be done by using the following methods:

--- a/reference/gnosis-transactions-rpc-methods.mdx
+++ b/reference/gnosis-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions info | Gnosis"
 description: "Gnosis Chain transaction info JSON-RPC methods — retrieve transaction data, receipts, and status for monitoring and analyzing on-chain network activity."
-sidebarTitle: Overview
+sidebarTitle: "Transactions info"
 ---
 
 Retrieving transaction information from the Gnosis Chain can be done by using the following methods:

--- a/reference/gnosis-web3js-subscriptions-methods.mdx
+++ b/reference/gnosis-web3js-subscriptions-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Web3.js subscriptions | Gnosis"
 description: "Gnosis Chain web3.js subscription methods — subscribe to new block headers, contract events, and other real-time blockchain updates via WebSocket."
-sidebarTitle: Overview
+sidebarTitle: "Web3.js subscriptions"
 ---
 
 <Info>

--- a/reference/monad-accounts-info-rpc-methods.mdx
+++ b/reference/monad-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Monad"
 description: "The accounts info JSON RPC methods allow developers to access account-specific information on Monad, including balances, transaction counts, and contract code."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-blocks-rpc-methods.mdx
+++ b/reference/monad-blocks-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Monad"
 description: "Monad block information JSON-RPC methods — query block details including transactions, timestamps, block height, and headers on the Monad network."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-chain-data-rpc-methods.mdx
+++ b/reference/monad-chain-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Monad"
 description: "Monad chain data JSON-RPC methods — retrieve the chain ID for transaction signing, replay protection, and other chain-specific network information."
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-client-data-rpc-methods.mdx
+++ b/reference/monad-client-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client information | Monad"
 description: "The client information JSON RPC methods allow developers to access node and network information on Monad, including client version and network status."
-sidebarTitle: Overview
+sidebarTitle: "Client information"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-debug-trace-rpc-methods.mdx
+++ b/reference/monad-debug-trace-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug and Trace | Monad"
 description: "The debug and trace JSON RPC methods allow developers to trace transaction execution and analyze contract calls on Monad with detailed step-by-step information."
-sidebarTitle: Overview
+sidebarTitle: "Debug and Trace"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-execution-rpc-methods.mdx
+++ b/reference/monad-execution-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Executing transactions | Monad"
 description: "Monad transaction execution JSON-RPC methods — call smart contracts, simulate transactions, send raw transactions, and estimate gas on the Monad network."
-sidebarTitle: Overview
+sidebarTitle: "Executing transactions"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-gas-data-rpc-methods.mdx
+++ b/reference/monad-gas-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gas data | Monad"
 description: "The gas data JSON RPC methods allow developers to access gas-related information on Monad, including current gas prices and gas estimation for transactions."
-sidebarTitle: Overview
+sidebarTitle: "Gas data"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-logs-rpc-methods.mdx
+++ b/reference/monad-logs-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs & events | Monad"
 description: "Monad logs and events JSON-RPC methods — query event logs emitted by smart contracts to track state changes and monitor on-chain contract activity."
-sidebarTitle: Overview
+sidebarTitle: "Logs & events"
 ---
 
 <Visibility for="humans">

--- a/reference/monad-transactions-rpc-methods.mdx
+++ b/reference/monad-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions info | Monad"
 description: "Monad transaction info JSON-RPC methods — retrieve transaction details including sender, recipient, value, gas used, status, and receipts on the network."
-sidebarTitle: Overview
+sidebarTitle: "Transactions info"
 ---
 
 <Visibility for="humans">

--- a/reference/plasma-accounts-info-rpc-methods.mdx
+++ b/reference/plasma-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Plasma"
 description: "Plasma account information JSON-RPC methods — retrieve account balances, nonces, storage values, and contract bytecode for addresses on the Plasma network."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 Retrieving account information from the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-blocks-info-rpc-methods.mdx
+++ b/reference/plasma-blocks-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Plasma"
 description: "Plasma block information JSON-RPC methods — query block details including transactions, timestamps, block height, and header data on the Plasma blockchain."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 Retrieving block information from the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-chain-info-rpc-methods.mdx
+++ b/reference/plasma-chain-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Plasma"
 description: "The chain info JSON-RPC methods allow developers to access blockchain-level information such as chain ID, sync status, and protocol version."
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 Retrieving chain information from the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-client-info-rpc-methods.mdx
+++ b/reference/plasma-client-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client info | Plasma"
 description: "The client info JSON-RPC methods allow developers to access information about the Plasma node client, including version, network ID, and peer connections."
-sidebarTitle: Overview
+sidebarTitle: "Client info"
 ---
 
 Retrieving client information from the Plasma node can be done using the following methods:

--- a/reference/plasma-debug-and-trace-rpc-methods.mdx
+++ b/reference/plasma-debug-and-trace-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug and trace | Plasma"
 description: "The debug and trace JSON-RPC methods provide advanced debugging capabilities for developers, including transaction tracing, call tracing, and raw data access."
-sidebarTitle: Overview
+sidebarTitle: "Debug and trace"
 ---
 
 Debugging and tracing on the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-execute-transactions-rpc-methods.mdx
+++ b/reference/plasma-execute-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Execute transactions | Plasma"
 description: "Plasma transaction execution JSON-RPC methods — simulate eth_call executions and estimate gas costs without broadcasting transactions to the Plasma blockchain."
-sidebarTitle: Overview
+sidebarTitle: "Execute transactions"
 ---
 
 Executing and simulating transactions on the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-filter-handling-rpc-methods.mdx
+++ b/reference/plasma-filter-handling-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Filter handling | Plasma"
 description: "The filter handling JSON-RPC methods allow developers to create and manage filters for monitoring blockchain events such as new blocks and logs."
-sidebarTitle: Overview
+sidebarTitle: "Filter handling"
 ---
 
 Managing filters on the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-gas-data-rpc-methods.mdx
+++ b/reference/plasma-gas-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gas data | Plasma"
 description: "The gas data JSON-RPC methods allow developers to access current gas prices and historical fee information on the Plasma blockchain."
-sidebarTitle: Overview
+sidebarTitle: "Gas data"
 ---
 
 Retrieving gas and fee information from the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-logs-and-events-rpc-methods.mdx
+++ b/reference/plasma-logs-and-events-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs and events | Plasma"
 description: "Plasma logs and events JSON-RPC methods — query smart contract event logs, filter by topics and address, and track on-chain activity on the Plasma network."
-sidebarTitle: Overview
+sidebarTitle: "Logs and events"
 ---
 
 Retrieving logs and events from the Plasma blockchain can be done using the following methods:

--- a/reference/plasma-transaction-info-rpc-methods.mdx
+++ b/reference/plasma-transaction-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transaction info | Plasma"
 description: "Plasma transaction info JSON-RPC methods — retrieve transaction data, receipts, and confirmation status for monitoring on-chain activity on the Plasma network."
-sidebarTitle: Overview
+sidebarTitle: "Transaction info"
 ---
 
 Retrieving transaction information from the Plasma blockchain can be done using the following methods:

--- a/reference/polygon-accounts-info-rpc-methods.mdx
+++ b/reference/polygon-accounts-info-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts info | Polygon"
 description: "Polygon account information JSON-RPC methods — retrieve balances, nonces, contract code, and storage data for accounts on the Polygon PoS network."
-sidebarTitle: Overview
+sidebarTitle: "Accounts info"
 ---
 
 Retrieving account information from the Polygon blockchain can be done by using the following methods:

--- a/reference/polygon-blocks-rpc-methods.mdx
+++ b/reference/polygon-blocks-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blocks info | Polygon"
 description: "Polygon block information JSON-RPC methods — query block details including transactions, timestamps, height, headers, and uncle counts on Polygon PoS."
-sidebarTitle: Overview
+sidebarTitle: "Blocks info"
 ---
 
 <Visibility for="humans">

--- a/reference/polygon-chain-data-rpc-methods.mdx
+++ b/reference/polygon-chain-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Chain info | Polygon"
 description: Polygon PoS chain data RPC methods for querying network details like chain ID, syncing status, and protocol version through Chainstack endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Chain info"
 ---
 
 For example, if a developer wants to build a DApp on Polygon, they would use these methods to get information about the network they are connecting to. They could use the chain ID information to make sure they are connecting to the right network and to ensure the security of their DApp; for example, distinguishing between the main network and a test network.

--- a/reference/polygon-client-data-rpc-methods.mdx
+++ b/reference/polygon-client-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client information | Polygon"
 description: "Polygon client information JSON-RPC methods — check client version, network ID, chain ID, listening status, and peer count for your Polygon PoS node."
-sidebarTitle: Overview
+sidebarTitle: "Client information"
 ---
 
 Retrieving blockchain client information from a Polygon node can be done by using the following methods:

--- a/reference/polygon-debug-trace-rpc-methods.mdx
+++ b/reference/polygon-debug-trace-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug & Trace | Polygon"
 description: Polygon debug and trace API methods for inspecting smart contract execution, analyzing gas usage, and tracing transactions on Chainstack nodes.
-sidebarTitle: Overview
+sidebarTitle: "Debug & Trace"
 ---
 
 <Visibility for="humans">

--- a/reference/polygon-evm-excecution-rpc-methods.mdx
+++ b/reference/polygon-evm-excecution-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Executing transactions | Polygon"
 description: "Polygon transaction execution JSON-RPC methods — call smart contracts, send raw transactions, and estimate gas for building dapps on the Polygon network."
-sidebarTitle: Overview
+sidebarTitle: "Executing transactions"
 ---
 
 Specifically, these methods can be used to execute function calls on smart contracts, sign transactions with a private key, and submit signed transactions to the network for execution. This enables developers to build a wide range of decentralized applications, including wallets, exchanges, and other tools for interacting with the Polygon network. These methods can be particularly useful for testing, offline transaction signing, and programmatic interaction with the network.

--- a/reference/polygon-filters-rpc-methods.mdx
+++ b/reference/polygon-filters-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Filter handling | Polygon"
 description: "Polygon filter JSON-RPC methods — create event and block filters, poll for changes, retrieve filter logs, and manage on-chain event subscriptions."
-sidebarTitle: Overview
+sidebarTitle: "Filter handling"
 ---
 
 Handling filters can be done by using the following methods:

--- a/reference/polygon-gas-data-rpc-methods.mdx
+++ b/reference/polygon-gas-data-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gas data | Polygon"
 description: "Polygon gas data JSON-RPC methods — query current gas prices and estimate gas costs for transactions to build cost-effective dapps on Polygon PoS."
-sidebarTitle: Overview
+sidebarTitle: "Gas data"
 ---
 
 

--- a/reference/polygon-logs-rpc-methods.mdx
+++ b/reference/polygon-logs-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs and events | Polygon"
 description: Polygon PoS event log RPC methods for querying smart contract events, applying log filters, and tracking on-chain activity via Chainstack endpoints.
-sidebarTitle: Overview
+sidebarTitle: "Logs and events"
 ---
 
 

--- a/reference/polygon-transactions-rpc-methods.mdx
+++ b/reference/polygon-transactions-rpc-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions info | Polygon"
 description: "Polygon transaction info JSON-RPC methods — retrieve transaction data, receipts, and status for monitoring and analyzing on-chain Polygon PoS activity."
-sidebarTitle: Overview
+sidebarTitle: "Transactions info"
 ---
 
 Retrieving transaction information from the Polygon blockchain can be done by using the following methods:

--- a/reference/polygon-web3js-subscriptions-methods.mdx
+++ b/reference/polygon-web3js-subscriptions-methods.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Subscriptions | Polygon"
 description: "Polygon web3.js subscription methods — subscribe to new block headers, pending transactions, contract events, and other real-time blockchain updates."
-sidebarTitle: Overview
+sidebarTitle: "Subscriptions"
 ---
 
 <Info>


### PR DESCRIPTION
## Why

Every namespace overview page in the node API reference sets ships with `sidebarTitle: Overview`. Because each chain's pages sit in a **flat** nav list (getting-started, then per-namespace [overview + methods]), all ~10 overviews render as identical **"Overview"** rows with no section labels — the nav reads as a wall of "Overview" between method clusters.

## What

Set `sidebarTitle` on each namespace overview to its namespace name, **derived from the page's own `title`** (`"Accounts info | Ethereum"` → `Accounts info`). Swept **64 pages** across all chains plus the 4 Ethereum Beacon Chain overviews.

- Pure sidebar-label change — page `title`, body content, and URLs are untouched.
- Existing per-chain naming is **preserved, not normalized** (e.g. "Client information" vs "Client info", "Execute" vs "Executing transactions" stay as each chain has them). Normalizing those is a separate call.
- `docs/` guide-landing pages that use `sidebarTitle: Overview` as an intentional standalone label were left alone.

Companion to the Robinhood reference set (PR #557), which applies the same labeling to its own overviews.

## Gates
- `mintlify broken-links` — no broken links
- `mintlify validate` — build validation passed