### PR TITLE
CORE-15493 self-hosted release notes v2.14.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3456,6 +3456,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-9-1-july-23-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026.mdx
@@ -1,0 +1,30 @@
+---
+title: "Chainstack Self-Hosted v2.14.0: July 29, 2026"
+description: "Tempo Mainnet and Tempo Testnet are now available as deployment targets."
+---
+
+This release adds Tempo Mainnet and Tempo Testnet as deployment targets, running as non-validator nodes in archive mode.
+
+## Tempo support
+
+Tempo Mainnet and Tempo Testnet are now available as deployment targets, running as non-validator nodes in archive mode.
+
+- Tempo Mainnet — chain ID 4217, explorer at [explore.tempo.xyz](https://explore.tempo.xyz)
+- Tempo Testnet — chain ID 42431, explorer at [explore.testnet.tempo.xyz](https://explore.testnet.tempo.xyz)
+- Endpoints — HTTP and WebSocket JSON-RPC, with the `eth`, `net`, `web3`, `debug`, and `trace` namespaces enabled
+
+Testnet carries considerably more history than mainnet — provision about 1,100 GiB of storage for Testnet against 70 GiB for Mainnet. See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Snapshot bootstrap
+
+Tempo deployments bootstrap from a snapshot provided by the client's own software.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.9.0 |
+| cp-deployments-api | v0.51.0 |
+| cp-workflows | v3.17.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 
@@ -45,6 +45,8 @@ Pick the preset that matches your goal — the standard preset for production, t
 <Warning>
 Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, and Sui) temporarily require **2× the steady-state storage**. The node first downloads the snapshot archive, then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; the volume can be reclaimed or stay sized for headroom once the snapshot archive is removed. See [Initial sync times](#initial-sync-times) below.
 </Warning>
+
+Tempo also bootstraps from a snapshot, but its client handles the download and extraction within the storage its presets already allocate, so no extra headroom is needed.
 
 </Step>
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), and Sui (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a pre-built chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), and Tempo (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.14.0: July 29, 2026" description="">
+
+This release adds Tempo Mainnet and Tempo Testnet as deployment targets, running as non-validator nodes in archive mode. Tempo deployments bootstrap from a snapshot provided by the client's own software.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.12.0: July 28, 2026" description="">
 
 This release adds Sui mainnet and Sui testnet as deployment targets, running the official Sui full node. You can now switch between deploying from a snapshot and syncing from genesis for each deployment.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -77,6 +77,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | TRON | TRON Mainnet | 8 | 32 GiB | ~3 TB |
 | Bitcoin | Bitcoin Mainnet | 4 | 8 GiB | ~1 TB |
 | Sui | Sui Mainnet, Testnet | 16 | 64 GiB | 400 GB–2.2 TB |
+| Tempo | Tempo Mainnet, Testnet | 4 | 16 GiB | 70 GB–1.1 TB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -87,6 +88,8 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 <Warning>
 Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), and Sui (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
+
+Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.
 
 ### Storage considerations
 
@@ -104,7 +107,7 @@ For a deep dive on SSD selection for Ethereum nodes, see [yorickdowne's SSD guid
 
 ### Initial sync time
 
-Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, and Sui) start from a pre-built chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
+Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, Sui, and Tempo) start from a chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
 
 ## Network requirements
 

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -26,6 +26,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Bitcoin | Mainnet | Bitcoin Core 31 | 4 | 8 GiB | ~1 TB |
 | Sui | Mainnet | Sui-Node v1.75.2 | 16 | 64 GiB | 400 GB |
 | Sui | Testnet | Sui-Node v1.76.0 | 16 | 64 GiB | ~2.2 TB |
+| Tempo | Mainnet | Tempo v1.11.0 | 4 | 16 GiB | 70 GB |
+| Tempo | Testnet | Tempo v1.11.0 | 4 | 16 GiB | ~1.1 TB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -205,6 +207,30 @@ Sui Testnet needs more storage than Mainnet — ~2.2 TB against 400 GB. Mainnet 
 | Sui-Node | 9000 | TCP | JSON-RPC and gRPC (multiplexed) |
 
 The node serves JSON-RPC and gRPC on the same port — there is no separate gRPC listener. The P2P port (8084/UDP) and the validator network address (8080) are used internally and are not exposed.
+
+## Tempo
+
+Runs a single full node client (Tempo v1.11.0) that serves both the execution and the consensus layers, so there is no separate consensus client to configure. Each node runs as a non-validator follower of an upstream endpoint, in archive mode.
+
+These deployments bootstrap from a chain snapshot that the client downloads itself rather than syncing from genesis. Unlike the other snapshot-bootstrapped families, Tempo needs no extra storage headroom for the bootstrap — the storage figures above already cover the temporary peak while the archive is downloaded and extracted. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Block explorer |
+|---------|----------|----------------|
+| Tempo Mainnet | 4217 | [explore.tempo.xyz](https://explore.tempo.xyz) |
+| Tempo Testnet | 42431 | [explore.testnet.tempo.xyz](https://explore.testnet.tempo.xyz) |
+
+<Note>
+Tempo Testnet needs considerably more storage than Mainnet — ~1.1 TB against 70 GB — because the test network carries far more history.
+</Note>
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Tempo | 8545 | TCP | HTTP JSON-RPC |
+| Tempo | 8546 | TCP | WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `debug`, and `trace` namespaces. The P2P port (30303 on TCP for RLPx and UDP for peer discovery) is used internally and is not exposed.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -115,6 +115,16 @@
         { "port": 8084, "proto": "UDP", "purpose": "P2P", "exposed": false },
         { "port": 8080, "proto": "TCP", "purpose": "Validator network address", "exposed": false }
       ]
+    },
+    "tempo": {
+      "label": "Tempo",
+      "role": "full",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 30303, "proto": "TCP", "purpose": "P2P (RLPx)", "exposed": false },
+        { "port": 30303, "proto": "UDP", "purpose": "Peer discovery", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -178,6 +188,13 @@
         "Runs a single full node client.",
         "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted.",
         "Client version is pinned per network, so Mainnet and Testnet can run different versions."
+      ]
+    },
+    "tempo": {
+      "label": "Tempo",
+      "notes": [
+        "Runs a single full node client that serves both the execution and the consensus layers, following an upstream endpoint as a non-validator.",
+        "Bootstraps from a chain snapshot that the client downloads itself. The listed storage already covers the temporary peak during download and extraction."
       ]
     }
   },
@@ -359,6 +376,26 @@
         { "client": "sui-node", "version": "v1.76.0", "cpu": 16, "ramGi": 64, "storageGi": 2200 }
       ],
       "totals": { "cpu": 16, "ramGi": 64, "storageGi": 2200 }
+    },
+    {
+      "protocol": "Tempo", "network": "Mainnet", "chainId": 4217,
+      "explorer": "https://explore.tempo.xyz",
+      "family": "tempo", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "tempo", "version": "1.11.0", "cpu": 4, "ramGi": 16, "storageGi": 70 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 70 }
+    },
+    {
+      "protocol": "Tempo", "network": "Testnet", "chainId": 42431,
+      "explorer": "https://explore.testnet.tempo.xyz",
+      "family": "tempo", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "tempo", "version": "1.11.0", "cpu": 4, "ramGi": 16, "storageGi": 1100 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 1100 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.14.0 release note. Adds Tempo (Mainnet and Testnet) to the supported-deployments catalog, requirements summary, and protocol enumerations.