### PR TITLE
PROD-1432 adding hourly data-update note to the Statistics page

### DIFF
--- a/docs/see-statistics.mdx
+++ b/docs/see-statistics.mdx
@@ -5,6 +5,10 @@ description: "View your Chainstack organization's request unit consumption, prot
 
 The [Statistics](https://console.chainstack.com/statistics) page provides an organization-wide view of your request units (RUs) consumption across all your nodes.
 
+<Note>
+Data updates approximately once per hour. Today's figures are partial and continue to fill in through the day.
+</Note>
+
 <Info>
 For per-node metrics with granular request data, method calls, and response codes, see [View node requests metrics](/docs/manage-your-node#view-node-requests-metrics).
 </Info>


### PR DESCRIPTION
## Summary

Adds a short, unobtrusive info note to the Statistics docs page indicating that the underlying data refreshes approximately once per hour and that the current day's figures are partial.

This is the docs counterpart to the console change on the [Statistics page](https://console.chainstack.com/statistics) (PROD-1432), where the embedded Metabase dashboards are backed by a data source updated once per hour.

## Change

- `docs/see-statistics.mdx` — new `<Note>` callout near the top of the page (after the intro, before the existing per-node-metrics `<Info>`), so it is visible without cluttering the view.

Copy:
> Data updates approximately once per hour. Today's figures are partial and continue to fill in through the day.

## Acceptance criteria

- [x] Info text is visible on the Statistics page.
- [x] Conveys the approximately hourly update cadence.
- [x] Makes clear the current day is partial and periodic, not real-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)