### PR TITLE
docs: Starknet Pathfinder 0.23.0 — RPC version removal (0.6/0.7/0.8), default → 0.9

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 21, 2026" description=" by Ake">
+
+**Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — a breaking change to JSON-RPC API version support: versions 0.6, 0.7, and 0.8 are removed, and the default `/` endpoint now serves version 0.9. Pin `/rpc/v0_9` or `/rpc/v0_10` before the upgrade reaches your node.
+
+<Button href="/changelog/chainstack-updates-july-21-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 17, 2026" description=" by Ake">
 
 **Protocols**. Chainstack now supports Robinhood Chain — an Ethereum L2 (Arbitrum Orbit, Nitro client) for tokenized stocks and real-world assets. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Robinhood Chain Mainnet and Testnet, in Full and Archive modes with debug and trace.

--- a/changelog/chainstack-updates-july-21-2026.mdx
+++ b/changelog/chainstack-updates-july-21-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: July 21, 2026"
+description: "Starknet nodes are upgrading to Pathfinder v0.23.0 — a breaking change that removes JSON-RPC API versions 0.6, 0.7, and 0.8 and moves the default endpoint to version 0.9."
+---
+
+**Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0). This is a breaking change to JSON-RPC API version support: versions 0.6, 0.7, and 0.8 are removed, and the default `/` endpoint now serves version 0.9. Pin `/rpc/v0_9` or `/rpc/v0_10` in your endpoint URL before the upgrade reaches your node. See [Pathfinder RPC version removal 0.23.0](/reference/starknet-pathfinder-0-23-0-rpc-version-removal) for the migration guide.

--- a/docs.json
+++ b/docs.json
@@ -3070,6 +3070,7 @@
                 "expanded": false,
                 "pages": [
                   "reference/getting-started-starknet",
+                  "reference/starknet-pathfinder-0-23-0-rpc-version-removal",
                   "reference/starknet-pathfinder-default-api-version-change",
                   "reference/starknet-pathfinder-methods-deprecation",
                   "reference/starknet-starknetcall",

--- a/docs.json
+++ b/docs.json
@@ -3186,6 +3186,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-21-2026",
           "changelog/chainstack-updates-july-17-2026",
           "changelog/chainstack-updates-july-6-2026",
           "changelog/chainstack-updates-june-17-2026",

--- a/reference/getting-started-starknet.mdx
+++ b/reference/getting-started-starknet.mdx
@@ -15,14 +15,18 @@ description: "Use the Starknet JSON-RPC API on Chainstack via Pathfinder nodes t
 
 Chainstack Starknet endpoints support sending requests to different JSON-RPC API versions. For versions, see the [Pathfinder GitHub repository](https://github.com/eqlabs/pathfinder/tree/main#json-rpc-api).
 
-To send a request to a specific version, append your Chainstack Starknet endpoint with the version URL suffix. For example, `/rpc/v0_6`.
+To send a request to a specific version, append your Chainstack Starknet endpoint with the version URL suffix. For example, `/rpc/v0_9`. The default `/` path serves version 0.9.
+
+<Note>
+Pathfinder [0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) removed JSON-RPC API versions 0.6, 0.7, and 0.8. The supported versions are 0.9 (`/rpc/v0_9`, also the default) and 0.10 (`/rpc/v0_10`). See [Pathfinder RPC version removal 0.23.0](/reference/starknet-pathfinder-0-23-0-rpc-version-removal).
+</Note>
 
 Check the following examples.
 
 <CodeGroup>
-  ```Text starknet_getNonce v0.4
+  ```Text starknet_getNonce v0.9
   curl --request POST \
-       --url https://starknet-mainnet.core.chainstack.com/365cf697a3ad6d950b4c4a911e2e4f4d/rpc/v0_4 \
+       --url https://starknet-mainnet.core.chainstack.com/365cf697a3ad6d950b4c4a911e2e4f4d/rpc/v0_9 \
        --header 'content-type: application/json' \
        --data '
   {
@@ -39,28 +43,9 @@ Check the following examples.
   '
   ```
 
-  ```Text starknet_getNonce v0.5
+  ```Text starknet_getNonce v0.10
   curl --request POST \
-       --url https://starknet-mainnet.core.chainstack.com/365cf697a3ad6d950b4c4a911e2e4f4d/rpc/v0_5 \
-       --header 'content-type: application/json' \
-       --data '
-  {
-    "id": 1,
-    "jsonrpc": "2.0",
-    "method": "starknet_getNonce",
-    "params": [
-      {
-        "block_number": 385940
-      },
-      "0x0569b13e8164bc8000c0bbcf4887856516643af123c5bc3b01e229e92f9cfd10"
-    ]
-  }
-  '
-  ```
-
-  ```Text starknet_getNonce v0.6
-  curl --request POST \
-       --url https://starknet-mainnet.core.chainstack.com/365cf697a3ad6d950b4c4a911e2e4f4d/rpc/v0_6 \
+       --url https://starknet-mainnet.core.chainstack.com/365cf697a3ad6d950b4c4a911e2e4f4d/rpc/v0_10 \
        --header 'content-type: application/json' \
        --data '
   {

--- a/reference/starknet-pathfinder-0-23-0-rpc-version-removal.mdx
+++ b/reference/starknet-pathfinder-0-23-0-rpc-version-removal.mdx
@@ -104,6 +104,7 @@ No URL change is required — the default `/` endpoint keeps working and now ser
 
 ## Additional resources
 
+- [Chainstack changelog: Starknet Pathfinder v0.23.0](/changelog/chainstack-updates-july-21-2026) — the dated release note for this change
 - [Pathfinder v0.23.0 release notes](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — details of this release
 - [Pathfinder GitHub repository](https://github.com/eqlabs/pathfinder) — latest version information
 - [Starknet spec releases](https://github.com/starkware-libs/starknet-specs/releases) — complete changelog and differences between spec versions

--- a/reference/starknet-pathfinder-0-23-0-rpc-version-removal.mdx
+++ b/reference/starknet-pathfinder-0-23-0-rpc-version-removal.mdx
@@ -1,0 +1,109 @@
+---
+title: "Pathfinder RPC version removal 0.23.0 | Starknet"
+description: "Pathfinder 0.23.0 removes Starknet JSON-RPC API versions 0.6, 0.7, and 0.8, and serves 0.9 by default on the root endpoint. Learn what breaks and how to migrate to v0_9 or v0_10."
+---
+
+<Warning>
+  **Breaking change notice**
+
+  With the roll-out of Pathfinder node version [0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0), Starknet JSON-RPC API versions **0.6, 0.7, and 0.8 are removed**, and the default version served on the `/` path changes to **0.9**. Requests to `/rpc/v0_6`, `/rpc/v0_7`, or `/rpc/v0_8` now fail. Migrate to `/rpc/v0_9` or `/rpc/v0_10` before the upgrade reaches your node.
+</Warning>
+
+This change affects you if your application pins one of the removed API versions in its endpoint URL, or if it relies on the default `/` endpoint serving version 0.8.
+
+## What changed
+
+Pathfinder 0.23.0 makes two changes to JSON-RPC API version support:
+
+- **Removed** — JSON-RPC API versions 0.6, 0.7, and 0.8. The `/rpc/v0_6`, `/rpc/v0_7`, and `/rpc/v0_8` paths no longer serve requests.
+- **Default version** — the root (`/`) endpoint now serves JSON-RPC API version 0.9. Previously it served 0.8.
+
+The supported versions after the upgrade are:
+
+| JSON-RPC API version | Endpoint path | Notes |
+| --- | --- | --- |
+| 0.9 | `/rpc/v0_9` | Also served on the default `/` path |
+| 0.10 | `/rpc/v0_10` | Latest available version |
+
+## What breaks
+
+A request to a removed version path returns an HTTP `404` with a JSON-RPC error. For example, calling `/rpc/v0_8` after the upgrade:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "error": { "code": -32603, "message": "Internal error" } }
+```
+
+Applications that call the default `/` endpoint keep working, but they now receive JSON-RPC 0.9 responses instead of 0.8. Review the [Starknet spec differences](https://github.com/starkware-libs/starknet-specs/releases) between 0.8 and 0.9 for any response-shape changes that affect your code.
+
+## Checking the current API version
+
+Verify which JSON-RPC API version an endpoint serves with the `starknet_specVersion` method:
+
+```bash
+curl -X POST CHAINSTACK_STARKNET_PATHFINDER_ENDPOINT \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "starknet_specVersion",
+    "params": [],
+    "id": 1
+  }'
+```
+
+Against the default endpoint this returns `0.9.0` after the upgrade. Append `/rpc/v0_10` to the endpoint to confirm the 0.10 version is served.
+
+<Visibility for="humans">
+<Check>
+**Get your own node endpoint today**
+
+[Start for free](https://console.chainstack.com/) and get your app to production levels immediately. No credit card required.
+
+You can sign up with your GitHub, X, Google, or Microsoft account.
+</Check>
+</Visibility>
+
+## Migration guide
+
+### If you pin a removed version (v0_6, v0_7, v0_8)
+
+Move your requests to a supported version. Version 0.9 is the closest to the removed 0.8:
+
+**Before (removed after 0.23.0):**
+```bash
+curl -X POST CHAINSTACK_STARKNET_PATHFINDER_ENDPOINT/rpc/v0_8 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "starknet_specVersion",
+    "params": [],
+    "id": 1
+  }'
+```
+
+**After (pin v0.9):**
+```bash
+curl -X POST CHAINSTACK_STARKNET_PATHFINDER_ENDPOINT/rpc/v0_9 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "starknet_specVersion",
+    "params": [],
+    "id": 1
+  }'
+```
+
+### If you use the default endpoint
+
+No URL change is required — the default `/` endpoint keeps working and now serves 0.9. Test your application against 0.9 before the upgrade reaches your node, because response shapes can differ between spec versions. To pin the version explicitly and avoid future default changes, append `/rpc/v0_9`.
+
+## Best practices
+
+1. **Always pin the API version explicitly** in production applications (for example, `/rpc/v0_9`) so a future default change does not affect you.
+2. **Test against 0.9** before the upgrade, and review the spec differences from 0.8.
+3. **Check the spec changes** to understand new features and breaking changes between versions.
+
+## Additional resources
+
+- [Pathfinder v0.23.0 release notes](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — details of this release
+- [Pathfinder GitHub repository](https://github.com/eqlabs/pathfinder) — latest version information
+- [Starknet spec releases](https://github.com/starkware-libs/starknet-specs/releases) — complete changelog and differences between spec versions

--- a/reference/starknet-pathfinder-default-api-version-change.mdx
+++ b/reference/starknet-pathfinder-default-api-version-change.mdx
@@ -9,6 +9,10 @@ description: "Pathfinder 0.19.0 changes the default Starknet JSON-RPC API at the
   With the roll-out of Pathfinder node version [0.19.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.19.0), the default version of the JSON-RPC API served on the `/` path has changed to 0.8.0. Previously, the Starknet spec version served on the default endpoint was 0.7.1.
 </Warning>
 
+<Note>
+This page documents the 0.19.0 default change. A later upgrade, [Pathfinder 0.23.0](/reference/starknet-pathfinder-0-23-0-rpc-version-removal), removed versions 0.6, 0.7, and 0.8 and moved the default to 0.9. If your node runs 0.23.0 or later, the current default is 0.9 and versions 0.7 and 0.8 in the examples below are no longer available.
+</Note>
+
 This change affects how you interact with Starknet through the Pathfinder node if you're using the default endpoint without specifying a specific API version.
 
 ## What changed

--- a/reference/starknet-pathfinder-methods-deprecation.mdx
+++ b/reference/starknet-pathfinder-methods-deprecation.mdx
@@ -51,7 +51,7 @@ curl -X POST CHAINSTACK_STARKNET_ENDPOINT \
 
 **Replacement call:**
 ```bash
-curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_8 \
+curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_9 \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -87,7 +87,7 @@ curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/pathfinder/v0_1 \
 
 **Replacement call:**
 ```bash
-curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_8 \
+curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_9 \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -118,7 +118,7 @@ curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/pathfinder/v0_1 \
 
 **Replacement call:**
 ```bash
-curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_8 \
+curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_9 \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -132,7 +132,7 @@ curl -X POST CHAINSTACK_STARKNET_ENDPOINT/rpc/v0_8 \
 
 ## Key changes
 
-- **Endpoint updates** — Note the endpoint path changes from `/rpc/pathfinder/v0_1` to `/rpc/v0_8` for the replacement methods
+- **Endpoint updates** — Note the endpoint path changes from `/rpc/pathfinder/v0_1` to `/rpc/v0_9` for the replacement methods
 - **Parameter structure** — The replacement methods use standardized Starknet parameter structures
 - **Method names** — All replacement methods use the `starknet_` prefix instead of `pathfinder_`
 

--- a/reference/starknet/llms.txt
+++ b/reference/starknet/llms.txt
@@ -3,6 +3,7 @@
 > Chainstack Starknet node API — index of pages. Each links to clean Markdown (.md).
 
 ## Pages
+- [Pathfinder RPC version removal 0.23.0 | Starknet](/reference/starknet-pathfinder-0-23-0-rpc-version-removal.md)
 - [Pathfinder default API version change 0.19.0 | Starknet](/reference/starknet-pathfinder-default-api-version-change.md)
 - [Pathfinder methods deprecation notice 0.17.0 | Starknet](/reference/starknet-pathfinder-methods-deprecation.md)
 - [starknet_call | Starknet](/reference/starknet-starknetcall.md)


### PR DESCRIPTION
## Context

Pathfinder **0.23.0** (pending Starknet node upgrade — flagged by Kristijan before rollout) is a **breaking change for API consumers**:

- Removes JSON-RPC API versions **0.6, 0.7, and 0.8**
- Moves the default `/` path from 0.8 to **0.9**

Source: [pathfinder v0.23.0 release notes](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0).

## Verified against live Chainstack Starknet nodes

Probed a running `starknet-mainnet` node via `starknet_specVersion` per path:

| Path | Now (pre-upgrade) | After 0.23.0 |
| --- | --- | --- |
| `/` (default) | 0.8.1 | **0.9** |
| `/rpc/v0_6` · `/rpc/v0_7` · `/rpc/v0_8` | 0.6.0 / 0.7.1 / 0.8.1 | **removed → HTTP 404 `-32603`** |
| `/rpc/v0_9` | 0.9.0 | 0.9 (also default) |
| `/rpc/v0_10` | 0.10.3-rc.0 | 0.10 |

`/rpc/v0_4` and `/rpc/v0_5` already 404 today — the getting-started page's examples were broken before this upgrade.

## Changes

- **New** `reference/starknet-pathfinder-0-23-0-rpc-version-removal.mdx` — breaking-change notice: what changed, what breaks (404 shape), how to check the version, migration to `v0_9`/`v0_10`. Modeled on the existing 0.19.0 notice page.
- **`getting-started-starknet.mdx`** — replace dead `v0_4/v0_5/v0_6` examples with live-tested `v0_9`/`v0_10`; add a version-support note.
- **`starknet-pathfinder-methods-deprecation.mdx`** — bump replacement examples `/rpc/v0_8` → `/rpc/v0_9` (`starknet_getStorageProof` verified on v0_9).
- **`starknet-pathfinder-default-api-version-change.mdx`** (0.19.0) — pointer note to the 0.23.0 change; kept as historical record.
- `docs.json` nav + `starknet/llms.txt` updated.

Every code example was executed against a live node before inclusion. Per-method Try-it specs hit the default path and need no change (0.8 → 0.9 automatically).

## Merge timing

⚠️ Describes the **post-0.23.0** state. **Merge to line up with the node rollout** so the docs match prod — coordinating with Kristijan.

## Gates
- `mintlify broken-links` — no broken links
- `mintlify validate` — build validation passed