### PR TITLE
docs(changelog): add Arc (Circle) testnet protocol support (July 27, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,6 +8,8 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: July 27, 2026" description=" by Ake">
 
+**Protocols**. Chainstack now supports Arc — Circle's USDC-native, EVM-compatible L1 for stablecoin payments. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Arc testnet, in Full and Archive modes with debug and trace.
+
 **MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet now supports Robinhood Chain testnet (`request_testnet_funds` with `network="robinhood"`), replacing the retired Scroll Sepolia.
 
 <Button href="/changelog/chainstack-updates-july-27-2026">Read more</Button>

--- a/changelog/chainstack-updates-july-27-2026.mdx
+++ b/changelog/chainstack-updates-july-27-2026.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Chainstack updates: July 27, 2026"
-description: "The Chainstack MCP server's testnet faucet now supports Robinhood Chain testnet, replacing the retired Scroll Sepolia."
+description: "Chainstack now supports Arc — Circle's USDC-native, EVM-compatible L1 — on Global Nodes and Dedicated Nodes for testnet, and the MCP server faucet adds Robinhood Chain testnet."
 ---
+
+**Protocols**. Chainstack now supports Arc — Circle's USDC-native, EVM-compatible L1 for stablecoin payments. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Arc testnet, in Full and Archive modes with debug and trace.
 
 **MCP Server**. The [Chainstack MCP server](https://mcp.chainstack.com) testnet faucet (`request_testnet_funds`) now supports **Robinhood Chain testnet** — request funds with `network="robinhood"` (it tops up to 1 ETH), and common aliases like `robinhood-chain` and `robinhood-testnet` resolve automatically. Scroll Sepolia has been retired from the faucet, so `scroll-sepolia-testnet` is no longer available. The supported testnet count is unchanged at 12.


### PR DESCRIPTION
## What

Adds an **Arc (Circle)** protocol section to the existing **July 27, 2026** release note. Arc is Circle's USDC-native, EVM-compatible L1 for stablecoin payments; its testnet is now deployable on Chainstack as [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) in Full and Archive modes with debug and trace.

The wording matches the established new-protocol release-note pattern (e.g. Robinhood Chain, July 17).

## Changes

- `changelog.mdx` — new `**Protocols**` paragraph added to the July 27 `<Update>`.
- `changelog/chainstack-updates-july-27-2026.mdx` — same paragraph added; `description` updated to cover Arc.

`docs.json` is unchanged — the July 27 page is already registered.

## Local validation

- `mintlify broken-links` — the `/docs/global-elastic-node` and `/docs/dedicated-node` links resolve; no new broken links.