### PR TITLE
docs: clarify what mempool access actually requires

### DIFF
--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -15,6 +15,10 @@ By using debug and trace APIs, developers can build more reliable and secure DAp
   To debug and trace transactions, you need to have historical states on the node. Full nodes of different protocols can [store different amount of historical states](/docs/protocols-modes-and-types#modes). At the same time, archive nodes keep historical states for the *entire chain*.
 </Info>
 
+<Note>
+  The debug and trace APIs do not include the mempool. The `txpool_*` methods are a separate namespace with their own requirements — see [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+</Note>
+
 ## Protocols with debug and trace APIs
 
 ### Ethereum

--- a/docs/dedicated-node.mdx
+++ b/docs/dedicated-node.mdx
@@ -24,9 +24,9 @@ For the full list of chains available as Dedicated Nodes, see [Networks](/docs/p
 </Check>
 
 <Note>
-  ### Mempool access is separate from debug and trace
+  ### Pool inspection is separate from debug and trace
 
-  `txpool_*` is its own namespace, so enabling debug and trace does not enable the mempool. A Dedicated Node can serve `txpool_*` in the full mode as well as the archive mode — ask for it when you deploy. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+  `txpool_*` is its own namespace, so enabling debug and trace does not enable the pool-inspection methods. A Dedicated Node can serve `txpool_*` in the full mode as well as the archive mode — ask for it when you deploy. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
 </Note>
 
 <Note>

--- a/docs/dedicated-node.mdx
+++ b/docs/dedicated-node.mdx
@@ -24,6 +24,12 @@ For the full list of chains available as Dedicated Nodes, see [Networks](/docs/p
 </Check>
 
 <Note>
+  ### Mempool access is separate from debug and trace
+
+  `txpool_*` is its own namespace, so enabling debug and trace does not enable the mempool. A Dedicated Node can serve `txpool_*` in the full mode as well as the archive mode — ask for it when you deploy. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+</Note>
+
+<Note>
   ### TON Dedicated Nodes: ADNL protocol support
 
   TON Dedicated Nodes support the [ADNL protocol](https://docs.ton.org/v3/documentation/network/protocols/adnl/overview) in addition to the standard HTTP API. ADNL (Abstract Datagram Network Layer) provides secure, low-level network communication for advanced TON blockchain interactions and specialized use cases.

--- a/docs/evm-transaction-pool-pending-vs-queued.mdx
+++ b/docs/evm-transaction-pool-pending-vs-queued.mdx
@@ -8,6 +8,10 @@ description: "Understand pending vs queued transactions in an EVM node's local p
 * **Queued** transactions are sitting locally because their account nonce is out of sequence; they don't propagate until the gap is filled.
 * Inspect the pool with `txpool_status` / `txpool_content`; subscribe to new pending transactions with `eth_subscribe`; fix a queued transaction by filling the nonce gap.
 
+<Note>
+  The `txpool_*` methods on this page need an archive-mode node — a full-mode node returns `-32601` for them. The `eth_subscribe` part works in either mode. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+</Note>
+
 ## Pending vs queued
 
 A transaction submitted through an EVM node has one of two states before it lands in a block:

--- a/docs/mempool-configuration.mdx
+++ b/docs/mempool-configuration.mdx
@@ -9,22 +9,29 @@ The table here is a maintained reference of mempool configurations & specifics a
 
 ## What gives you mempool access
 
-The node mode gives you mempool access. The debug and trace APIs do not.
+Two different things get called mempool access, and they have different requirements. On the EVM chains with a public mempool — Ethereum, Polygon, and BNB Smart Chain:
 
-On the EVM chains with a public mempool — Ethereum, Polygon, and BNB Smart Chain — Chainstack serves the `txpool_*` methods on archive nodes. Full-mode [Global Nodes](/docs/global-elastic-node) and [Trader Nodes](/docs/trader-node) do not serve them. A [Dedicated Node](/docs/dedicated-node) can serve them in the full mode too — that one is a [customization](/docs/features-availability-across-subscription-plans#node-customization), so ask for it when you deploy.
+| What you want                             | Methods                                                                     | Full mode     | Archive mode |
+| ----------------------------------------- | --------------------------------------------------------------------------- | ------------- | ------------ |
+| Watch pending transactions as they arrive | `eth_subscribe("newPendingTransactions")`, `eth_newPendingTransactionFilter` | Available     | Available    |
+| Inspect the transaction pool itself       | `txpool_content`, `txpool_status`, `txpool_inspect`                          | Not available | Available    |
 
-`txpool_*` is a separate namespace from `debug_*` and `trace_*`, and each one has its own gate:
+For a live feed of pending transactions, a full-mode node is enough. The feed is the node's view of the public mempool — transactions that reached it over the p2p network, not only the ones you submitted through it. No node sees every pending transaction, as each node's view depends on its peers.
+
+The `txpool_*` namespace is the part that needs the archive mode. A [Dedicated Node](/docs/dedicated-node) can serve `txpool_*` in the full mode too — that one is a [customization](/docs/features-availability-across-subscription-plans#node-customization), so ask for it when you deploy.
+
+`txpool_*` is also a separate namespace from `debug_*` and `trace_*`, and each one has its own gate:
 
 * `txpool_*` — the node mode enables it, not your plan. It works on an archive node even when your plan has no debug and trace access.
-* `debug_*` and `trace_*` — your [plan](/docs/features-availability-across-subscription-plans#debug-and-trace-apis) enables them. They also work on full-mode nodes, and they do not bring the mempool with them.
+* `debug_*` and `trace_*` — your [plan](/docs/features-availability-across-subscription-plans#debug-and-trace-apis) enables them. They also work on full-mode nodes, and they do not bring `txpool_*` with them.
 
-This means a full-mode node with the debug and trace APIs enabled still has no mempool by default. Calling `txpool_content` on such a node returns:
+So enabling the debug and trace APIs on a full-mode node does not give you the pool methods. Calling `txpool_content` on such a node returns:
 
 ```json
 {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method txpool_content is not available"}}
 ```
 
-To get the mempool methods, deploy the node in the [archive mode](/docs/protocols-modes-and-types#modes), or ask for `txpool_*` on a full-mode [Dedicated Node](/docs/dedicated-node). Trader Nodes are regional and not every region offers the archive mode, so check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for your region before you deploy.
+To get the `txpool_*` methods, deploy the node in the [archive mode](/docs/protocols-modes-and-types#modes), or ask for them on a full-mode [Dedicated Node](/docs/dedicated-node). Trader Nodes are regional and not every region offers the archive mode, so check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for your region before you deploy.
 
 <Note>
 On protocols with no public mempool, pending-transaction methods like `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` return empty by design — pending transactions are visible only to the sequencer. On Base and Optimism, follow transactions in real time with Flashblocks instead — see the how-to guides ([Base](/docs/base-streaming-transactions-flashblocks), [Optimism](/docs/optimism-streaming-transactions-flashblocks)) or how Flashblocks works ([Base](/docs/flashblocks-on-base), [Optimism](/docs/flashblocks-on-optimism)).
@@ -34,7 +41,7 @@ The table structure:
 
 * Protocol — protocol name.
 * Protocol availability — details of the mempool availability on the protocol level.
-* Chainstack availability — how to access the protocol's mempool on Chainstack.
+* Chainstack availability — what you need to deploy for the protocol's pool-inspection methods on Chainstack.
 * Client configuration — the default node client configuration for the mempool as deployed at Chainstack.
 * Example — a simple curl example. Remember to replace YOUR\_CHAINSTACK\_NODE with your Chainstack node endpoint for that particular protocol.
 

--- a/docs/mempool-configuration.mdx
+++ b/docs/mempool-configuration.mdx
@@ -7,6 +7,25 @@ Mempool configurations vary wildly across different protocols & node client conf
 
 The table here is a maintained reference of mempool configurations & specifics across all the protocols that Chainstack supports.
 
+## What gives you mempool access
+
+The node mode gives you mempool access. The debug and trace APIs do not.
+
+On the EVM chains with a public mempool — Ethereum, Polygon, and BNB Smart Chain — Chainstack serves the `txpool_*` methods on archive nodes. Full-mode [Global Nodes](/docs/global-elastic-node) and [Trader Nodes](/docs/trader-node) do not serve them. A [Dedicated Node](/docs/dedicated-node) can serve them in the full mode too — that one is a [customization](/docs/features-availability-across-subscription-plans#node-customization), so ask for it when you deploy.
+
+`txpool_*` is a separate namespace from `debug_*` and `trace_*`, and each one has its own gate:
+
+* `txpool_*` — the node mode enables it, not your plan. It works on an archive node even when your plan has no debug and trace access.
+* `debug_*` and `trace_*` — your [plan](/docs/features-availability-across-subscription-plans#debug-and-trace-apis) enables them. They also work on full-mode nodes, and they do not bring the mempool with them.
+
+This means a full-mode node with the debug and trace APIs enabled still has no mempool by default. Calling `txpool_content` on such a node returns:
+
+```json
+{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method txpool_content is not available"}}
+```
+
+To get the mempool methods, deploy the node in the [archive mode](/docs/protocols-modes-and-types#modes), or ask for `txpool_*` on a full-mode [Dedicated Node](/docs/dedicated-node). Trader Nodes are regional and not every region offers the archive mode, so check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for your region before you deploy.
+
 <Note>
 On protocols with no public mempool, pending-transaction methods like `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` return empty by design — pending transactions are visible only to the sequencer. On Base and Optimism, follow transactions in real time with Flashblocks instead — see the how-to guides ([Base](/docs/base-streaming-transactions-flashblocks), [Optimism](/docs/optimism-streaming-transactions-flashblocks)) or how Flashblocks works ([Base](/docs/flashblocks-on-base), [Optimism](/docs/flashblocks-on-optimism)).
 </Note>
@@ -23,9 +42,9 @@ Remember that whatever the default configuration, we can always [customize](/doc
 
 | Protocol        | Protocol availability                                                                                                                                                    | Chainstack availability                                                                            | Client configuration                                        | Example                                                |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------ |
-| Ethereum        | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types) with [Debug and trace APIs](/docs/debug-and-trace-apis) | 4096 pending transactions                                   | [Ethereum txpool\_content](#ethereum-txpool_content)   |
-| Polygon         | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types) with [Debug and trace APIs](/docs/debug-and-trace-apis) | 4096 pending transactions                                   | [Polygon txpool\_content](#polygon-txpool_content)     |
-| BNB Smart Chain | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types) with [Debug and trace APIs](/docs/debug-and-trace-apis) | 4096 pending transactions                                   | [BSC txpool\_content](#bsc-txpool_content)             |
+| Ethereum        | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types#modes) mode                                              | 4096 pending transactions                                   | [Ethereum txpool\_content](#ethereum-txpool_content)   |
+| Polygon         | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types#modes) mode                                              | 4096 pending transactions                                   | [Polygon txpool\_content](#polygon-txpool_content)     |
+| BNB Smart Chain | Available to everyone                                                                                                                                                    | [Archive](/docs/protocols-modes-and-types#modes) mode                                              | 4096 pending transactions                                   | [BSC txpool\_content](#bsc-txpool_content)             |
 | Base            | [Private to Sequencer](https://github.com/base/node/issues/78).                                                                                                      | N/A                                                                                                | N/A                                                         | N/A                                                    |
 | Avalanche       | [Available only to validators](https://support.avax.network/en/articles/6158842-nodes-faq).                                                                              | Not available on Chainstack                                                                        | N/A                                                         | N/A                                                    |
 | TON             | External messages are available in mempool                                                                                                                               | Available                                                                                          |                                                             |                                                        |

--- a/docs/protocols-modes-and-types.mdx
+++ b/docs/protocols-modes-and-types.mdx
@@ -23,6 +23,8 @@ For most of the available public chains, Chainstack supports deploying nodes in 
   Archive semantics can also vary by protocol — for example, TRON archive mode serves the complete block and transaction history but not historical state, because java-tron has no state-at-block queries. See [TRON historical data availability](/docs/tron-tooling#historical-data-availability).
 
   Node mode describes data retention, not pricing. Requests are billed by request class — on some protocols every request bills as full even on archive-mode nodes. See [Request units](/docs/request-units).
+
+  On the EVM chains with a public mempool, the archive mode also enables the `txpool_*` pool-inspection methods. Subscribing to pending transactions works in either mode. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
 </Note>
 
 <Info>

--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -22,9 +22,9 @@ For Trader Nodes deployed on the most of public chains, Chainstack supports the 
 
 ## Mode and mempool availability by region
 
-Trader Nodes are bound to a single region, and the modes on offer differ from region to region. Because the `txpool_*` methods need the archive mode, a region that offers only the full mode gives you no mempool access. On Ethereum Mainnet, for example, Trader Nodes are archive in London (lon1) and Ashburn (ash1), and full mode only in Singapore (sgp1).
+Trader Nodes are bound to a single region, and the modes on offer differ from region to region. Because the `txpool_*` methods need the archive mode, a region that offers only the full mode gives you no pool inspection — though subscribing to pending transactions still works there. On Ethereum Mainnet, for example, Trader Nodes are archive in London (lon1) and Ashburn (ash1), and full mode only in Singapore (sgp1).
 
-Check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for the modes in your region, and [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access) for the rule itself. If you need both a specific region and the mempool, and no Trader Node region offers it, deploy a [Dedicated Node](/docs/dedicated-node) instead and ask for the mempool on it — a Dedicated Node can serve `txpool_*` in either mode.
+Check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for the modes in your region, and [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access) for the rule itself. If you need `txpool_*` in a region that offers only the full mode, deploy a [Dedicated Node](/docs/dedicated-node) there instead and ask for it — a Dedicated Node can serve `txpool_*` in either mode.
 
 ## Warp transactions
 

--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -20,6 +20,12 @@ For Trader Nodes deployed on the most of public chains, Chainstack supports the 
 * Full — a node that stores full blockchain data. However, it has limitations to how many blocks are available for querying.
 * Archive — a node that stores full blockchain data and an archive of historical states, which makes it possible to query any block since the chain genesis.
 
+## Mode and mempool availability by region
+
+Trader Nodes are bound to a single region, and the modes on offer differ from region to region. Because the `txpool_*` methods need the archive mode, a region that offers only the full mode gives you no mempool access. On Ethereum Mainnet, for example, Trader Nodes are archive in London (lon1) and Ashburn (ash1), and full mode only in Singapore (sgp1).
+
+Check [Available clouds, regions, & locations](/docs/nodes-clouds-regions-and-locations) for the modes in your region, and [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access) for the rule itself. If you need both a specific region and the mempool, and no Trader Node region offers it, deploy a [Dedicated Node](/docs/dedicated-node) instead and ask for the mempool on it — a Dedicated Node can serve `txpool_*` in either mode.
+
 ## Warp transactions
 
 [Warp transactions](/docs/warp-transactions) propagate and land your transactions at the fastest speed possible. They are now a node [add-on](/docs/add-ons) you install on Trader and Global Nodes from the node's **Add-ons** tab, rather than a deployment-time option.


### PR DESCRIPTION
## Problem

Two pages each stated something true, and together they implied something false.

- **Mempool configurations** listed the Ethereum, Polygon, and BNB Smart Chain availability as *"Archive with Debug and trace APIs"*.
- **Dedicated Node** states that *"regardless of mode, all Dedicated Nodes will have debug and trace API enabled"*.

Read together, those say a full-mode node with debug and trace has mempool access. It does not. And the page never separated the two very different things people mean by "mempool access", so the archive requirement got applied to both.

This is a purchase-decision fact — full and archive are materially different price points — so getting it wrong sends people to sales instead of to the answer.

## What was verified

Probed against running nodes rather than inferred from the client docs.

**Streaming and inspecting are gated differently:**

| What you want | Methods | Full mode | Archive mode |
|---|---|---|---|
| Watch pending transactions | `eth_subscribe("newPendingTransactions")`, `eth_newPendingTransactionFilter` | works | works |
| Inspect the pool | `txpool_content`, `txpool_status`, `txpool_inspect` | `-32601` | works |

**Debug and trace is orthogonal to both** — neither sufficient nor necessary:

| Configuration | `txpool_*` |
|---|---|
| Full mode, debug and trace **enabled** | `-32601 the method txpool_content is not available` |
| Archive mode, debug and trace **plan-gated off** (`-32002`) | works |

Confirmed on Ethereum, Polygon, and BNB Smart Chain.

**The streaming feed is the public mempool, not just local submissions.** Subscribing on two independent nodes in different regions over the same window, with nothing submitted from this side: they shared 88% of the smaller node's pending set, and hashes seen on only one node resolved through `eth_getTransactionByHash` on the other.

Two further facts that were not documented anywhere:

- A Dedicated Node can serve `txpool_*` in the full mode as a customization, so archive is not the only route.
- Trader Node modes vary by region, so a full-mode-only region has no pool inspection. On Ethereum Mainnet that means archive in `lon1` and `ash1`, and full mode only in `sgp1`.

## Changes

- **`mempool-configuration`** — new answer-first *"What gives you mempool access"* section: the streaming-vs-inspection table, what the feed actually contains, the per-namespace gates, the `-32601` signature of the wrong configuration, and the full-mode Dedicated Node option. Removed `with [Debug and trace APIs]` from the Ethereum, Polygon, and BSC availability cells.
- **`dedicated-node`** — a note directly under the debug and trace callout, since that is the sentence being misread.
- **`debug-and-trace-apis`** — the same disambiguation at the top of the page.
- **`trader-node`** — new *"Mode and mempool availability by region"* section.
- **`protocols-modes-and-types`** — the modes section now says archive adds `txpool_*` and that subscribing works in either mode, so the distinction is visible at the point where people choose a mode.
- **`evm-transaction-pool-pending-vs-queued`** — flags that its `txpool_*` examples need archive while its `eth_subscribe` example does not.

## Validation

`mintlify broken-links` passes clean.