### PR TITLE
docs(changelog): Sui gRPC endpoints now support gRPC-Web (July 22, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 22, 2026" description=" by Ake">
+
+**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet. Native gRPC and JSON-RPC are unchanged. See [Sui gRPC endpoint](/docs/sui-grpc-endpoint) and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).
+
+<Button href="/changelog/chainstack-updates-july-22-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 21, 2026" description=" by Ake">
 
 **Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — a breaking change to JSON-RPC API version support: versions 0.6, 0.7, and 0.8 are removed, and the default `/` endpoint now serves version 0.9. Pin `/rpc/v0_9` or `/rpc/v0_10` before the upgrade reaches your node.

--- a/changelog/chainstack-updates-july-22-2026.mdx
+++ b/changelog/chainstack-updates-july-22-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: July 22, 2026"
+description: "Chainstack Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK works against Chainstack nodes over HTTPS on mainnet and testnet."
+---
+
+**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet. Native gRPC and JSON-RPC are unchanged. See [Sui gRPC endpoint](/docs/sui-grpc-endpoint) and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).

--- a/docs.json
+++ b/docs.json
@@ -3186,6 +3186,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-22-2026",
           "changelog/chainstack-updates-july-21-2026",
           "changelog/chainstack-updates-july-17-2026",
           "changelog/chainstack-updates-july-6-2026",


### PR DESCRIPTION
## What

Adds the **July 22, 2026** Cloud release note: Chainstack Sui gRPC endpoints now support **gRPC-Web**, so the official Sui TypeScript SDK (`@mysten/sui`) works against Chainstack Sui nodes over HTTPS on Mainnet and Testnet. Native gRPC and JSON-RPC are unchanged.

## Changes

- `changelog.mdx` — new `<Update>` entry at the top.
- `changelog/chainstack-updates-july-22-2026.mdx` — standalone release note page.
- `docs.json` — page added to the Release notes tab.

## Local validation

- `docs.json` — valid JSON.
- `mintlify broken-links` — the two `/docs/sui-*` links resolve; no new broken links.