### PR TITLE
CORE-15553 self-hosted release notes v2.16.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3456,6 +3456,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-10-0-july-27-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026.mdx
@@ -1,0 +1,27 @@
+---
+title: "Chainstack Self-Hosted v2.16.0: July 30, 2026"
+description: "Plasma Mainnet and Plasma Testnet are now available as deployment targets."
+---
+
+This release adds Plasma Mainnet and Plasma Testnet as deployment targets, running Reth for execution alongside the PlasmaBFT consensus client as non-validator nodes in full mode.
+
+## Plasma support
+
+Plasma Mainnet and Plasma Testnet are now available as deployment targets. Each deployment runs two components — Reth for execution and the PlasmaBFT consensus client — as non-validator nodes in full mode.
+
+- Plasma Mainnet — chain ID 9745, explorer at [plasmascan.to](https://plasmascan.to)
+- Plasma Testnet — chain ID 9746, explorer at [testnet.plasmascan.to](https://testnet.plasmascan.to)
+- Endpoints — HTTP and WebSocket JSON-RPC, with the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces enabled
+
+Both networks sync from genesis over the network's public peers rather than restoring from a snapshot. Provision about 350 GiB of storage for Mainnet and 250 GiB for Testnet across the two components. See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.9.0 |
+| cp-deployments-api | v0.53.0 |
+| cp-workflows | v3.19.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.3.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,7 +11,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.16.0: July 30, 2026" description="">
+
+This release adds Plasma Mainnet and Plasma Testnet as deployment targets, running Reth for execution alongside the PlasmaBFT consensus client as non-validator nodes in full mode. Both networks sync from genesis over the network's public peers.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.14.0: July 29, 2026" description="">
 
 This release adds Tempo Mainnet and Tempo Testnet as deployment targets, running as non-validator nodes in archive mode. Tempo deployments bootstrap from a snapshot provided by the client's own software.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -78,6 +78,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Bitcoin | Bitcoin Mainnet | 4 | 8 GiB | ~1 TB |
 | Sui | Sui Mainnet, Testnet | 16 | 64 GiB | 400 GB–2.2 TB |
 | Tempo | Tempo Mainnet, Testnet | 4 | 16 GiB | 70 GB–1.1 TB |
+| Plasma | Plasma Mainnet, Testnet | 5 | 20 GiB | 250–350 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -28,6 +28,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Sui | Testnet | Sui-Node v1.76.0 | 16 | 64 GiB | ~2.2 TB |
 | Tempo | Mainnet | Tempo v1.11.0 | 4 | 16 GiB | 70 GB |
 | Tempo | Testnet | Tempo v1.11.0 | 4 | 16 GiB | ~1.1 TB |
+| Plasma | Mainnet | Reth v1.11.3 + PlasmaBFT v0.15.0 | 5 | 20 GiB | 350 GB |
+| Plasma | Testnet | Reth v1.11.3 + PlasmaBFT v0.15.0 | 5 | 20 GiB | 250 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -231,6 +233,29 @@ Tempo Testnet needs considerably more storage than Mainnet — ~1.1 TB against 7
 | Tempo | 8546 | TCP | WS JSON-RPC |
 
 Both listeners serve the `eth`, `net`, `web3`, `debug`, and `trace` namespaces. The P2P port (30303 on TCP for RLPx and UDP for peer discovery) is used internally and is not exposed.
+
+## Plasma
+
+Runs a paired execution client and consensus client — Reth for execution and the PlasmaBFT observer for consensus — as a non-validator node in full mode. Reth takes 4 vCPU / 16 GiB and PlasmaBFT takes 1 vCPU / 4 GiB.
+
+These deployments sync from genesis over the network's public peers rather than restoring from a snapshot, so they need no extra storage headroom beyond the figures above. Expect a longer initial sync than a snapshot-bootstrapped deployment — see [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Block explorer |
+|---------|----------|----------------|
+| Plasma Mainnet | 9745 | [plasmascan.to](https://plasmascan.to) |
+| Plasma Testnet | 9746 | [testnet.plasmascan.to](https://testnet.plasmascan.to) |
+
+Storage splits into 300 GB for Reth and 50 GB for PlasmaBFT on Mainnet, and 200 GB for Reth and 50 GB for PlasmaBFT on Testnet.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Reth | 8545 | TCP | HTTP JSON-RPC |
+| Reth | 8546 | TCP | WS JSON-RPC |
+| PlasmaBFT | 35070 | TCP | Consensus API (HTTP) |
+
+Both Reth listeners serve the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces. The execution client's auth RPC port (8551) carries the engine API between the two clients, and the consensus client's P2P port (34070) and telemetry port (9745) are internal — none of the three are exposed.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -125,6 +125,15 @@
         { "port": 30303, "proto": "TCP", "purpose": "P2P (RLPx)", "exposed": false },
         { "port": 30303, "proto": "UDP", "purpose": "Peer discovery", "exposed": false }
       ]
+    },
+    "plasma": {
+      "label": "PlasmaBFT",
+      "role": "consensus",
+      "ports": [
+        { "port": 35070, "proto": "TCP", "purpose": "Consensus API (HTTP)", "exposed": true },
+        { "port": 34070, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 9745, "proto": "TCP", "purpose": "Telemetry", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -195,6 +204,13 @@
       "notes": [
         "Runs a single full node client that serves both the execution and the consensus layers, following an upstream endpoint as a non-validator.",
         "Bootstraps from a chain snapshot that the client downloads itself. The listed storage already covers the temporary peak during download and extraction."
+      ]
+    },
+    "plasma": {
+      "label": "Plasma",
+      "notes": [
+        "Runs a paired execution client and consensus client as a non-validator node. CPU and RAM are split across the two clients.",
+        "Syncs from genesis over the network's public peers rather than restoring from a snapshot, so no extra storage headroom is needed for the initial sync."
       ]
     }
   },
@@ -396,6 +412,28 @@
         { "client": "tempo", "version": "1.11.0", "cpu": 4, "ramGi": 16, "storageGi": 1100 }
       ],
       "totals": { "cpu": 4, "ramGi": 16, "storageGi": 1100 }
+    },
+    {
+      "protocol": "Plasma", "network": "Mainnet", "chainId": 9745,
+      "explorer": "https://plasmascan.to",
+      "family": "plasma", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "reth", "version": "v1.11.3", "cpu": 4, "ramGi": 16, "storageGi": 300 },
+        { "client": "plasma", "version": "0.15.0", "cpu": 1, "ramGi": 4, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 5, "ramGi": 20, "storageGi": 350 }
+    },
+    {
+      "protocol": "Plasma", "network": "Testnet", "chainId": 9746,
+      "explorer": "https://testnet.plasmascan.to",
+      "family": "plasma", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "reth", "version": "v1.11.3", "cpu": 4, "ramGi": 16, "storageGi": 200 },
+        { "client": "plasma", "version": "0.15.0", "cpu": 1, "ramGi": 4, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 5, "ramGi": 20, "storageGi": 250 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.16.0 release note. Adds Plasma Mainnet and Plasma Testnet to the supported-deployments catalog.