### PR TITLE
docs: Sui gRPC-Web support — fix stale 415 guidance + verified browser example

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,7 +8,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: July 22, 2026" description=" by Ake">
 
-**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet. Native gRPC and JSON-RPC are unchanged. See [Sui gRPC endpoint](/docs/sui-grpc-endpoint) and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).
+**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet — including from the browser, with only your node URL. Native gRPC and JSON-RPC are unchanged. See [Sui tooling](/docs/sui-tooling#grpc-from-code) for the SDK setup, [Sui gRPC endpoint](/docs/sui-grpc-endpoint), and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).
 
 <Button href="/changelog/chainstack-updates-july-22-2026">Read more</Button>
 </Update>

--- a/changelog/chainstack-updates-july-22-2026.mdx
+++ b/changelog/chainstack-updates-july-22-2026.mdx
@@ -3,4 +3,4 @@ title: "Chainstack updates: July 22, 2026"
 description: "Chainstack Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK works against Chainstack nodes over HTTPS on mainnet and testnet."
 ---
 
-**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet. Native gRPC and JSON-RPC are unchanged. See [Sui gRPC endpoint](/docs/sui-grpc-endpoint) and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).
+**Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet — including from the browser, with only your node URL. Native gRPC and JSON-RPC are unchanged. See [Sui tooling](/docs/sui-tooling#grpc-from-code) for the SDK setup, [Sui gRPC endpoint](/docs/sui-grpc-endpoint), and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).

--- a/docs/sui-grpc-endpoint.mdx
+++ b/docs/sui-grpc-endpoint.mdx
@@ -70,7 +70,7 @@ In this snapshot from Jul 10, 2026, the node served checkpoints from 253,124,671
 The `list` output shows the node's `sui.rpc.v2` services — [Sui tooling](/docs/sui-tooling#grpc-api) describes what each one is for.
 
 <Info>
-  The official Sui TypeScript SDK (`@mysten/sui`) works here over a native gRPC transport — see [the setup in Sui tooling](/docs/sui-tooling#grpc-from-code). Its default gRPC-Web transport is not supported on Chainstack yet (HTTP 415), so browser apps should use JSON-RPC or proxy gRPC through a backend.
+  The official Sui TypeScript SDK (`@mysten/sui`) works here over both its default gRPC-Web transport and a native gRPC transport — see [the setup in Sui tooling](/docs/sui-tooling#grpc-from-code). gRPC-Web is served over HTTPS on Mainnet and Testnet, so browser apps can use the SDK directly, no proxy required.
 </Info>
 
 ## Next steps

--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -144,26 +144,21 @@ grpcurl -H "x-token: YOUR_X_TOKEN" \
 
 ## gRPC from code
 
-In TypeScript, use the official Sui SDK (`@mysten/sui`) with a **native gRPC transport**. The SDK's default transport is gRPC-Web, which Chainstack does not serve (it returns HTTP 415), so pass a `@protobuf-ts/grpc-transport` transport backed by `@grpc/grpc-js` and authenticate with the `x-token` metadata header. From other languages, generate stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto) and attach the same `x-token` metadata.
+In TypeScript, use the official Sui SDK (`@mysten/sui`). Its **default gRPC-Web transport** works against Chainstack over HTTPS — in the browser and in Node.js — so you only need your node URL as `baseUrl`. For server-side apps that prefer native gRPC over HTTP/2, pass a native transport instead (see [Sui tooling](/docs/sui-tooling#grpc-from-code) for the native setup). From other languages, generate stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto) and attach the `x-token` metadata.
 
 <Note>
-  Use recent client versions — `@mysten/sui` 2.16 or later and `@grpc/grpc-js` 1.14 or later. Older releases mishandle gRPC streams and produce intermittent `RST` and internal errors under load; current versions are reliable.
+  Use recent client versions — `@mysten/sui` 2.16 or later (and `@grpc/grpc-js` 1.14 or later for the native transport). Older releases mishandle gRPC streams and produce intermittent `RST` and internal errors under load; current versions are reliable.
 </Note>
 
 <CodeGroup>
   ```typescript TypeScript
-  // npm install @mysten/sui @protobuf-ts/grpc-transport @grpc/grpc-js
+  // npm install @mysten/sui
+  // Default gRPC-Web transport over HTTPS — works in the browser and in Node.js.
   import { SuiGrpcClient } from '@mysten/sui/grpc';
-  import { GrpcTransport } from '@protobuf-ts/grpc-transport';
-  import { ChannelCredentials } from '@grpc/grpc-js';
 
   const client = new SuiGrpcClient({
     network: 'mainnet',
-    transport: new GrpcTransport({
-      host: 'sui-mainnet.core.chainstack.com:443',
-      channelCredentials: ChannelCredentials.createSsl(),
-      meta: { 'x-token': 'YOUR_X_TOKEN' },
-    }),
+    baseUrl: 'YOUR_CHAINSTACK_SUI_HTTPS_ENDPOINT',
   });
 
   // High-level helpers on client.core; raw services on client.ledgerService, etc.
@@ -192,7 +187,7 @@ In TypeScript, use the official Sui SDK (`@mysten/sui`) with a **native gRPC tra
 </CodeGroup>
 
 <Info>
-  This path is server-side only. The SDK's browser transport is gRPC-Web, which Chainstack does not serve yet (HTTP 415) — from the browser, use JSON-RPC or proxy gRPC through your backend.
+  The default gRPC-Web transport shown above works in the browser and in Node.js. Native gRPC over HTTP/2 is server-side only; use it when you specifically need native gRPC.
 </Info>
 
 ## Next steps

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -48,11 +48,26 @@ The node exposes six `sui.rpc.v2` services:
 
 ### gRPC from code
 
-In TypeScript, use the official `@mysten/sui` SDK with a native gRPC transport (its default transport is gRPC-Web, which Chainstack does not serve). From other languages, generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto). Either way, attach the `x-token` metadata to every call, and use recent client versions — `@mysten/sui` 2.16+ and `@grpc/grpc-js` 1.14+ — since older releases produce intermittent gRPC errors under load.
+In TypeScript, use the official `@mysten/sui` SDK. Its default gRPC-Web transport works against Chainstack over HTTPS — including from the browser — so the simplest setup needs only your node URL as `baseUrl`. For server-side apps that prefer native gRPC over HTTP/2, pass a native transport instead. From other languages, generate typed stubs from [Sui's proto definitions](https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto) and connect over native gRPC. Authenticate with your node's `x-token` — carried in the endpoint URL, or as `x-token` metadata on native-gRPC calls — and use recent client versions — `@mysten/sui` 2.16+ and `@grpc/grpc-js` 1.14+ — since older releases produce intermittent gRPC errors under load.
 
 <CodeGroup>
-  ```typescript TypeScript
+  ```typescript TypeScript (gRPC-Web)
+  // npm install @mysten/sui
+  // Default gRPC-Web transport over HTTPS — works in the browser and in Node.js.
+  import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+  const client = new SuiGrpcClient({
+    network: 'mainnet',
+    baseUrl: 'YOUR_CHAINSTACK_SUI_HTTPS_ENDPOINT',
+  });
+
+  const gasPrice = await client.core.getReferenceGasPrice();
+  console.log(gasPrice.referenceGasPrice);
+  ```
+
+  ```typescript TypeScript (native gRPC)
   // npm install @mysten/sui @protobuf-ts/grpc-transport @grpc/grpc-js
+  // Native gRPC over HTTP/2 — server runtimes only.
   import { SuiGrpcClient } from '@mysten/sui/grpc';
   import { GrpcTransport } from '@protobuf-ts/grpc-transport';
   import { ChannelCredentials } from '@grpc/grpc-js';
@@ -133,7 +148,7 @@ In TypeScript, use the official `@mysten/sui` SDK with a native gRPC transport (
 </CodeGroup>
 
 <Info>
-  The native gRPC transport above works only in Node.js and other server runtimes. The SDK's browser transport is gRPC-Web, which Chainstack does not serve yet (HTTP 415) — from the browser, use JSON-RPC or proxy gRPC through your backend.
+  The default gRPC-Web transport works in both the browser and server runtimes, so it is the simplest choice for most apps. The native gRPC transport (HTTP/2) is server-side only — use it when you specifically need native gRPC.
 </Info>
 
 ## JSON-RPC API


### PR DESCRIPTION
## Context

Infra shipped **gRPC-Web on the same Sui endpoint** (Mainnet + Testnet), announced in the July 22 changelog (**#571**, merged). But the three docs pages that changelog links to still told developers gRPC-Web returns **HTTP 415 / "Chainstack does not serve it"** — so the live docs directly contradicted the release note.

## Verified live before writing

- The exact gRPC-Web request that used to **415** now returns **HTTP 200 + a valid `application/grpc-web+proto` response** on both Mainnet and Testnet.
- Ran the official **`@mysten/sui` SDK** (2.22.1) default (gRPC-Web) transport against a live Chainstack Sui node: `getReferenceGasPrice()` succeeds on mainnet (100) and testnet (1000).
- **Auth gotcha found by testing:** the intuitive `meta: { 'x-token' }` at the client-options level returns **Unauthorized**; the config that authenticates is **token-in-URL `baseUrl`** (or an explicit `GrpcWebFetchTransport` with `meta`). The shipped example uses the form that actually works.

## Changes

- **`sui-grpc-endpoint.mdx`** — drop the 415 caveat; gRPC-Web is served over HTTPS, browser apps can use the SDK directly.
- **`sui-tooling.mdx`** — rewrite the gRPC-from-code prose; add a verified **TypeScript (gRPC-Web)** example (`SuiGrpcClient({ network, baseUrl })`, browser + Node); relabel the existing native example **TypeScript (native gRPC)** and keep it as the server-side option; fix the browser Info callout.
- **`sui-migrate-json-rpc-to-grpc.mdx`** — lead with the verified default gRPC-Web example; keep native gRPC as the server-side option (pointer to tooling); fix the browser callout.
- **`changelog.mdx` + `changelog/chainstack-updates-july-22-2026.mdx`** — reference the fixed Sui tooling SDK setup alongside the endpoint and migration pages, and note the browser/URL-only setup.

## Merge timing

Merge now — the capability is already live in prod and announced.

## Gates
- `mintlify broken-links` — no broken links
- `mintlify validate` — build validation passed