### PR TITLE
fix(docs): replace hardcoded API token with placeholder and fix GithHub typo

### DIFF
--- a/docs/blob-transactions-the-hard-way.mdx
+++ b/docs/blob-transactions-the-hard-way.mdx
@@ -134,7 +134,7 @@ Here's what we are going to do:
    PRIVATE_KEY=
    ```
 
-[GithHub repository](https://github.com/chainstacklabs/blob-transactions-the-hard-way) for the all the scripts.
+[GitHub repository](https://github.com/chainstacklabs/blob-transactions-the-hard-way) for the all the scripts.
 
 ### Create blob data
 

--- a/docs/ethereum-dencun-rundown-with-examples.mdx
+++ b/docs/ethereum-dencun-rundown-with-examples.mdx
@@ -92,7 +92,7 @@ Now let's do an [eth\_getBlockByNumber | Ethereum](/reference/ethereum-getblockb
 <CodeGroup>
   ```shell Shell
   curl --request POST \
-       --url https://ethereum-sepolia.core.chainstack.com/1fc2ff7e068591f6b44db1a454232d3d \
+       --url https://ethereum-sepolia.core.chainstack.com/YOUR_CHAINSTACK_TOKEN \
        --header 'accept: application/json' \
        --header 'content-type: application/json' \
        --data '
@@ -116,7 +116,7 @@ Use the slot number in a [Retrieve blobs by block ID](/reference/getblobsbyblock
 <CodeGroup>
   ```shell Shell
   curl -X 'GET' \
-    'https://ethereum-sepolia.core.chainstack.com/beacon/1fc2ff7e068591f6b44db1a454232d3d/eth/v1/beacon/blob_sidecars/4548476' \
+    'https://ethereum-sepolia.core.chainstack.com/beacon/YOUR_CHAINSTACK_TOKEN/eth/v1/beacon/blob_sidecars/4548476' \
     -H 'accept: application/json'
   ```
 </CodeGroup>


### PR DESCRIPTION
## What

- `ethereum-dencun-rundown-with-examples.mdx`: Replace hardcoded token `1fc2ff7e068591f6b44db1a454232d3d` with `YOUR_CHAINSTACK_TOKEN` placeholder in two `curl` examples (lines 95 and 119)
- `blob-transactions-the-hard-way.mdx`: Fix typo `GithHub` → `GitHub` in repository link text (line 137)

## Why

The hardcoded token looks like a real credential and could mislead readers into thinking it's a valid endpoint. Replacing it with a placeholder follows the docs style used elsewhere in the repo.

The typo is a minor but visible error in a link label.

Closes #603, #604