### PR TITLE
CORE-15453 self-hosted release notes v2.12.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3455,6 +3455,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-9-1-july-23-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-9-0-july-22-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026.mdx
@@ -1,0 +1,36 @@
+---
+title: "Chainstack Self-Hosted v2.12.0: July 28, 2026"
+description: "Sui mainnet and Sui testnet are now available as deployment targets."
+---
+
+This release adds Sui mainnet and Sui testnet as deployment targets and turns deploying from a snapshot into an editable per-component choice.
+
+## Sui support
+
+Sui mainnet and Sui testnet are now available as deployment targets, running the official Sui full node. You can deploy and manage Sui nodes from the Control Panel with the same workflows as other supported networks, including snapshot-accelerated initial sync.
+
+- **Sui mainnet** — deployed against the mainnet genesis and peer set
+- **Sui testnet** — deployed against the testnet genesis and peer set
+- **Endpoints** — Sui serves gRPC and JSON-RPC multiplexed on a single port, and the node overview now shows the gRPC endpoint
+
+Sui nodes read any checkpoints their peers no longer retain from Sui's state archive. A node restored from a snapshot older than the peer retention window catches up to the chain tip on its own rather than stalling with nothing to sync from.
+
+## Snapshot choice per component
+
+Deploying from a snapshot is now an editable choice on each component rather than a fixed toggle, in both the preset and custom configuration flows.
+
+- **Preset default** — clients that ship a snapshot default to it, with the source URL shown
+- **Sync from genesis** — turn the snapshot off to sync a component from genesis instead
+- **Custom source** — point a component at your own snapshot URL, validated before you continue
+
+The deployment summary shows the choice made for each component.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.9.0 |
+| cp-deployments-api | v0.49.0 |
+| cp-workflows | v3.15.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.12.0: July 28, 2026" description="">
+
+This release adds Sui mainnet and Sui testnet as deployment targets, running the official Sui full node. Deploying from a snapshot is now an editable choice on each component, with a preset default, a sync-from-genesis option, and support for your own snapshot URL.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.10.0: July 27, 2026" description="">
 
 This release adds Arbitrum One and Arbitrum Sepolia as deployment targets, running the Arbitrum Nitro client. Ethereum mainnet and Sepolia reth deployments now run in full mode rather than archive mode, matching the pruned snapshots they restore from.


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.12.0 release note.