### PR TITLE
changelog: MCP testnet faucet network enum + aliases (July 23, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 23, 2026" description=" by Ake">
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet now advertises its supported networks to your agent and accepts common aliases (`ethereum-sepolia` → `sepolia`, `solana-devnet` → `solana`), so testnet fund requests land on the first try instead of failing on a wrong-network name.
+
+<Button href="/changelog/chainstack-updates-july-23-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 22, 2026" description=" by Ake">
 
 **Protocols**. Sui gRPC endpoints now support gRPC-Web, so the official Sui TypeScript SDK (`@mysten/sui`) works against your Chainstack nodes over HTTPS on Mainnet and Testnet — including from the browser, with only your node URL. Native gRPC and JSON-RPC are unchanged. See [Sui tooling](/docs/sui-tooling#grpc-from-code) for the SDK setup, [Sui gRPC endpoint](/docs/sui-grpc-endpoint), and [migrating from JSON-RPC to gRPC](/docs/sui-migrate-json-rpc-to-grpc).

--- a/changelog/chainstack-updates-july-23-2026.mdx
+++ b/changelog/chainstack-updates-july-23-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: July 23, 2026"
+description: "The Chainstack MCP server's testnet faucet now advertises its supported networks to your agent and accepts common network-name aliases, so testnet fund requests land on the first try."
+---
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet (`request_testnet_funds`) now tells your agent exactly which testnets it supports — the supported networks are published as a schema enum, so the agent picks a valid one up front instead of guessing. Common near-miss spellings are also accepted and normalized to the canonical id — `ethereum-sepolia` → `sepolia`, `base-sepolia` → `base`, `solana-devnet` → `solana` — so a slightly-off network name still delivers the funds. Supported testnets: sepolia, hoodi, base, amoy, bnb-testnet, zksync-testnet, scroll-sepolia-testnet, hyperevm, plasma, monad, ton, and solana (Solana devnet).

--- a/docs.json
+++ b/docs.json
@@ -3186,6 +3186,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-23-2026",
           "changelog/chainstack-updates-july-22-2026",
           "changelog/chainstack-updates-july-21-2026",
           "changelog/chainstack-updates-july-17-2026",


### PR DESCRIPTION
Docs release note for the July 23, 2026 MCP server update — the testnet faucet now advertises its supported networks to the agent and accepts common network-name aliases, so testnet fund requests land on the first try.

Three coordinated edits (per the release-note flow):
- New standalone page `changelog/chainstack-updates-july-23-2026.mdx`
- `<Update>` feed block in `changelog.mdx` (inserted newest-first, above July 22)
- Nav entry in `docs.json` Release notes

`mint broken-links`: no broken links.