### PR TITLE
docs: fix GitHub typo, document the public demo endpoint exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,19 @@ This repository is public, and every page renders publicly at [docs.chainstack.c
 
 A secret committed to a public repo is compromised even after you delete or force-push it — rotate it.
 
+### Exception — public demo endpoints
+
+The Chainstack node endpoints that appear in the API reference specs and in some tutorials are **intentional public demo endpoints**. They exist so the Try it playground works and so readers can run an example by copy-paste. They look like credentials because they are node auth tokens, but they are published deliberately and maintained on purpose.
+
+Leave them as they are. Do not replace them with placeholders, and do not open an issue or PR reporting them as leaked secrets.
+
+Two places you will see them:
+
+- API reference — the token is the `paths` key in `openapi/`, and it must match the one in the corresponding `reference/` page frontmatter. Changing one without the other breaks the Try it button.
+- Tutorials — a small number of guides call a demo endpoint directly so the example is runnable as written.
+
+Everything else in the list above still applies. A node endpoint from your own account, a Chainstack platform API key, or a private key is a real secret and must never be committed — use a placeholder such as `YOUR_CHAINSTACK_ENDPOINT`, `YOUR_AUTH_TOKEN`, or `YOUR_API_KEY`.
+
 ## Project context
 
 - This is a documentation project on the Mintlify platform

--- a/docs/blob-transactions-the-hard-way.mdx
+++ b/docs/blob-transactions-the-hard-way.mdx
@@ -134,7 +134,7 @@ Here's what we are going to do:
    PRIVATE_KEY=
    ```
 
-[GithHub repository](https://github.com/chainstacklabs/blob-transactions-the-hard-way) for the all the scripts.
+[GitHub repository](https://github.com/chainstacklabs/blob-transactions-the-hard-way) for all the scripts.
 
 ### Create blob data
 


### PR DESCRIPTION
## What

- `CLAUDE.md` — add an explicit exception for the public demo endpoints, so they stop being reported as leaked secrets.
- `blob-transactions-the-hard-way.mdx` — `GithHub` → `GitHub`, and remove a stray "the" in the same sentence.

## Why

The contributing rules currently say, without qualification:

> **Secrets** — API keys, tokens, private keys, credentials. Use placeholders like `YOUR_API_KEY`.

There is no carve-out for the demo endpoints the docs depend on, so following the rule literally produces a change that breaks things:

- In the API reference, the token **is** the `paths` key in `openapi/`, and it has to match the `reference/` page frontmatter. Replacing it with a placeholder breaks the Try it button.
- A few tutorials call a demo endpoint directly so the example runs as written by copy-paste.

This has now arrived as an external bug report (#603), which makes it a documentation problem rather than a docs-content problem — a contributor read our stated rule correctly and arrived at the wrong change. The exception spells out where these endpoints appear, that they are deliberate, and what still counts as a real secret that must never be committed.

Closes #604