### PR TITLE
docs: newPendingTransactionsWithBody is gone on Polygon, use the boolean

### DIFF
--- a/reference/polygon-native-subscribe-newpendingtransactions.mdx
+++ b/reference/polygon-native-subscribe-newpendingtransactions.mdx
@@ -15,13 +15,17 @@ description: "Subscribe to pending Polygon transactions via WebSocket. Receive r
 
 ## Parameters
 
-* To subscribe to transaction hashes only —`newPendingTransactions`.
-* To subscribe to full transaction bodies — `newPendingTransactionsWithBody`
+* `newPendingTransactions` — the event to subscribe to.
+* `boolean` — optional. Pass `true` to receive full transaction bodies instead of hashes. Defaults to `false`.
+
+<Warning>
+  `newPendingTransactionsWithBody` is not available on Polygon. It was an Erigon extension, and Polygon nodes run the Bor client, which rejects it with `no "newPendingTransactionsWithBody" subscription in eth namespace`. Pass `true` as the second parameter instead — see [Polygon methods](/docs/polygon-methods) for the rest of the Erigon-to-Bor changes.
+</Warning>
 
 ## Response
 
 * `subscription` — the subscription ID.
-* `string `— the hash of a pending transaction.
+* `result` — the hash of a pending transaction, or the full transaction object when you pass `true`.
 
 ## `eth_subscribe("newPendingTransactions")` code examples
 
@@ -40,7 +44,11 @@ description: "Subscribe to pending Polygon transactions via WebSocket. Receive r
 
   Connected (press CTRL+C to quit)
 
+  # Transaction hashes only
   > {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["newPendingTransactions"]}
+
+  # Full transaction bodies
+  > {"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["newPendingTransactions",true]}
   ```
 
   ```javascript javascript


### PR DESCRIPTION
Fixes #616.

## What happened

Polygon retired the Erigon client on Aug 1, 2026. The Chainstack Polygon mainnet fleet has fully migrated — all 127 mainnet nodes now run Bor v2.9.0, where a week ago the archive nodes were Erigon.

`newPendingTransactionsWithBody` was an Erigon extension, so it went with it:

```
no "newPendingTransactionsWithBody" subscription in eth namespace
```

That is the exact error the reporter hit, reproduced on our own node.

## Full bodies are not lost

The standard Geth form still carries them. Verified over WSS against a Bor archive node:

| Subscription | Result |
|---|---|
| `["newPendingTransactions"]` | 436 events in 8s — hashes |
| `["newPendingTransactions", true]` | 474 events in 8s — **full transaction objects** (`accessList`, `from`, `gas`, `input`, …) |
| `["newPendingTransactionsWithBody"]` | rejected |

## The page contradicted itself

Its JavaScript example already used `params: ['newPendingTransactions', true]`, while the parameters section told readers to use `newPendingTransactionsWithBody`. So a reader following the prose got an error and a reader copying the code did not — even before the sunset.

## Changes

- Parameters now document the optional `boolean` second parameter.
- A warning names the removed method, gives the exact error string so the failure is searchable, and points at [Polygon methods](/docs/polygon-methods) for the rest of the Erigon-to-Bor migration.
- The response entry covers both shapes.
- The wscat example shows the hashes-only and full-body forms.

## Notes

- Only this page mentioned `newPendingTransactionsWithBody`; the Ethereum equivalent is unaffected.
- The rest of the sunset is already covered — `polygon-methods.mdx` carries the full `trace_*` → `debug_*` + `flatCallTracer` migration table, and I confirmed `flatCallTracer` works natively on Bor.
- This file uses CRLF with one bare-LF line; that line was restored so the diff shows only real changes.
- `mintlify broken-links` passes clean.