### PR TITLE
docs: Polygon — recommend flatCallTracer for trace_* migration

### DIFF
--- a/docs/polygon-methods.mdx
+++ b/docs/polygon-methods.mdx
@@ -11,12 +11,12 @@ Polygon runs on the Bor client, which does not implement the Erigon-only Parity 
 
 | Parity `trace_*` method | Replacement on Bor |
 | --- | --- |
-| `trace_transaction` | [`debug_traceTransaction`](/reference/polygon-tracetransaction) with `callTracer` |
-| `trace_block` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with `callTracer` |
-| `trace_call` | [`debug_traceCall`](/reference/polygon-tracecall) with `callTracer` |
-| `trace_filter`, `trace_replayBlockTransactions`, `trace_replayTransaction` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) per block, or [`eth_getLogs`](/docs/understanding-eth-getlogs-limitations) for event ranges |
+| `trace_transaction` | [`debug_traceTransaction`](/reference/polygon-tracetransaction) with `flatCallTracer` |
+| `trace_block` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with `flatCallTracer` |
+| `trace_call` | [`debug_traceCall`](/reference/polygon-tracecall) with `flatCallTracer` |
+| `trace_filter`, `trace_replayBlockTransactions`, `trace_replayTransaction` | [`debug_traceBlockByNumber`](/reference/polygon-traceblockbynumber) with `flatCallTracer` per block, or [`eth_getLogs`](/docs/understanding-eth-getlogs-limitations) for event ranges |
 
-The `debug_trace*` methods return equivalent execution traces on Bor. The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
+On Bor, `debug_trace*` with `flatCallTracer` returns traces in the Parity-style flat format, matching the shape of the Erigon `trace_*` output, so you can reuse your existing trace-parsing logic. The `erigon_*` convenience methods have no Bor equivalent — use the standard `eth_*` methods instead.
 
 On Bor, `eth_getProof` returns state proofs only for roughly the latest 128 blocks; historical proof queries are not available.
 

--- a/docs/protocols-clients.mdx
+++ b/docs/protocols-clients.mdx
@@ -30,7 +30,7 @@ See [Debug and trace APIs](/docs/debug-and-trace-apis#ethereum) for how the exec
 Polygon runs the **Bor** client — the [native Polygon client](https://github.com/0xPolygon/bor). It is interacted with using the [standard Ethereum JSON-RPC methods](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 
 <Warning>
-  Chainstack has **retired the Erigon client for Polygon** — archive nodes now run Bor. Because Bor does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces, use the `debug_*` methods (with `callTracer`) instead. See [Polygon methods](/docs/polygon-methods) and [Debug and trace APIs](/docs/debug-and-trace-apis).
+  Chainstack has **retired the Erigon client for Polygon** — archive nodes now run Bor. Because Bor does not implement the Erigon-only Parity `trace_*` or `erigon_*` namespaces, use the `debug_*` methods (with `flatCallTracer`) instead. See [Polygon methods](/docs/polygon-methods) and [Debug and trace APIs](/docs/debug-and-trace-apis).
 </Warning>
 
 ## BNB Smart Chain


### PR DESCRIPTION
## What

Switch the Polygon `trace_*` → `debug_*` migration mapping to recommend **`flatCallTracer`** instead of `callTracer`:

- `docs/polygon-methods.mdx` — the migration table, plus a note on the output format
- `docs/protocols-clients.mdx` — the Polygon Bor retirement warning

## Why

Polygon archive nodes run Bor, which doesn't implement the Erigon-only Parity `trace_*` namespace. `flatCallTracer` (a native Bor/go-ethereum tracer, `eth/tracers/native/call_flat.go`) returns traces in the **Parity-style flat format** — the same shape as the old `trace_*` output — so developers migrating off `trace_*` can reuse their existing trace-parsing logic. `callTracer` returns Geth's nested format, which would force a rewrite.

`flatCallTracer` is enabled on Chainstack's Polygon Bor nodes and verified working.

## Scope

Only the migration mapping changes. The `reference/polygon-*trace*` pages continue to document `callTracer` with its nested-format response examples — `callTracer` remains fully supported; this only changes which tracer we recommend as the drop-in replacement for `trace_*`.

Follows up #577 (which shipped the post-Bor reference coverage with `callTracer`).