### PR TITLE
docs: finish the Goerli cleanup

### DIFF
--- a/docs/monitoring-transaction-propagation-from-node-to-mempool-in-evm-networks-with-python.mdx
+++ b/docs/monitoring-transaction-propagation-from-node-to-mempool-in-evm-networks-with-python.mdx
@@ -29,7 +29,7 @@ Propagation in the mempool predominantly affects two major factors: latency and 
 
 If you want to see how transactions and blocks are moving in a blockchain network, tools like [web3.js](/docs/web3-development-frameworks-and-libraries-glossary#web3js) or [web3.py](/docs/web3-development-frameworks-and-libraries-glossary#web3py) are your friends. They let you write your own scripts to understand better how things like the network setup, network conditions, and the number of transactions can make a difference.
 
-You can run these tests on your private networks or public ones like Goerli and Sepolia to mimic what happens in the real world. Pair this with network monitoring tools; you'll get a clear image of your blockchain's performance and where things might be slowing down. This can help you adjust your setup and keep things moving smoothly.
+You can run these tests on your private networks or public ones like Sepolia and Hoodi to mimic what happens in the real world. Pair this with network monitoring tools; you'll get a clear image of your blockchain's performance and where things might be slowing down. This can help you adjust your setup and keep things moving smoothly.
 
 <Info>
   We'll be using the [web3.py](https://github.com/ethereum/web3.py) library to interact with the Ethereum network.

--- a/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
+++ b/docs/starknet-tutorial-an-nft-contract-with-nile-and-l1-l2-reputation-messaging.mdx
@@ -3,6 +3,12 @@ title: "Starknet: NFT contract with Nile and L1-L2 messaging"
 description: "Build Starknet NFT contract with L1-L2 messaging using Nile, Cairo, and OpenZeppelin. Deploy cross-chain reputation system between Ethereum and Starknet."
 ---
 
+<Warning>
+  ### Deprecation notice
+
+  This guide is for historical reference. It builds on [Nile](https://github.com/OpenZeppelin/nile), which OpenZeppelin archived in December 2023, and on the Starknet Goerli testnet, which no longer exists. For current Starknet development, see [Starknet tooling](/docs/starknet-tooling).
+</Warning>
+
 **TLDR:**
 * Starknet employs an account-based model and a distinct L1–L2 messaging architecture to enable cross-chain interactions with Ethereum.
 * This tutorial walks through deploying a Starknet-based NFT contract (with a reputation system) and a corresponding L1 contract on Ethereum Sepolia.

--- a/docs/zksync-tutorial-develop-a-custom-paymaster-contract.mdx
+++ b/docs/zksync-tutorial-develop-a-custom-paymaster-contract.mdx
@@ -855,10 +855,7 @@ The console will log the following result:
   ```
 </CodeGroup>
 
-You can now verify the contracts on the [zkSync explorer](https://goerli.explorer.zksync.io/). You will see the deployment transactions and the verified contracts. You can check the contracts we deployed:
-
-* [CSgas token](https://goerli.explorer.zksync.io/address/0x0E5E64716321cd013E6814f06A8c42475506331E)
-* [Paymaster contract](https://goerli.explorer.zksync.io/address/0x17a27157E6CE8FdD50bede091d63Df8Ab6A44f93)
+You can now verify the contracts on the [zkSync Era Sepolia explorer](https://sepolia.explorer.zksync.io/). You will see the deployment transactions and the verified contracts.
 
 Now the smart contracts are deployed. The paymaster should have 0.001 ETH to sponsor gas fees, and the new account should have 10 `CSG` tokens.
 

--- a/reference/arbitrum-sendrawtransaction.mdx
+++ b/reference/arbitrum-sendrawtransaction.mdx
@@ -32,7 +32,7 @@ You can sign up with your GitHub, X, Google, or Microsoft account.
 
 ## `eth_sendRawTransaction` code examples
 
-The following examples demonstrate how to use Web3 libraries to make an ETH transfer on the Arbitrum Goerli testnet.
+The following examples demonstrate how to use Web3 libraries to make an ETH transfer on the Arbitrum Sepolia testnet.
 
 <Note>
 **Additional libraries requirement**

--- a/reference/chainstack-faucet-get-tokens-rpc-method.mdx
+++ b/reference/chainstack-faucet-get-tokens-rpc-method.mdx
@@ -69,7 +69,7 @@ Here's an example of a script that automatically refills your wallet by calling 
 const axios = require('axios');
 
 // API config
-const chain = 'sepolia' // goerli
+const chain = 'sepolia' // hoodi
 const address = 'YOUR_ADDRESS';
 
 const apiUrl = `https://api.chainstack.com/v1/faucet/${chain}`;
@@ -105,7 +105,7 @@ import requests
 import time
 
 # API config
-chain = 'sepolia'  # goerli
+chain = 'sepolia'  # hoodi
 address = 'YOUR_ADDRESS'
 
 api_url = f'https://api.chainstack.com/v1/faucet/{chain}'


### PR DESCRIPTION
Follow-on to #618. Goerli shut down in 2023 and `goerli.etherscan.io` now returns 521.

## Most of the remaining references are correct

A sweep found 73 Goerli references after #618, but the raw count is misleading. These are intentional and stay as they are:

| File | Refs | Why it stays |
|---|---|---|
| `arbitrum-tutorial-l1-to-l2-messaging-smart-contract` | 23 | already carries a deprecation notice, kept as a historical reference |
| `polygon-tutorial-bridging-erc20-from-ethereum-to-polygon` | 16 | same |
| `migrating-from-google-cloud-blockchain-node-engine-to-chainstack` | 1 | the migration table names Goerli only to say it is deprecated |

That left three genuinely broken spots and two stale ones.

## Starknet NFT tutorial — deprecated, not migrated

Its prose had already been moved to Sepolia, but twelve links and CLI commands still pointed at Goerli — including one line labelled "L2 Goerli ETH" that linked to the Sepolia faucet, and `nile deploy ... --network goerli` sitting in the same file as `--network=alpha-sepolia`.

Repointing those links would not have helped. The guide is built on [Nile](https://github.com/OpenZeppelin/nile), which OpenZeppelin **archived in December 2023** (`archived: true`, last push 2023-12-01). The toolchain is gone, so a link fix would produce a tutorial that still cannot be followed. It now carries a deprecation notice pointing at [Starknet tooling](/docs/starknet-tooling), matching how the other dead-testnet guides are handled.

## zkSync paymaster tutorial

The guide runs on Sepolia throughout, but its closing section linked `goerli.explorer.zksync.io`, which no longer resolves. Now points at the Sepolia explorer. The two example contract links are dropped — those contracts were deployed on Goerli and do not exist on Sepolia, so repointing them would just produce two 404s.

## Three smaller ones

- `arbitrum-sendrawtransaction` — a **live** API reference page describing the transfer as happening on Arbitrum Goerli. Now Arbitrum Sepolia.
- Faucet reference — the `// goerli` code comment in both the JavaScript and Python samples suggested an unsupported chain. Now `hoodi`, which the faucet does support.
- Mempool propagation article — "public ones like Goerli and Sepolia" is now "Sepolia and Hoodi".

## Verification

| URL | Status |
|---|---|
| `sepolia.etherscan.io` | 200 |
| `sepolia.explorer.zksync.io` | 200 |
| `goerli.etherscan.io` | 521 |
| `goerli.voyager.online` | no response |
| `goerli.explorer.zksync.io` | no response |

Both edited `reference/` files are CRLF; line-ending counts are unchanged, so the diff is real changes only. `mintlify broken-links` passes clean.