### PR TITLE
PROD-1432 correcting Statistics data-update cadence to every few hours

### DIFF
--- a/docs/see-statistics.mdx
+++ b/docs/see-statistics.mdx
@@ -6,7 +6,7 @@ description: "View your Chainstack organization's request unit consumption, prot
 The [Statistics](https://console.chainstack.com/statistics) page provides an organization-wide view of your request units (RUs) consumption across all your nodes.
 
 <Note>
-Data updates approximately once per hour. Today's figures are partial and continue to fill in through the day.
+Data updates every few hours, not in real time. Today's figures are partial and continue to fill in through the day.
 </Note>
 
 <Info>


### PR DESCRIPTION
## Summary

Follow-up to #566. The Statistics data source does not refresh hourly — it is a cron that runs every 6 hours (currently landing in roughly 4 hours), and the cadence may improve later. This corrects the docs note so it stays accurate without pinning a specific interval that would soon be stale.

## Change

- `docs/see-statistics.mdx` — updated the `<Note>` copy.

Before:
> Data updates approximately once per hour. Today's figures are partial and continue to fill in through the day.

After:
> Data updates every few hours, not in real time. Today's figures are partial and continue to fill in through the day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)