### PR TITLE
docs: fix Sui mainnet faucet + Gnosis archive client reference

### DIFF
--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -131,9 +131,9 @@ To enable debug and trace APIs on your Ronin node, deploy a [Global Node](/docs/
 
 ### Gnosis Chain
 
-To enable debug and trace APIs on your Gnosis Chain node, you must deploy a Dedicated Node in the full or archive mode. The node will expose the `debug_*` and `trace_*` API methods. A dedicated debug and trace node for Gnosis Chain is available starting from a [paid plan](https://chainstack.com/pricing/).
+To enable debug and trace APIs on your Gnosis Chain node, you must deploy a Dedicated Node in the full or archive mode. The node will expose the `debug_*` and `trace_*` API methods. A dedicated debug and trace node for Gnosis Chain is available starting from a [paid plan](https://chainstack.com/pricing/). Full-mode nodes run Nethermind; archive-mode nodes run Erigon.
 
-For the full list of the available debug and trace API methods, see [Nethermind documentation](https://docs.nethermind.io/nethermind/ethereum-client/json-rpc).
+For the full list of available debug and trace API methods, see the [Nethermind documentation](https://docs.nethermind.io/nethermind/ethereum-client/json-rpc) for full-mode nodes, or the [Erigon documentation](https://docs.erigon.tech/) for archive-mode nodes.
 
 ### Fantom
 

--- a/docs/protocols-clients.mdx
+++ b/docs/protocols-clients.mdx
@@ -47,7 +47,7 @@ Archive nodes run **Reth** (the [`reth-bsc`](https://github.com/paradigmxyz/reth
 
 ## Gnosis Chain
 
-* **Execution layer** — [Nethermind](https://github.com/NethermindEth/nethermind), the .NET implementation. See the JSON-RPC reference in the [Nethermind documentation](https://docs.nethermind.io/).
+* **Execution layer** — [Nethermind](https://github.com/NethermindEth/nethermind) (.NET implementation) for full nodes, and [Erigon](https://github.com/erigontech/erigon) for archive nodes. See the JSON-RPC reference in the [Nethermind](https://docs.nethermind.io/) and [Erigon](https://docs.erigon.tech/) documentation.
 * **Consensus layer** — [Lighthouse](https://github.com/sigp/lighthouse).
 
 ## Harmony

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1283,7 +1283,7 @@
       "dedicated_node_availability": "Platform",
       "mainnet": {
         "network_name": "Mainnet",
-        "faucet_url": "https://faucet.sui.io/",
+        "faucet_url": "N/A",
         "locations": [
           {
             "cloud": "Chainstack Global Network",


### PR DESCRIPTION
Two small, verified corrections from reconciling the node-options master list against the actual platform state.

## 1. Sui mainnet `faucet_url` → `N/A`
`node-options-master-list.json` listed a faucet URL on **Sui mainnet** — mainnet has no faucet; the value was a copy-paste from the testnet entry (every other protocol uses `N/A` on mainnet). Testnet faucet left unchanged.

## 2. Gnosis Chain client: archive is now Erigon
The docs attributed Gnosis Chain to **Nethermind** only. Gnosis **archive** nodes now run **Erigon** (full nodes remain Nethermind). Verified against live nodes — `Nethermind/v1.36.2` (full) and `erigon/3.5.2` (archive).

- `docs/protocols-clients.mdx` — execution layer now notes Nethermind (full) + Erigon (archive).
- `docs/debug-and-trace-apis.mdx` — Gnosis debug/trace section notes the per-mode client and points to both clients' method references.

`mint broken-links` clean.