### PR TITLE
CORE-15490 Add Sui and Arbitrum self-hosted specs

### DIFF
--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Robinhood Chain, Polygon, Starknet, TRON, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 
@@ -43,7 +43,7 @@ Each network ships with a preset that fixes the clients, versions, and resource 
 Pick the preset that matches your goal — the standard preset for production, the Light preset for evaluation on a smaller server. For the exact clients, versions, and resource figures per network, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols), and size your host per [System requirements](/docs/self-hosted/requirements).
 
 <Warning>
-Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, and Robinhood Chain (Mainnet and Testnet)) temporarily require **2× the steady-state storage**. The node first downloads the snapshot archive, then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; the volume can be reclaimed or stay sized for headroom once the snapshot archive is removed. See [Initial sync times](#initial-sync-times) below.
+Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, and Sui) temporarily require **2× the steady-state storage**. The node first downloads the snapshot archive, then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; the volume can be reclaimed or stay sized for headroom once the snapshot archive is removed. See [Initial sync times](#initial-sync-times) below.
 </Warning>
 
 </Step>

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Robinhood Chain, Polygon, Starknet, TRON, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, and Robinhood Chain (Mainnet and Testnet) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a pre-built chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), and Sui (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a pre-built chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Robinhood Chain, Polygon, Starknet, TRON, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -71,11 +71,12 @@ The table below summarizes the standard preset totals by architecture family. Us
 |--------|---------------------|------|-----|------------------------|
 | EVM Layer 1 (execution + consensus) | Ethereum Mainnet, Sepolia, Hoodi | 8 | 32 GiB | 250 GB–2 TB |
 | EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora | 12 | 48 GiB | 2–3.5 TB |
-| EVM Layer 2 — Arbitrum Nitro | Robinhood Chain Mainnet, Testnet | 4–8 | 32–64 GiB | 200–300 GB |
+| EVM Layer 2 — Arbitrum Nitro | Arbitrum One, Arbitrum Sepolia, Robinhood Chain | 4–8 | 32–64 GiB | 200 GB–2.5 TB |
 | Polygon PoS | Polygon Mainnet | 12 | 64 GiB | ~5.5 TB |
 | Starknet | Starknet Mainnet | 8 | 32 GiB | ~1 TB |
 | TRON | TRON Mainnet | 8 | 32 GiB | ~3 TB |
 | Bitcoin | Bitcoin Mainnet | 4 | 8 GiB | ~1 TB |
+| Sui | Sui Mainnet, Testnet | 16 | 64 GiB | 400 GB–2.2 TB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -84,7 +85,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, and Robinhood Chain (Mainnet and Testnet) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), and Sui (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 ### Storage considerations
@@ -103,7 +104,7 @@ For a deep dive on SSD selection for Ethereum nodes, see [yorickdowne's SSD guid
 
 ### Initial sync time
 
-Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, and Robinhood Chain (Mainnet and Testnet)) start from a pre-built chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
+Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, and Sui) start from a pre-built chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
 
 ## Network requirements
 

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -16,12 +16,16 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Base | Mainnet | Base-Reth v1.1.0 + Base-Node v1.1.0 | 12 | 48 GiB | ~3.5 TB |
 | Unichain | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
 | Zora | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
+| Arbitrum | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | ~2.5 TB |
+| Arbitrum | Sepolia | Nitro v3.11.2 | 4 | 32 GiB | ~1.5 TB |
 | Robinhood Chain | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | 200 GB |
 | Robinhood Chain | Testnet | Nitro v3.11.2 | 4 | 32 GiB | 300 GB |
 | Polygon PoS | Mainnet | Bor v2.8.3 + Heimdall v0.9.0 | 12 | 64 GiB | ~5.5 TB |
 | Starknet | Mainnet | Pathfinder v0.22.5 | 8 | 32 GiB | ~1 TB |
 | TRON | Mainnet | Java-Tron GreatVoyage-v4.8.1.1 | 8 | 32 GiB | ~3 TB |
 | Bitcoin | Mainnet | Bitcoin Core 31 | 4 | 8 GiB | ~1 TB |
+| Sui | Mainnet | Sui-Node v1.75.2 | 16 | 64 GiB | 400 GB |
+| Sui | Testnet | Sui-Node v1.76.0 | 16 | 64 GiB | ~2.2 TB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -88,13 +92,15 @@ The execution client's auth RPC port (8551) is used internally between clients a
 Runs a single Arbitrum Nitro full node client (Nitro v3.11.2).
 
 <Warning>
-Robinhood Chain requires an Ethereum Layer 1 **RPC endpoint** and a **Beacon API endpoint** that you supply. The Nitro node uses them to derive Layer 2 state from Layer 1.
+Arbitrum Nitro deployments require an Ethereum Layer 1 **RPC endpoint** and a **Beacon API endpoint** that you supply. The Nitro node uses them to derive Layer 2 state from Layer 1.
 </Warning>
 
 These deployments bootstrap from a pre-built chain snapshot rather than syncing from genesis. Snapshot bootstrap temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
 
 | Network | Chain ID | Block explorer |
 |---------|----------|----------------|
+| Arbitrum One Mainnet | 42161 | [arbiscan.io](https://arbiscan.io) |
+| Arbitrum Sepolia | 421614 | [sepolia.arbiscan.io](https://sepolia.arbiscan.io) |
 | Robinhood Chain Mainnet | 4663 | [robinhoodchain.blockscout.com](https://robinhoodchain.blockscout.com) |
 | Robinhood Chain Testnet | 46630 | [explorer.testnet.chain.robinhood.com](https://explorer.testnet.chain.robinhood.com) |
 
@@ -176,6 +182,29 @@ Runs a single full node client (Bitcoin Core 31) with the transaction index (`tx
 | Bitcoin Core | 8332 | TCP | HTTP JSON-RPC |
 
 The P2P port (8333) is used internally and is not exposed.
+
+## Sui
+
+Runs a single full node client. The client version is pinned per network, so Mainnet and Testnet can run different versions — see the [Available deployments](#available-deployments) table above.
+
+These deployments bootstrap from a pre-built chain snapshot rather than syncing from genesis. Snapshot bootstrap temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Block explorer |
+|---------|----------------|
+| Sui Mainnet | [suivision.xyz](https://suivision.xyz) |
+| Sui Testnet | [testnet.suivision.xyz](https://testnet.suivision.xyz) |
+
+<Note>
+Sui Testnet needs more storage than Mainnet — ~2.2 TB against 400 GB. Mainnet bootstraps from a pruned snapshot, while Testnet bootstraps from a full snapshot and additionally ingests state from a checkpoint archive.
+</Note>
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Sui-Node | 9000 | TCP | JSON-RPC and gRPC (multiplexed) |
+
+The node serves JSON-RPC and gRPC on the same port — there is no separate gRPC listener. The P2P port (8084/UDP) and the validator network address (8080) are used internally and are not exposed.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -106,6 +106,15 @@
         { "port": 8547, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
         { "port": 8548, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true }
       ]
+    },
+    "sui-node": {
+      "label": "Sui-Node",
+      "role": "full",
+      "ports": [
+        { "port": 9000, "proto": "TCP", "purpose": "JSON-RPC and gRPC (multiplexed)", "exposed": true },
+        { "port": 8084, "proto": "UDP", "purpose": "P2P", "exposed": false },
+        { "port": 8080, "proto": "TCP", "purpose": "Validator network address", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -161,6 +170,14 @@
         "Runs a single Arbitrum Nitro full node client.",
         "Requires an Ethereum Layer 1 RPC endpoint and a Beacon API endpoint that you supply.",
         "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted."
+      ]
+    },
+    "sui": {
+      "label": "Sui",
+      "notes": [
+        "Runs a single full node client.",
+        "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted.",
+        "Client version is pinned per network, so Mainnet and Testnet can run different versions."
       ]
     }
   },
@@ -243,6 +260,26 @@
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
     },
     {
+      "protocol": "Arbitrum", "network": "Mainnet", "chainId": 42161,
+      "explorer": "https://arbiscan.io",
+      "family": "arbitrum-nitro", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "nitro", "version": "v3.11.2", "cpu": 8, "ramGi": 64, "storageGi": 2500 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 64, "storageGi": 2500 }
+    },
+    {
+      "protocol": "Arbitrum", "network": "Sepolia", "chainId": 421614,
+      "explorer": "https://sepolia.arbiscan.io",
+      "family": "arbitrum-nitro", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "nitro", "version": "v3.11.2", "cpu": 4, "ramGi": 32, "storageGi": 1500 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 32, "storageGi": 1500 }
+    },
+    {
       "protocol": "Robinhood Chain", "network": "Mainnet", "chainId": 4663,
       "explorer": "https://robinhoodchain.blockscout.com",
       "family": "arbitrum-nitro", "status": "available", "snapshotBootstrap": true,
@@ -302,6 +339,26 @@
         { "client": "bitcoind", "version": "31", "cpu": 4, "ramGi": 8, "storageGi": 1000 }
       ],
       "totals": { "cpu": 4, "ramGi": 8, "storageGi": 1000 }
+    },
+    {
+      "protocol": "Sui", "network": "Mainnet", "chainId": null,
+      "explorer": "https://suivision.xyz",
+      "family": "sui", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "sui-node", "version": "v1.75.2", "cpu": 16, "ramGi": 64, "storageGi": 400 }
+      ],
+      "totals": { "cpu": 16, "ramGi": 64, "storageGi": 400 }
+    },
+    {
+      "protocol": "Sui", "network": "Testnet", "chainId": null,
+      "explorer": "https://testnet.suivision.xyz",
+      "family": "sui", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "sui-node", "version": "v1.76.0", "cpu": 16, "ramGi": 64, "storageGi": 2200 }
+      ],
+      "totals": { "cpu": 16, "ramGi": 64, "storageGi": 2200 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Catching up with the release notes for Chainstack self-hosted by documenting the deployment specs.