### PR TITLE
docs: point Polygon node API references at the Bor Global Node endpoint

### DIFF
--- a/openapi/polygon_node_api/account_info/eth_getBalance.json
+++ b/openapi/polygon_node_api/account_info/eth_getBalance.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/account_info/eth_getCode.json
+++ b/openapi/polygon_node_api/account_info/eth_getCode.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/account_info/eth_getProof.json
+++ b/openapi/polygon_node_api/account_info/eth_getProof.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/account_info/eth_getStorageAt.json
+++ b/openapi/polygon_node_api/account_info/eth_getStorageAt.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/account_info/eth_getTransactionCount.json
+++ b/openapi/polygon_node_api/account_info/eth_getTransactionCount.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/blocks_info/eth_blockNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_blockNumber.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Blocks info"

--- a/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
+++ b/openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Blocks info"

--- a/openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json
+++ b/openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "summary": "eth_newBlockFilter",
         "operationId": "newBlockFilter",

--- a/openapi/polygon_node_api/bor/bor_getAuthor.json
+++ b/openapi/polygon_node_api/bor/bor_getAuthor.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/bor/bor_getCurrentProposer.json
+++ b/openapi/polygon_node_api/bor/bor_getCurrentProposer.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/bor/bor_getCurrentValidators.json
+++ b/openapi/polygon_node_api/bor/bor_getCurrentValidators.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/bor/bor_getRootHash.json
+++ b/openapi/polygon_node_api/bor/bor_getRootHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/bor/bor_getSignersAtHash.json
+++ b/openapi/polygon_node_api/bor/bor_getSignersAtHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Ethereum Operations"

--- a/openapi/polygon_node_api/chain_info/eth_chainId.json
+++ b/openapi/polygon_node_api/chain_info/eth_chainId.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/chain_info/eth_syncing.json
+++ b/openapi/polygon_node_api/chain_info/eth_syncing.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/client_info/net_listening.json
+++ b/openapi/polygon_node_api/client_info/net_listening.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/client_info/net_peerCount.json
+++ b/openapi/polygon_node_api/client_info/net_peerCount.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/client_info/web3_clientVersion.json
+++ b/openapi/polygon_node_api/client_info/web3_clientVersion.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceCall.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceCall.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json
+++ b/openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/trace_block.json
+++ b/openapi/polygon_node_api/debug_and_trace/trace_block.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/debug_and_trace/trace_transaction.json
+++ b/openapi/polygon_node_api/debug_and_trace/trace_transaction.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/execute_transactions/eth_call.json
+++ b/openapi/polygon_node_api/execute_transactions/eth_call.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/execute_transactions/eth_sendRawTransaction.json
+++ b/openapi/polygon_node_api/execute_transactions/eth_sendRawTransaction.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/filter_handling/eth_getFilterChanges.json
+++ b/openapi/polygon_node_api/filter_handling/eth_getFilterChanges.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json
+++ b/openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/gas_data/eth_estimateGas.json
+++ b/openapi/polygon_node_api/gas_data/eth_estimateGas.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/gas_data/eth_gasPrice.json
+++ b/openapi/polygon_node_api/gas_data/eth_gasPrice.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/logs_and_events/eth_getLogs.json
+++ b/openapi/polygon_node_api/logs_and_events/eth_getLogs.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/logs_and_events/eth_newFilter.json
+++ b/openapi/polygon_node_api/logs_and_events/eth_newFilter.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "upload"

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Transactions info"

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Transactions info"

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Transactions info"

--- a/openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json
+++ b/openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "tags": [
           "Transactions info"

--- a/openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json
+++ b/openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json
@@ -7,11 +7,11 @@
   },
   "servers": [
     {
-      "url": "https://nd-828-700-214.p2pify.com"
+      "url": "https://polygon-mainnet.core.chainstack.com"
     }
   ],
   "paths": {
-    "/a9bca2f0f84b54086ceebe590316fff3": {
+    "/0615fdf3c9eaf0681469e61a4308ea09": {
       "post": {
         "summary": "eth_newPendingTransactionFilter",
         "operationId": "newPendingTransactionFilter",

--- a/reference/chainid.mdx
+++ b/reference/chainid.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_chainId | Polygon
-openapi: /openapi/polygon_node_api/chain_info/eth_chainId.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/chain_info/eth_chainId.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the current chain ID. eth_chainId JSON-RPC method available on the Polygon blockchain via Chainstack."
 ---
 

--- a/reference/clientversion.mdx
+++ b/reference/clientversion.mdx
@@ -1,6 +1,6 @@
 ---
 title: web3_clientVersion | Polygon
-openapi: /openapi/polygon_node_api/client_info/web3_clientVersion.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/client_info/web3_clientVersion.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the client type and version running on the Polygon node. web3_clientVersion on Polygon via Chainstack."
 ---
 

--- a/reference/estimategas.mdx
+++ b/reference/estimategas.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_estimateGas | Polygon
-openapi: /openapi/polygon_node_api/gas_data/eth_estimateGas.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/gas_data/eth_estimateGas.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns an estimate of gas units needed for a given transaction. eth_estimateGas on Polygon via Chainstack."
 ---
 

--- a/reference/ethcall.mdx
+++ b/reference/ethcall.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_call | Polygon
-openapi: /openapi/polygon_node_api/execute_transactions/eth_call.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/execute_transactions/eth_call.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that enables instant execution of a new message call without requiring the creation of a transaction on the blockchain."
 ---
 

--- a/reference/gasprice.mdx
+++ b/reference/gasprice.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_gasPrice | Polygon
-openapi: /openapi/polygon_node_api/gas_data/eth_gasPrice.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/gas_data/eth_gasPrice.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the current gas base fee of the network. Chainstack supports eth_gasPrice on Polygon JSON-RPC nodes."
 ---
 

--- a/reference/getbalance.mdx
+++ b/reference/getbalance.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getBalance | Polygon
-openapi: /openapi/polygon_node_api/account_info/eth_getBalance.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/account_info/eth_getBalance.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the balance of a specific Polygon account in Wei, the smallest unit of ether. Polygon via Chainstack."
 ---
 

--- a/reference/getblockbyhash.mdx
+++ b/reference/getblockbyhash.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getBlockByHash | Polygon
-openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockByHash.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns information about the block matching the given block hash. eth_getBlockByHash on Polygon via Chainstack."
 ---
 

--- a/reference/getcode.mdx
+++ b/reference/getcode.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getCode | Polygon
-openapi: /openapi/polygon_node_api/account_info/eth_getCode.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/account_info/eth_getCode.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that retrieves the compiled bytecode of a smart contract providing its address as a parameter. Polygon via Chainstack."
 ---
 

--- a/reference/getfilterchanges.mdx
+++ b/reference/getfilterchanges.mdx
@@ -1,7 +1,7 @@
 ---
 title: eth_getFilterChanges | Polygon
 openapi: /openapi/polygon_node_api/filter_handling/eth_getFilterChanges.json POST
-  /a9bca2f0f84b54086ceebe590316fff3
+  /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API polling method used to retrieve updates from a filter. A filter is an object used to track changes to the state of the blockchain."
 ---
 

--- a/reference/getlogs.mdx
+++ b/reference/getlogs.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getLogs | Polygon
-openapi: /openapi/polygon_node_api/logs_and_events/eth_getLogs.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/logs_and_events/eth_getLogs.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns an array of all logs that match a given filter object. Available on Polygon via Chainstack JSON-RPC nodes."
 ---
 

--- a/reference/getstorageat.mdx
+++ b/reference/getstorageat.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getStorageAt | Polygon
-openapi: /openapi/polygon_node_api/account_info/eth_getStorageAt.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/account_info/eth_getStorageAt.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the data stored at a specific storage slot within a smart contract. Use it on Polygon via Chainstack."
 ---
 

--- a/reference/gettransactioncount.mdx
+++ b/reference/gettransactioncount.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getTransactionCount | Polygon
-openapi: /openapi/polygon_node_api/account_info/eth_getTransactionCount.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/account_info/eth_getTransactionCount.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the number of transactions sent from an address at the selected block. Chainstack Polygon reference."
 ---
 

--- a/reference/netlistening.mdx
+++ b/reference/netlistening.mdx
@@ -1,6 +1,6 @@
 ---
 title: net_listening | Polygon
-openapi: /openapi/polygon_node_api/client_info/net_listening.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/client_info/net_listening.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns a boolean value indicating whether the client is currently listening for network connections or not."
 ---
 

--- a/reference/newfilter.mdx
+++ b/reference/newfilter.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_newFilter | Polygon
-openapi: /openapi/polygon_node_api/logs_and_events/eth_newFilter.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/logs_and_events/eth_newFilter.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that generates a filter object based on the filter parameters. Available on Polygon via Chainstack JSON-RPC nodes."
 ---
 

--- a/reference/peercount.mdx
+++ b/reference/peercount.mdx
@@ -1,6 +1,6 @@
 ---
 title: net_peerCount | Polygon
-openapi: /openapi/polygon_node_api/client_info/net_peerCount.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/client_info/net_peerCount.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the number of peers connected to the node. Call net_peerCount on Polygon through Chainstack nodes."
 ---
 

--- a/reference/polygon-borgetauthor.mdx
+++ b/reference/polygon-borgetauthor.mdx
@@ -1,6 +1,6 @@
 ---
 title: bor_getAuthor | Polygon
-openapi: /openapi/polygon_node_api/bor/bor_getAuthor.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/bor/bor_getAuthor.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method bor_getAuthor returns the validator address that produced a given block. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-borgetcurrentproposer.mdx
+++ b/reference/polygon-borgetcurrentproposer.mdx
@@ -1,6 +1,6 @@
 ---
 title: bor_getCurrentProposer | Polygon
-openapi: /openapi/polygon_node_api/bor/bor_getCurrentProposer.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/bor/bor_getCurrentProposer.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method bor_getCurrentProposer returns the address of the current block proposer on the Bor consensus layer. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-borgetcurrentvalidators.mdx
+++ b/reference/polygon-borgetcurrentvalidators.mdx
@@ -1,6 +1,6 @@
 ---
 title: bor_getCurrentValidators | Polygon
-openapi: /openapi/polygon_node_api/bor/bor_getCurrentValidators.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/bor/bor_getCurrentValidators.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method bor_getCurrentValidators returns the current validator set seen by the Bor consensus engine. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-borgetroothash.mdx
+++ b/reference/polygon-borgetroothash.mdx
@@ -1,6 +1,6 @@
 ---
 title: bor_getRootHash | Polygon
-openapi: /openapi/polygon_node_api/bor/bor_getRootHash.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/bor/bor_getRootHash.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method bor_getRootHash returns the root hash for a given block range, used for checkpointing to Ethereum. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-borgetsignersathash.mdx
+++ b/reference/polygon-borgetsignersathash.mdx
@@ -1,6 +1,6 @@
 ---
 title: bor_getSignersAtHash | Polygon
-openapi: /openapi/polygon_node_api/bor/bor_getSignersAtHash.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/bor/bor_getSignersAtHash.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method bor_getSignersAtHash returns the authorized signers at a given block hash. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-getblockbynumber.mdx
+++ b/reference/polygon-getblockbynumber.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getBlockByNumber | Polygon
-openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockByNumber.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns information about the block matching the given block number. eth_getBlockByNumber on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-getblocknumber.mdx
+++ b/reference/polygon-getblocknumber.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_blockNumber | Polygon
-openapi: /openapi/polygon_node_api/blocks_info/eth_blockNumber.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/blocks_info/eth_blockNumber.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the latest block number of the blockchain. Reference for eth_blockNumber on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-getblockreceipts.mdx
+++ b/reference/polygon-getblockreceipts.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getBlockReceipts | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_getBlockReceipts.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that retrieves all transaction receipts for a given block. Reference for eth_getBlockReceipts on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-getblocktransactioncountbyhash.mdx
+++ b/reference/polygon-getblocktransactioncountbyhash.mdx
@@ -1,7 +1,7 @@
 ---
 title: eth_getBlockTransactionCountByHash | Polygon
 openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByHash.json
-  POST /a9bca2f0f84b54086ceebe590316fff3
+  POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the number of transactions in a block specified by block hash. This information can be useful for analytics purposes."
 ---
 

--- a/reference/polygon-getblocktransactioncountbynumber.mdx
+++ b/reference/polygon-getblocktransactioncountbynumber.mdx
@@ -1,7 +1,7 @@
 ---
 title: eth_getBlockTransactionCountByNumber | Polygon
 openapi: /openapi/polygon_node_api/blocks_info/eth_getBlockTransactionCountByNumber.json
-  POST /a9bca2f0f84b54086ceebe590316fff3
+  POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the number of transactions in a block specified by block number or tag. This information can be useful for analytics purposes."
 ---
 

--- a/reference/polygon-getproof.mdx
+++ b/reference/polygon-getproof.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getProof | Polygon
-openapi: /openapi/polygon_node_api/account_info/eth_getProof.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/account_info/eth_getProof.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method eth_getProof returns the account and storage Merkle proof for an address, letting clients verify state without the full chain. On Polygon via Chainstack."
 ---
 

--- a/reference/polygon-gettransactionbyblockhashandindex.mdx
+++ b/reference/polygon-gettransactionbyblockhashandindex.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getTransactionByBlockHashAndIndex | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockHashAndIndex.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that retrieves information about a specific transaction based on the block hash and the transaction index within the block."
 ---
 

--- a/reference/polygon-gettransactionbyblocknumberandindex.mdx
+++ b/reference/polygon-gettransactionbyblocknumberandindex.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getTransactionByBlockNumberAndIndex | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByBlockNumberAndIndex.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that retrieves information about a specific transaction based on the block number and the transaction index within the block."
 ---
 

--- a/reference/polygon-gettransactionbyhash.mdx
+++ b/reference/polygon-gettransactionbyhash.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getTransactionByHash | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionByHash.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns the information about a transaction from the transaction hash. Available on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-gettransactionreceipt.mdx
+++ b/reference/polygon-gettransactionreceipt.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_getTransactionReceipt | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_getTransactionReceipt.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that retrieves the receipt of a transaction from a transaction hash. eth_getTransactionReceipt on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-newblockfilter.mdx
+++ b/reference/polygon-newblockfilter.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_newBlockFilter | Polygon
-openapi: /openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/blocks_info/eth_newBlockFilter.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that creates a filter that watches for new blocks on the blockchain. eth_newBlockFilter on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-newpendingtransactionfilter.mdx
+++ b/reference/polygon-newpendingtransactionfilter.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_newPendingTransactionFilter | Polygon
-openapi: /openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/transaction_info/eth_newPendingTransactionFilter.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that creates a filter that listens for new pending transactions on the blockchain. Chainstack Polygon reference."
 ---
 

--- a/reference/polygon-traceblockbyhash.mdx
+++ b/reference/polygon-traceblockbyhash.mdx
@@ -1,6 +1,6 @@
 ---
 title: debug_traceBlockByHash | Polygon
-openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByHash.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that traces the execution of a block. debug_traceBlockByHash JSON-RPC method available on the Polygon blockchain via Chainstack."
 ---
 

--- a/reference/polygon-traceblockbynumber.mdx
+++ b/reference/polygon-traceblockbynumber.mdx
@@ -1,6 +1,6 @@
 ---
 title: debug_traceBlockByNumber | Polygon
-openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceBlockByNumber.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that enables the tracing of the execution of a specific block using its number. Use it on Polygon via Chainstack."
 ---
 

--- a/reference/polygon-tracecall.mdx
+++ b/reference/polygon-tracecall.mdx
@@ -1,6 +1,6 @@
 ---
 title: debug_traceCall | Polygon
-openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceCall.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceCall.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that traces the execution of eth_call | Polygon within the context of a specific block's execution. On Polygon."
 ---
 

--- a/reference/polygon-tracetransaction.mdx
+++ b/reference/polygon-tracetransaction.mdx
@@ -1,6 +1,6 @@
 ---
 title: debug_traceTransaction | Polygon
-openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/debug_and_trace/debug_traceTransaction.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns a transaction's traces by replaying it. Reference for debug_traceTransaction on Polygon via Chainstack."
 ---
 

--- a/reference/sendrawtransaction.mdx
+++ b/reference/sendrawtransaction.mdx
@@ -1,7 +1,7 @@
 ---
 title: eth_sendRawTransaction | Polygon
 openapi: /openapi/polygon_node_api/execute_transactions/eth_sendRawTransaction.json
-  POST /a9bca2f0f84b54086ceebe590316fff3
+  POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that allows submitting a signed transaction to the network. Available on Polygon via Chainstack JSON-RPC nodes."
 ---
 

--- a/reference/syncing.mdx
+++ b/reference/syncing.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_syncing | Polygon
-openapi: /openapi/polygon_node_api/chain_info/eth_syncing.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/chain_info/eth_syncing.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method that returns an object with information about the current synchronization status of the node, or false if the node is fully synced."
 ---
 

--- a/reference/uninstallfilter.mdx
+++ b/reference/uninstallfilter.mdx
@@ -1,6 +1,6 @@
 ---
 title: eth_uninstallFilter | Polygon
-openapi: /openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json POST /a9bca2f0f84b54086ceebe590316fff3
+openapi: /openapi/polygon_node_api/filter_handling/eth_uninstallFilter.json POST /0615fdf3c9eaf0681469e61a4308ea09
 description: "Polygon API method used to remove a filter previously created using one of the following methods:. Use it on Polygon via Chainstack."
 ---
 


### PR DESCRIPTION
The Polygon node API reference pages (under **API → Node APIs → Polygon node API**) had their "Try it" endpoint and code samples pointing at the **retired Erigon demo node**. That node no longer reflects the live Polygon service — most importantly, trace calls there return misleading results versus the Bor end-state we now document.

This swaps every Polygon node API spec and reference page to the current **Polygon Bor Global Node** demo endpoint (archive + debug/trace).

## Scope

- **41 OpenAPI specs** under `openapi/polygon_node_api/` — `servers` host + operation path.
- **39 reference pages** — the `openapi:` frontmatter path.
- Covers both the `polygon-*` pages and the older unprefixed pages (`chainid`, `getcode`, `ethcall`, …) — all are in the Polygon node API nav section.
- One spec (`eth_sendRawTransactionSync`) was already on the new endpoint.

Only the endpoint host and token changed (121 lines); line endings preserved, no whitespace churn.

## Verified live

Confirmed the new endpoint serves everything the references exercise: **bor v2.9.0**, chainId **0x89**, archive state (balance at block 1,000,000), `callTracer` + `flatCallTracer`, `debug_traceBlockByNumber`, and the `bor_*` namespace (`bor_getAuthor`, `bor_getSignersAtHash`) — all respond correctly.

`mint broken-links` clean.