### PR TITLE
docs: add Arc (Circle) as a new protocol (testnet)

### DIFF
--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -185,7 +185,7 @@ To enable debug and trace APIs on your Arc node, you must have a [paid plan](htt
 
 Arc runs the Reth client, which exposes both the `debug_*` and `trace_*` namespaces.
 
-For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
+For the full list of the available methods, see the Reth documentation for the [debug namespace](https://reth.rs/jsonrpc/debug) and the [trace namespace](https://reth.rs/jsonrpc/trace).
 
 ### Linea
 

--- a/docs/debug-and-trace-apis.mdx
+++ b/docs/debug-and-trace-apis.mdx
@@ -179,6 +179,14 @@ To enable debug and trace APIs on your Robinhood Chain node, you must have a [pa
 
 For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
 
+### Arc
+
+To enable debug and trace APIs on your Arc node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).
+
+Arc runs the Reth client, which exposes both the `debug_*` and `trace_*` namespaces.
+
+For the full list of the available debug and trace API methods, see [Debug namespace](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
+
 ### Linea
 
 To enable debug and trace APIs on your Linea node, you must have a [paid plan](https://chainstack.com/pricing/) and deploy the node as a [Global Node](/docs/global-elastic-node).

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -73,6 +73,12 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | Mainnet | Chainstack Cloud           | fra1        | Frankfurt   | NA      | NA            |
 | Testnet | Chainstack Global Network  | global1     | Worldwide   | Archive | Available     |
 
+## Arc
+
+| Network | Cloud                     | Region  | Location  | Mode    | Debug & trace |
+| ------- | ------------------------- | ------- | --------- | ------- | ------------- |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
+
 ## Base
 
 | Network | Cloud                     | Region  | Location    | Mode    | Debug & trace |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -18,6 +18,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Apechain | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-apechain/#request) |
 | Aptos | Global Node, Dedicated | Full, Archive | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Arbitrum | Global Node, Dedicated | Full, Archive | Full, Archive | Arbitrum Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Arc | Global Node, Dedicated | - | Full, Archive | Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Astar | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-astar/#request) |
 | Avalanche | Global Node, Dedicated | Full, Archive | Full, Archive | Fuji Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | B^2 | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-b2/#request) |

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -22,7 +22,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 | Protocols | Classification |
 | --- | --- |
-| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo, Robinhood Chain | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
+| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Arc, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo, Robinhood Chain | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -505,6 +505,45 @@
       ],
       "additional_notes": "N/A"
     },
+    "Arc": {
+      "protocol_name": "Arc",
+      "supported_modes": [
+        "Full",
+        "Archive"
+      ],
+      "full_mode_query_limit": "Latest 128 blocks",
+      "archive_mode_available": true,
+      "debug_trace_available": true,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Platform",
+      "mainnet": {
+        "network_name": "N/A",
+        "faucet_url": "N/A",
+        "locations": []
+      },
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "N/A",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Archive",
+                  "debug_trace": true,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "additional_notes": "Testnet only; mainnet not yet live."
+    },
     "Base": {
       "protocol_name": "Base",
       "supported_modes": [


### PR DESCRIPTION
## What

Adds **Arc** — Circle's USDC-native, EVM-compatible L1 (Reth execution client) — as a supported protocol. Arc is **testnet only** for now (mainnet not yet live).

- **Network** — Testnet
- **Node types** — Global Nodes (Chainstack Global Network, `global1`, Worldwide) and dedicated nodes
- **Modes** — Full and Archive; **debug and trace** available; warp transactions — no
- **Billing** — archive requests (state 127+ blocks behind the tip) billed at 2 RU, same as other EVM chains

## Changes

- `node-options-master-list.json` — new Arc entry (source of truth): testnet-only (empty mainnet, like NEAR), Global Node `global1` archive, dedicated available, `Latest 128 blocks` full-mode query limit.
- `docs/protocols-networks.mdx` — Arc row (alphabetical, between Arbitrum and Astar).
- `docs/nodes-clouds-regions-and-locations.mdx` — Arc section (Testnet, archive on `global1`).
- `docs/request-units.mdx` — Arc added to the EVM 127-block archive-billing list.
- `docs/debug-and-trace-apis.mdx` — Arc section (Reth exposes `debug_*` and `trace_*`).

## Notes

- Data verified against the deployed fleet: Arc testnet archive nodes are live; GEN is represented as `global1` / Worldwide per the standard Global Node convention.
- The release note for Arc shipped separately and is already merged.