### PR TITLE
fix(docs): update deprecated URLs and packages in zksync-era, ethereum, and sui tooling

### DIFF
--- a/docs/ethereum-tooling.mdx
+++ b/docs/ethereum-tooling.mdx
@@ -459,7 +459,7 @@ Configure [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2) to de
        solidity: "0.8.20", // Ensure to specify the correct Solidity version
        networks: {
          mainnet: {
-           url: process.env.CHAINSTACK_MAINNET_ENDPOINT || `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`, // Use the Chainstack mainnet endpoint
+           url: process.env.CHAINSTACK_MAINNET_ENDPOINT || `https://eth-mainnet.g.alchemy.com/v2/${providerApiKey}`, // Use the Chainstack mainnet endpoint
            // accounts: [process.env.DEPLOYER_PRIVATE_KEY_MAINNET as string], // Mainnet private key
          },
          sepolia: {

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -210,14 +210,14 @@ The [Sui TypeScript SDK](https://github.com/MystenLabs/sui/tree/main/sdk/typescr
 ### Installation
 
 ```bash
-npm install @mysten/sui.js
+npm install @mysten/sui
 ```
 
 ### Basic usage
 
 <CodeGroup>
   ```typescript Connection
-  import { SuiClient, getFullnodeUrl } from '@mysten/sui.js/client';
+  import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
   
   // Connect to your Chainstack node
   const client = new SuiClient({
@@ -230,7 +230,7 @@ npm install @mysten/sui.js
   ```
 
   ```typescript Query Objects
-  import { SuiClient } from '@mysten/sui.js/client';
+  import { SuiClient } from '@mysten/sui/client';
   
   const client = new SuiClient({
     url: 'YOUR_CHAINSTACK_ENDPOINT'
@@ -247,22 +247,22 @@ npm install @mysten/sui.js
   ```
 
   ```typescript Send Transaction
-  import { SuiClient } from '@mysten/sui.js/client';
-  import { TransactionBlock } from '@mysten/sui.js/transactions';
-  import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
+  import { SuiClient } from '@mysten/sui/client';
+  import { Transaction } from '@mysten/sui/transactions';
+  import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
   
   const client = new SuiClient({
     url: 'YOUR_CHAINSTACK_ENDPOINT'
   });
   
   const keypair = Ed25519Keypair.generate();
-  const tx = new TransactionBlock();
+  const tx = new Transaction();
   
   // Add transaction commands
   tx.transferObjects([objectId], recipient);
   
   // Sign and execute
-  const result = await client.signAndExecuteTransactionBlock({
+  const result = await client.signAndExecuteTransaction({
     signer: keypair,
     transactionBlock: tx,
   });

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -257,6 +257,8 @@ npm install @mysten/sui
   
   const keypair = Ed25519Keypair.generate();
   const tx = new Transaction();
+  const objectId = '0x<OBJECT_ID>'; // Replace with your object ID
+  const recipient = '0x<RECIPIENT_ADDRESS>'; // Replace with recipient address
   
   // Add transaction commands
   tx.transferObjects([objectId], recipient);
@@ -264,7 +266,7 @@ npm install @mysten/sui
   // Sign and execute
   const result = await client.signAndExecuteTransaction({
     signer: keypair,
-    transactionBlock: tx,
+    transaction: tx,
   });
   ```
 </CodeGroup>

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -57,7 +57,7 @@ Configure [Hardhat](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync)
         ethNetwork: "sepolia",
         zksync: true,
         verifyURL:
-          "https://zksync2-testnet-explorer.zksync.dev/contract_verification",
+          "https://explorer.sepolia.era.zksync.dev/contract_verification",
       },
     },
     solidity: {


### PR DESCRIPTION
## What

Fixes three documentation issues involving deprecated URLs and packages across three tooling guides.

## Changes

**`zksync-era-tooling.mdx`** The Hardhat `verifyURL` pointed to `zksync2-testnet-explorer.zksync.dev`, a pre-rebrand zkSync 2.0 subdomain that no longer resolves. Replaced with the current zkSync Era Sepolia explorer URL.

**`ethereum-tooling.mdx`** The Scaffold-ETH 2 mainnet fallback URL used the deprecated `alchemyapi.io` domain, while the Sepolia fallback in the same code block already used the current `alchemy.com` format. Made consistent.

**`sui-tooling.mdx`** The JSON-RPC section referenced the legacy `@mysten/sui.js` package (deprecated, superseded by `@mysten/sui`). Updated install command, all import paths, and two renamed APIs:
- `TransactionBlock` → `Transaction`
- `signAndExecuteTransactionBlock` → `signAndExecuteTransaction`

The gRPC section in the same file already used `@mysten/sui` correctly only the JSON-RPC section needed updating.

## Closes

Fixes #589, #590, #591