### PR TITLE
docs: modernize Sui/Ethereum/zkSync tooling to current SDKs and flows

### DIFF
--- a/docs/ethereum-tooling.mdx
+++ b/docs/ethereum-tooling.mdx
@@ -459,7 +459,7 @@ Configure [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2) to de
        solidity: "0.8.20", // Ensure to specify the correct Solidity version
        networks: {
          mainnet: {
-           url: process.env.CHAINSTACK_MAINNET_ENDPOINT || `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`, // Use the Chainstack mainnet endpoint
+           url: process.env.CHAINSTACK_MAINNET_ENDPOINT || `https://eth-mainnet.g.alchemy.com/v2/${providerApiKey}`, // Use the Chainstack mainnet endpoint
            // accounts: [process.env.DEPLOYER_PRIVATE_KEY_MAINNET as string], // Mainnet private key
          },
          sepolia: {

--- a/docs/sui-tooling.mdx
+++ b/docs/sui-tooling.mdx
@@ -210,29 +210,33 @@ The [Sui TypeScript SDK](https://github.com/MystenLabs/sui/tree/main/sdk/typescr
 ### Installation
 
 ```bash
-npm install @mysten/sui.js
+npm install @mysten/sui
 ```
+
+<Note>
+The SDK was renamed from `@mysten/sui.js` to `@mysten/sui`, and the JSON-RPC client is now `SuiJsonRpcClient` from `@mysten/sui/jsonRpc` (previously `SuiClient` from `@mysten/sui.js/client`). See the [SDK 2.0 migration guide](https://sdk.mystenlabs.com/sui/migrations/sui-2.0).
+</Note>
 
 ### Basic usage
 
 <CodeGroup>
   ```typescript Connection
-  import { SuiClient, getFullnodeUrl } from '@mysten/sui.js/client';
+  import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
   
   // Connect to your Chainstack node
-  const client = new SuiClient({
+  const client = new SuiJsonRpcClient({
     url: 'YOUR_CHAINSTACK_ENDPOINT'
   });
   
-  // Get latest checkpoint
+  // Get the latest checkpoint
   const checkpoint = await client.getLatestCheckpointSequenceNumber();
   console.log('Latest checkpoint:', checkpoint);
   ```
 
   ```typescript Query Objects
-  import { SuiClient } from '@mysten/sui.js/client';
+  import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
   
-  const client = new SuiClient({
+  const client = new SuiJsonRpcClient({
     url: 'YOUR_CHAINSTACK_ENDPOINT'
   });
   
@@ -247,24 +251,28 @@ npm install @mysten/sui.js
   ```
 
   ```typescript Send Transaction
-  import { SuiClient } from '@mysten/sui.js/client';
-  import { TransactionBlock } from '@mysten/sui.js/transactions';
-  import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
+  import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+  import { Transaction } from '@mysten/sui/transactions';
+  import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
   
-  const client = new SuiClient({
+  const client = new SuiJsonRpcClient({
     url: 'YOUR_CHAINSTACK_ENDPOINT'
   });
   
   const keypair = Ed25519Keypair.generate();
-  const tx = new TransactionBlock();
+  const tx = new Transaction();
+  
+  // Replace with your object ID and recipient address
+  const objectId = 'YOUR_OBJECT_ID';
+  const recipient = 'RECIPIENT_ADDRESS';
   
   // Add transaction commands
   tx.transferObjects([objectId], recipient);
   
   // Sign and execute
-  const result = await client.signAndExecuteTransactionBlock({
+  const result = await client.signAndExecuteTransaction({
     signer: keypair,
-    transactionBlock: tx,
+    transaction: tx,
   });
   ```
 </CodeGroup>

--- a/docs/zksync-era-tooling.mdx
+++ b/docs/zksync-era-tooling.mdx
@@ -13,14 +13,18 @@ On [node access details](/docs/manage-your-node#view-node-access-and-credentials
 
 ## Development tools
 
+<Note>
+ZKsync Era runs standard EVM bytecode through its [EVM Bytecode Interpreter](https://docs.zksync.io/zksync-era/tooling/hardhat), so for most new projects you can use standard Ethereum tooling — Hardhat, Foundry, ethers, or viem — pointed at your Chainstack ZKsync Era endpoint, exactly like any other EVM chain. The EraVM-native workflow below (the `hardhat-zksync` plugin suite with the `zksolc` compiler) remains for contracts that target EraVM directly.
+</Note>
+
 ### zksync-ethers SDK
 
 See [zksync-ethers](https://github.com/zksync-sdk/zksync-ethers).
 
-### Hardhat
+### Hardhat (EraVM-native)
 
-Configure [Hardhat](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync) to deploy contracts and interact through your zkSync Era nodes.
-1. Install [Hardhat](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync) and create a project.
+To compile and deploy contracts that target EraVM natively, configure the [hardhat-zksync](https://docs.zksync.io/zksync-era/tooling/hardhat) plugin suite to build and interact through your zkSync Era nodes. For standard EVM contracts, use a normal Hardhat setup pointed at your Chainstack endpoint instead (see the note above).
+1. Install [Hardhat](https://docs.zksync.io/zksync-era/tooling/hardhat) and create a project.
 
    <CodeGroup>
      ```shell Shell
@@ -57,7 +61,7 @@ Configure [Hardhat](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync)
         ethNetwork: "sepolia",
         zksync: true,
         verifyURL:
-          "https://zksync2-testnet-explorer.zksync.dev/contract_verification",
+          "https://explorer.sepolia.era.zksync.dev/contract_verification",
       },
     },
     solidity: {


### PR DESCRIPTION
## What

Fixes real deprecations in three tooling pages **at source**, going further than the drive-by PR #592 where the upstream SDK/flow had moved on. Reported by @Sertug17 in #589 / #590 / #591 — thanks for flagging.

## Changes (all verified against current reality)

- **Sui** (`sui-tooling.mdx`) — the JSON-RPC examples used the deprecated `@mysten/sui.js` + `SuiClient`. On the **current `@mysten/sui` (2.22.1)**, `SuiClient` from `@mysten/sui/client` **no longer exists** — the JSON-RPC client is now **`SuiJsonRpcClient` from `@mysten/sui/jsonRpc`** (with `Transaction` / `signAndExecuteTransaction`). Rewrote the examples to the current API and added a migration `<Note>`. *Live-verified against a Chainstack Sui node:* `SuiJsonRpcClient` + `getReferenceGasPrice` (=100), `getObject`, `getOwnedObjects`, `getLatestCheckpointSequenceNumber` all confirmed present/working. (The drive-by PR's `SuiClient@/client` would have been broken on 2.22.1.)
- **Ethereum** (`ethereum-tooling.mdx`) — Scaffold-ETH 2 mainnet fallback used the legacy `alchemyapi.io` domain while the Sepolia fallback already used `g.alchemy.com`. Made consistent. (Scaffold-ETH 2 confirmed actively maintained — `create-eth` 2.0.22, Jul 2026.)
- **zkSync Era** (`zksync-era-tooling.mdx`) — dead pre-rebrand verifier URL → current Era Sepolia URL (verified live). Also **reframed the page**: ZKsync now recommends **standard EVM tooling via the EVM Bytecode Interpreter** for new projects, so that's now the headline; the EraVM `hardhat-zksync` flow is relabeled as the native/legacy path (still valid for EraVM-targeted contracts).

Closes #589, #590, #591 (supersedes #592).

## Gates
- `mintlify broken-links` — no broken links
- `mintlify validate` — build validation passed