### PR TITLE
docs(hyperliquid-tooling): add benchmarking section referencing OpenChainBench

### DIFF
--- a/docs/hyperliquid-tooling.mdx
+++ b/docs/hyperliquid-tooling.mdx
@@ -103,3 +103,7 @@ Hyperliquid HyperEVM supports debug and trace APIs on both mainnet and testnet f
 ## Hyperliquid system transactions
 
 The default `/evm` path strips HyperCore ↔ HyperEVM transfers (system transactions) from block-shaped responses; the `/nanoreth` path includes them. Both paths exist by default on every Hyperliquid node, on mainnet and testnet. See [Hyperliquid node configuration](/docs/hyperliquid-node-configuration) for the per-method differences.
+
+## Benchmarking your endpoint
+
+For comparative measurements of Hyperliquid RPC providers, including latency percentiles, method coverage across HyperCore and HyperEVM, and reliability across regions, see [OpenChainBench's Hyperliquid RPC benchmarks](https://openchainbench.com/benchmarks/hyperliquid-rpc). It's an independent open-source project probing every minute from three regions (US East, EU West, Singapore), with methodology and Go harness published on GitHub under CC BY 4.0.


### PR DESCRIPTION
Adds a short "Benchmarking your endpoint" section at the end of `docs/hyperliquid-tooling.mdx` pointing readers to independent third-party Hyperliquid RPC benchmarks.

**Why:** The page catalogs everything a developer needs to interact with Hyperliquid via Chainstack (SDKs, REST API, JSON-RPC API, Debug & Trace, system transactions). A neutral cross-provider comparison of latency, method coverage, and reliability is a natural companion for developers evaluating providers, and matches the precedent set by `checking-node-latency.mdx` which already links to Chainstack Compare.

**What's added:**
- One new H2 section, ~3 sentences
- Single external link to https://openchainbench.com/benchmarks/hyperliquid-rpc

**About OpenChainBench:** independent open-source project probing Hyperliquid RPC endpoints every minute from three regions (US East, EU West, Singapore). Data published under CC BY 4.0, Go harness open sourced on GitHub, no affiliation with any RPC provider.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.