### PR TITLE
PROD-1433 adding Self-Hosted release notes v2.8.2

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3444,6 +3444,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-8-2-july-22-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-7-1-july-17-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-4-0-july-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-3-0-june-22-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-8-2-july-22-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-8-2-july-22-2026.mdx
@@ -1,0 +1,33 @@
+---
+title: "Chainstack Self-Hosted v2.8.2: July 22, 2026"
+description: "Robinhood Chain support, zero-downtime control-plane upgrades, cpctl update notifications, and node creation fixes."
+---
+
+This release adds Robinhood Chain support and makes control-plane upgrades safer with zero-downtime rollouts. It also brings update notifications to `cpctl` and fixes an invalid-configuration case in the new-node wizard.
+
+## Robinhood Chain support
+
+You can now deploy Robinhood Chain nodes. Support is built on a config-driven Arbitrum Nitro component, so the same foundation extends cleanly to other Nitro-based networks over time.
+
+## Zero-downtime control-plane upgrades
+
+Upgrading the Control Panel no longer interrupts running operations. The deployments API, workflow engine, and tracer now roll out one instance at a time, so an upgrade to a newer version completes without a service gap. This makes routine platform maintenance safe to run during business hours.
+
+## Update notifications in cpctl
+
+`cpctl` now checks whether a newer control-panel version is available and surfaces it when you install, check status, or run an upgrade. You get a clear heads-up when your installation is behind, so staying current no longer depends on manually tracking releases.
+
+## Node creation improvements
+
+The new-node wizard now correctly disables custom settings when they don't apply to the selected configuration, preventing invalid combinations before a deployment starts.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.7.0 |
+| cp-deployments-api | v0.42.0 |
+| cp-workflows | v3.10.0 |
+| cp-tracer | v0.2.1 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.8.2: July 22, 2026" description="">
+
+This release adds Robinhood Chain support and makes control-plane upgrades safer with zero-downtime rollouts. It also brings update notifications to cpctl and fixes an invalid-configuration case in the new-node wizard.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-8-2-july-22-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.7.1: July 17, 2026" description="">
 
 This release adds an in-console notification center for update and version alerts, custom node sizing in the deployment wizard, and server-side session revocation on sign-out. It also improves TRON and Polygon network support and makes snapshot restores more reliable.


### PR DESCRIPTION
Add v2.8.0 changelog detail page (Robinhood Chain support, zero-downtime control-plane upgrades, cpctl update notifications, node creation fixes), insert the release-notes.mdx Update entry, and register the page in docs.json.