### PR TITLE
docs(sui): correct JSON-RPC deprecation dates to Sui's authoritative timeline

### DIFF
--- a/docs/sui-migrate-json-rpc-to-grpc.mdx
+++ b/docs/sui-migrate-json-rpc-to-grpc.mdx
@@ -1,21 +1,24 @@
 ---
 title: "Migrate Sui from JSON-RPC to gRPC"
-description: "Sui Foundation shuts down its public JSON-RPC endpoints on Jul 31, 2026. Migrate call by call to gRPC on Chainstack, where JSON-RPC and gRPC run on the same node and JSON-RPC keeps working."
+description: "Sui Foundation is retiring its public JSON-RPC, with mainnet endpoints going offline the week of Jul 27, 2026. Migrate call by call to gRPC on Chainstack, where JSON-RPC and gRPC run on the same node and JSON-RPC keeps working."
 ---
 
 Sui Foundation is shutting down its **public** JSON-RPC endpoints. On Chainstack, your Sui node serves JSON-RPC and gRPC on the **same endpoint**, so you migrate call by call — keep using JSON-RPC while you port each call to gRPC, with no provider switch and no re-sync.
 
 <Warning>
-  Apps calling Sui Foundation's public endpoints `fullnode.mainnet.sui.io` or `fullnode.testnet.sui.io` stop working after Jul 31, 2026.
+  Apps calling Sui Foundation's public JSON-RPC endpoint `fullnode.mainnet.sui.io` stop working when Sui disables mainnet JSON-RPC the week of Jul 27, 2026. Sui fully decommissions public JSON-RPC by mid-Oct 2026.
 </Warning>
 
-Sui Foundation retires its public JSON-RPC in stages:
+Sui Foundation retires its public mainnet JSON-RPC in stages, per [Sui's migration guide](https://docs.sui.io/develop/accessing-data/json-rpc-migration):
 
 | Milestone | Date |
 | --- | --- |
-| Testnet public JSON-RPC off | Week of Jul 6, 2026 |
-| Mainnet public JSON-RPC off | Week of Jul 20, 2026 |
-| Public JSON-RPC fully retired | Jul 31, 2026 |
+| Mainnet JSON-RPC disabled on Sui full nodes | Week of Jul 27, 2026 |
+| Sui stops publishing JSON-RPC snapshots | End of Aug 2026 |
+| Implicit fallback to the archival service disconnected | End of Sep 2026 |
+| Full decommission and code removal | Mid-Oct 2026 |
+
+Sui publishes this timeline for mainnet only and does not give a separate testnet date.
 
 ## What is actually being deprecated
 


### PR DESCRIPTION
## What

Corrects the Sui public JSON-RPC deprecation dates in `docs/sui-migrate-json-rpc-to-grpc.mdx` to match Sui Foundation's own [migration guide](https://docs.sui.io/develop/accessing-data/json-rpc-migration).

## Why

The page stated dates that don't match Sui's authoritative timeline:

| Field | Was (wrong) | Now (Sui's guide) |
|---|---|---|
| Mainnet JSON-RPC off | Week of Jul 20, 2026 | Week of Jul 27, 2026 |
| Full retirement | Jul 31, 2026 | Mid-Oct 2026 (staged) |
| Testnet | Week of Jul 6, 2026 | Sui publishes no separate testnet date |

## Changes

- Frontmatter description + intro Warning: corrected to the week of Jul 27, 2026 mainnet shutoff and mid-Oct 2026 full decommission.
- Staged-retirement table: replaced with Sui's authoritative 4-stage mainnet schedule (disable → snapshots stop → fallback off → full decommission), with the source linked.
- Removed the unverifiable testnet date; noted Sui publishes mainnet only.

Rest of the page (only public endpoints go dark, Chainstack JSON-RPC keeps serving, migrate call-by-call) is unchanged.