### PR TITLE
CORE-15453 simplify snapshot wording in v2.12.0 release note

### DIFF
--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026.mdx
@@ -3,7 +3,7 @@ title: "Chainstack Self-Hosted v2.12.0: July 28, 2026"
 description: "Sui mainnet and Sui testnet are now available as deployment targets."
 ---
 
-This release adds Sui mainnet and Sui testnet as deployment targets and turns deploying from a snapshot into an editable per-component choice.
+This release adds Sui mainnet and Sui testnet as deployment targets, and lets you choose whether a deployment syncs from a snapshot or from genesis.
 
 ## Sui support
 
@@ -13,17 +13,9 @@ Sui mainnet and Sui testnet are now available as deployment targets, running the
 - **Sui testnet** — deployed against the testnet genesis and peer set
 - **Endpoints** — Sui serves gRPC and JSON-RPC multiplexed on a single port, and the node overview now shows the gRPC endpoint
 
-Sui nodes read any checkpoints their peers no longer retain from Sui's state archive. A node restored from a snapshot older than the peer retention window catches up to the chain tip on its own rather than stalling with nothing to sync from.
+## Snapshot or genesis
 
-## Snapshot choice per component
-
-Deploying from a snapshot is now an editable choice on each component rather than a fixed toggle, in both the preset and custom configuration flows.
-
-- **Preset default** — clients that ship a snapshot default to it, with the source URL shown
-- **Sync from genesis** — turn the snapshot off to sync a component from genesis instead
-- **Custom source** — point a component at your own snapshot URL, validated before you continue
-
-The deployment summary shows the choice made for each component.
+You can now switch between deploying from a snapshot and syncing from genesis for each deployment. Clients that ship a snapshot default to it, and the deployment summary shows the choice.
 
 ## Component versions
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -8,7 +8,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack Self-Hosted v2.12.0: July 28, 2026" description="">
 
-This release adds Sui mainnet and Sui testnet as deployment targets, running the official Sui full node. Deploying from a snapshot is now an editable choice on each component, with a preset default, a sync-from-genesis option, and support for your own snapshot URL.
+This release adds Sui mainnet and Sui testnet as deployment targets, running the official Sui full node. You can now switch between deploying from a snapshot and syncing from genesis for each deployment.
 
 <Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026">Read more</Button>
 </Update>


### PR DESCRIPTION
Copy edit to the Chainstack Self-Hosted v2.12.0 release note published in #608.

Drops the state-archive fallback detail and the per-component framing, and states the snapshot behavior plainly: you can switch between deploying from a snapshot and syncing from genesis for each deployment.

Touches the release note and the release-notes entry only — no nav or docs.json change.