### PR TITLE
CORE-15421 self-hosted release notes v2.10.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3455,6 +3455,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-9-1-july-23-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-9-0-july-22-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-8-2-july-22-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026.mdx
@@ -1,0 +1,33 @@
+---
+title: "Chainstack Self-Hosted v2.10.0: July 27, 2026"
+description: "Arbitrum One and Arbitrum Sepolia are now available as deployment targets."
+---
+
+This release adds Arbitrum One and Arbitrum Sepolia as deployment targets and changes how Ethereum reth nodes handle pruning.
+
+## Arbitrum support
+
+Arbitrum One mainnet and Arbitrum Sepolia are now available as deployment targets, running the Arbitrum Nitro client. You can deploy and manage Arbitrum nodes from the Control Panel with the same workflows as other supported networks, including snapshot-accelerated initial sync.
+
+- **Arbitrum One** — mainnet, chain ID 42161
+- **Arbitrum Sepolia** — testnet, chain ID 421614
+
+Nitro deployments read their chain directory from the network preset, so snapshots packaged in the canonical Nitro layout restore and start correctly.
+
+## Ethereum reth pruning mode
+
+Ethereum mainnet and Sepolia reth deployments now run in full mode rather than archive mode, matching the pruned snapshots they restore from.
+
+- **Affected presets** — Ethereum mainnet, Ethereum mainnet light, Sepolia, and Sepolia light
+- **Receipt history** — full mode retains roughly the most recent 10,000 blocks of receipts
+- **Hoodi** — unaffected, and continues to run in archive mode
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.7.0 |
+| cp-deployments-api | v0.47.0 |
+| cp-workflows | v3.13.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.10.0: July 27, 2026" description="">
+
+This release adds Arbitrum One and Arbitrum Sepolia as deployment targets, running the Arbitrum Nitro client. Ethereum mainnet and Sepolia reth deployments now run in full mode rather than archive mode, matching the pruned snapshots they restore from.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.9.1: July 23, 2026" description="">
 
 This maintenance release renames the Robinhood Chain test network from Sepolia to Testnet across the network and deployment preset catalog. Existing deployments are unaffected.


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.10.0 release note.