### PR TITLE
fix(docs): replace leftover Goerli references with Sepolia in Optimism bridge tutorial

### DIFF
--- a/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
+++ b/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
@@ -112,7 +112,7 @@ The first step is to import the required packages and create the global variable
   const PRIVATE_KEY = process.env.PRIVATE_KEY;
 
   // Provider instances
-  const l1Provider = new ethers.providers.JsonRpcProvider(GOERLI_CHAINSTACK);
+  const l1Provider = new ethers.providers.JsonRpcProvider(SEPOLIA_CHAINSTACK);
   const l2Provider = new ethers.providers.JsonRpcProvider(OPTIMISM_SEPOLIA_CHAINSTACK);
 
   // Init Signers

--- a/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
+++ b/docs/optimism-tutorial-bridge-ether-from-ethereum-l1-to-optimism-l2-using-the-optimism-javascript-sdk.mdx
@@ -60,7 +60,7 @@ To get from zero to a functioning bridge between Ethereum L1 and Optimism L2, do
 
 See [Create a project](/docs/manage-your-project#create-a-project).
 
-### Join the Ethereum Sepolia testnet and Optimism Goerli testnet
+### Join the Ethereum Sepolia testnet and Optimism Sepolia testnet
 
 See [Join a public network](/docs/manage-your-networks).
 
@@ -90,7 +90,7 @@ Create a `.env` file in the root directory of your project and paste and fill in
   ```env env
   PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY"
   SEPOLIA_CHAINSTACK="YOUR_CHAINSTACK_SEPOLIA_ENDPOINT"
-  OPTIMISM_GOERLI_CHAINSTACK="YOUR_CHAINSTACK_OPTIMISM_GOERLI_ENDPOINT"
+  OPTIMISM_SEPOLIA_CHAINSTACK="YOUR_CHAINSTACK_OPTIMISM_SEPOLIA_ENDPOINT"
   ```
 </CodeGroup>
 
@@ -113,7 +113,7 @@ The first step is to import the required packages and create the global variable
 
   // Provider instances
   const l1Provider = new ethers.providers.JsonRpcProvider(GOERLI_CHAINSTACK);
-  const l2Provider = new ethers.providers.JsonRpcProvider(OPTIMISM_GOERLI_CHAINSTACK);
+  const l2Provider = new ethers.providers.JsonRpcProvider(OPTIMISM_SEPOLIA_CHAINSTACK);
 
   // Init Signers
   async function getSigners() {
@@ -342,7 +342,7 @@ At this point, the entire code will look like this:
 
       const depositResponse = await crossChainMessenger.depositETH(wei);
       console.log(`Transaction hash for deposit from L1 to L2: ${depositResponse.hash}`);
-      console.log(`See on Goerli Etherscan: https://goerli.etherscan.io/tx/${depositResponse.hash}`);
+      console.log(`See on Sepolia Etherscan: https://sepolia.etherscan.io/tx/${depositResponse.hash}`);
 
       await depositResponse.wait();
       console.log("Waiting for deposit transaction to be relayed...");
@@ -414,7 +414,6 @@ The console will log all of the steps and it will look similar to the following:
 
 As you can see, it prints the transaction hash and the link to check the transaction details using Sepolia Etherscan.
 
-See the details of one of the already [completed transactions on Etherscan](https://goerli.etherscan.io/tx/0x97455a64eb1c496f4ecc937ffcf2d9294228d9658504a16ab9dbfa638d32693a).
 
 ## Conclusion
 


### PR DESCRIPTION
## What

The Optimism bridge tutorial was partially migrated from Goerli to Sepolia but six references were missed:

- Line 63: section heading `Optimism Goerli testnet` → `Optimism Sepolia testnet`
- Line 93: env var `OPTIMISM_GOERLI_CHAINSTACK` / `OPTIMISM_GOERLI_ENDPOINT` → SEPOLIA equivalents
- Line 115: `l1Provider` still used `GOERLI_CHAINSTACK` undefined variable, code crashes
- Line 116: `l2Provider` used `OPTIMISM_GOERLI_CHAINSTACK` → `OPTIMISM_SEPOLIA_CHAINSTACK`
- Line 345: `console.log` pointed to `goerli.etherscan.io` → `sepolia.etherscan.io`
- Line 417: dead example link on `goerli.etherscan.io` (Goerli is shut down) removed

## Why

Goerli Etherscan no longer exists and Goerli is fully deprecated. The undefined `GOERLI_CHAINSTACK` variable on line 115 would cause a runtime crash for anyone following the tutorial.

Closes #617