### PR TITLE
changelog: MCP faucet — Robinhood Chain testnet added, Scroll removed (July 27, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: July 27, 2026" description=" by Ake">
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet now supports Robinhood Chain testnet (`request_testnet_funds` with `network="robinhood"`), replacing the retired Scroll Sepolia.
+
+<Button href="/changelog/chainstack-updates-july-27-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 23, 2026" description=" by Ake">
 
 **MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet now advertises its supported networks to your agent and accepts common aliases (`ethereum-sepolia` → `sepolia`, `solana-devnet` → `solana`), so testnet fund requests land on the first try instead of failing on a wrong-network name.

--- a/changelog/chainstack-updates-july-27-2026.mdx
+++ b/changelog/chainstack-updates-july-27-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: July 27, 2026"
+description: "The Chainstack MCP server's testnet faucet now supports Robinhood Chain testnet, replacing the retired Scroll Sepolia."
+---
+
+**MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet (`request_testnet_funds`) now supports **Robinhood Chain testnet** — request funds with `network="robinhood"` (it tops up to 1 ETH), and common aliases like `robinhood-chain` and `robinhood-testnet` resolve automatically. Scroll Sepolia has been retired from the faucet, so `scroll-sepolia-testnet` is no longer available. The supported testnet count is unchanged at 12.

--- a/docs.json
+++ b/docs.json
@@ -3194,6 +3194,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-july-27-2026",
           "changelog/chainstack-updates-july-23-2026",
           "changelog/chainstack-updates-july-22-2026",
           "changelog/chainstack-updates-july-21-2026",


### PR DESCRIPTION
Docs release note for the July 27, 2026 MCP server update — the testnet faucet now supports Robinhood Chain testnet, replacing the retired Scroll Sepolia.

Three coordinated edits: new `changelog/chainstack-updates-july-27-2026.mdx`, `<Update>` feed block in `changelog.mdx` (newest-first), nav entry in `docs.json`. `mint broken-links`: clean.