### PR TITLE
fix(node-options): correct TON query limit, Sui mainnet faucet URL, and document Celo/Monad mode split

### DIFF
--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -634,7 +634,7 @@
       "supported_modes": [
         "Archive"
       ],
-      "full_mode_query_limit": "Both v2 and v3 (indexer) are supported",
+      "full_mode_query_limit": "N/A",
       "archive_mode_available": true,
       "debug_trace_available": false,
       "warp_transactions_available": false,
@@ -1283,7 +1283,7 @@
       "dedicated_node_availability": "Platform",
       "mainnet": {
         "network_name": "Mainnet",
-        "faucet_url": "https://faucet.sui.io/",
+        "faucet_url": "N/A",
         "locations": [
           {
             "cloud": "Chainstack Global Network",
@@ -2257,7 +2257,7 @@
           ]
         }
       ],
-      "additional_notes": "N/A"
+      "additional_notes": "Archive mode on mainnet; Full mode on Alfajores testnet only"
     },
     "Bitcoin": {
       "protocol_name": "Bitcoin",
@@ -3057,7 +3057,7 @@
           ]
         }
       ],
-      "additional_notes": "N/A"
+      "additional_notes": "Archive mode on mainnet; Full mode on testnet only"
     },
     "NeoX": {
       "protocol_name": "NeoX",


### PR DESCRIPTION
## What

Fixes four data inconsistencies in `node-options-master-list.json`.

## Changes

**TON** `full_mode_query_limit` corrected to `"N/A"`. TON has no Full mode (`supported_modes: ["Archive"]`), so this field is not applicable. The v2/v3 API info is already captured in `deployment_options` and `additional_notes`. TON was the only protocol across all 91 entries where this field contained a non-standard descriptive string.

**Sui** mainnet `faucet_url` corrected to `"N/A"`. The mainnet entry contained the same faucet URL as the testnet entry a copy paste from the testnet block. Faucets distribute free test tokens and have no function on mainnet; all other protocols set `faucet_url: "N/A"` on mainnet.

**Celo + Monad** `additional_notes` updated to document the mode split. Both protocols list `supported_modes: ["Full", "Archive"]` at the top level, but the modes are split across networks: mainnet is Archive only, testnet is Full only. Added perprotocol notes so developers know what to expect per network.

## Closes

Fixes #580, #581