### PR TITLE
CORE-15640 self-hosted release notes v2.21.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3549,6 +3549,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-12-0-july-28-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026.mdx
@@ -7,7 +7,7 @@ This release adds three protocols as deployment targets — Avalanche, Arc, and 
 
 ## Avalanche support
 
-Avalanche Mainnet and Fuji Testnet are now available as deployment targets, running a single avalanchego node as a non-validator in full mode.
+Avalanche Mainnet and Fuji Testnet are now available as deployment targets, running a single AvalancheGo node as a non-validator in full mode.
 
 - Avalanche Mainnet — chain ID 43114, explorer at [snowscan.xyz](https://snowscan.xyz)
 - Avalanche Fuji — chain ID 43113, explorer at [testnet.snowscan.xyz](https://testnet.snowscan.xyz)

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026.mdx
@@ -1,0 +1,52 @@
+---
+title: "Chainstack Self-Hosted v2.21.0: August 4, 2026"
+description: "Avalanche, Arc, and World Chain are now available as deployment targets, and the bundled Grafana dashboards render correctly again."
+---
+
+This release adds three protocols as deployment targets — Avalanche, Arc, and World Chain — and fixes the bundled Kubernetes Grafana dashboards.
+
+## Avalanche support
+
+Avalanche Mainnet and Fuji Testnet are now available as deployment targets, running a single avalanchego node as a non-validator in full mode.
+
+- Avalanche Mainnet — chain ID 43114, explorer at [snowscan.xyz](https://snowscan.xyz)
+- Avalanche Fuji — chain ID 43113, explorer at [testnet.snowscan.xyz](https://testnet.snowscan.xyz)
+- Endpoints — one node serves the whole Primary Network, so the node overview lists four endpoints that share a single port and differ only by path: C-Chain HTTP and WebSocket JSON-RPC, X-Chain HTTP, and P-Chain HTTP
+
+Sync lag and peer count are reported for Avalanche nodes the same way as for any other EVM node. Mainnet restores from a snapshot, so provision about 400 GiB of storage; Fuji syncs from genesis over the network's public peers and needs about 300 GiB.
+
+## Arc support
+
+Arc Testnet is now available as a deployment target. Each deployment runs two components — an execution client and a consensus client — as a non-validator node in full mode, following the network's public endpoints.
+
+- Arc Testnet — chain ID 5042002, explorer at [testnet.arcscan.app](https://testnet.arcscan.app)
+- Endpoints — HTTP and WebSocket JSON-RPC, with the `eth`, `net`, `web3`, `txpool`, `trace`, and `debug` namespaces enabled
+
+The deployment restores from a snapshot. Provision about 314 GiB of storage across the two components.
+
+## World Chain support
+
+World Chain Mainnet and World Chain Sepolia are now available as OP Stack deployment targets, running a World Chain execution client alongside OP-Node as the rollup client.
+
+- World Chain Mainnet — chain ID 480, explorer at [worldscan.org](https://worldscan.org)
+- World Chain Sepolia — chain ID 4801, explorer at [worldchain-sepolia.explorer.alchemy.com](https://worldchain-sepolia.explorer.alchemy.com)
+- Endpoints — HTTP and WebSocket JSON-RPC on the execution client, plus the rollup HTTP RPC on OP-Node
+
+Like the other OP Stack deployments, both networks require an Ethereum Layer 1 RPC endpoint and a Beacon API endpoint that you supply. Both restore from a snapshot — provision about 1300 GiB of storage for Mainnet and 100 GiB for Sepolia.
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Monitoring dashboards
+
+The bundled Kubernetes node and pod Grafana dashboards render correctly again, and kube-state-metrics is now scraped with the labels those dashboards expect. Panels that previously came up empty are populated. See [Monitoring](/docs/self-hosted/monitoring) for how to reach the dashboards.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.1.0 |
+| cp-workflows | v3.23.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), and Tempo (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, and Arc Testnet presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, Arbitrum, Robinhood Chain, Polygon, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.21.0: August 4, 2026" description="">
+
+This release adds Avalanche, Arc, and World Chain as deployment targets. Avalanche runs a single node that serves the whole Primary Network, Arc runs a paired execution and consensus node, and World Chain joins the OP Stack deployments. The bundled Kubernetes Grafana dashboards also render correctly again.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.16.0: July 30, 2026" description="">
 
 This release adds Plasma Mainnet and Plasma Testnet as deployment targets, running Reth for execution alongside the PlasmaBFT consensus client as non-validator nodes in full mode. Both networks sync from genesis over the network's public peers.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -70,7 +70,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Family | Example deployments | vCPU | RAM | Storage (steady state) |
 |--------|---------------------|------|-----|------------------------|
 | EVM Layer 1 (execution + consensus) | Ethereum Mainnet, Sepolia, Hoodi | 8 | 32 GiB | 250 GB–2 TB |
-| EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora | 12 | 48 GiB | 2–3.5 TB |
+| EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora, World Chain | 6–12 | 24–48 GiB | 100 GB–3.5 TB |
 | EVM Layer 2 — Arbitrum Nitro | Arbitrum One, Arbitrum Sepolia, Robinhood Chain | 4–8 | 32–64 GiB | 200 GB–2.5 TB |
 | Polygon PoS | Polygon Mainnet | 12 | 64 GiB | ~5.5 TB |
 | Starknet | Starknet Mainnet | 8 | 32 GiB | ~1 TB |
@@ -79,6 +79,8 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Sui | Sui Mainnet, Testnet | 16 | 64 GiB | 400 GB–2.2 TB |
 | Tempo | Tempo Mainnet, Testnet | 4 | 16 GiB | 70 GB–1.1 TB |
 | Plasma | Plasma Mainnet, Testnet | 5 | 20 GiB | 250–350 GB |
+| Avalanche | Avalanche Mainnet, Fuji | 4 | 16 GiB | 300–400 GB |
+| Arc | Arc Testnet | 8 | 32 GiB | ~315 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -87,7 +89,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, Arbitrum (both networks), Robinhood Chain (both networks), and Sui (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, and Arc Testnet — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -16,6 +16,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Base | Mainnet | Base-Reth v1.1.0 + Base-Node v1.1.0 | 12 | 48 GiB | ~3.5 TB |
 | Unichain | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
 | Zora | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
+| World Chain | Mainnet | World-Chain v2.4.0 + OP-Node v1.19.3 | 12 | 48 GiB | ~1.3 TB |
+| World Chain | Sepolia | World-Chain v2.4.0 + OP-Node v1.19.3 | 6 | 24 GiB | 100 GB |
 | Arbitrum | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | ~2.5 TB |
 | Arbitrum | Sepolia | Nitro v3.11.2 | 4 | 32 GiB | ~1.5 TB |
 | Robinhood Chain | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | 200 GB |
@@ -30,6 +32,9 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Tempo | Testnet | Tempo v1.11.0 | 4 | 16 GiB | ~1.1 TB |
 | Plasma | Mainnet | Reth v1.11.3 + PlasmaBFT v0.15.0 | 5 | 20 GiB | 350 GB |
 | Plasma | Testnet | Reth v1.11.3 + PlasmaBFT v0.15.0 | 5 | 20 GiB | 250 GB |
+| Avalanche | Mainnet | AvalancheGo v1.14.2 | 4 | 16 GiB | 400 GB |
+| Avalanche | Fuji | AvalancheGo v1.15.0-fuji | 4 | 16 GiB | 300 GB |
+| Arc | Testnet | Arc-Execution 0.7.3 + Arc-Consensus 0.7.3 | 8 | 32 GiB | ~315 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -78,15 +83,21 @@ OP Stack deployments require an Ethereum Layer 1 **RPC endpoint** and a **Beacon
 | Base Mainnet | 8453 | Base-Reth + Base-Node | [basescan.org](https://basescan.org) |
 | Unichain Mainnet | 130 | OP-Reth + OP-Node | [uniscan.xyz](https://uniscan.xyz) |
 | Zora Mainnet | 7777777 | OP-Reth + OP-Node | [explorer.zora.energy](https://explorer.zora.energy) |
+| World Chain Mainnet | 480 | World-Chain + OP-Node | [worldscan.org](https://worldscan.org) |
+| World Chain Sepolia | 4801 | World-Chain + OP-Node | [worldchain-sepolia.explorer.alchemy.com](https://worldchain-sepolia.explorer.alchemy.com) |
 
-Optimism Mainnet bootstraps from a pre-built snapshot (plan for ~2× storage during deploy). Base, Unichain, and Zora sync without a snapshot.
+Optimism Mainnet and both World Chain networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy). Base, Unichain, and Zora sync without a snapshot.
+
+<Note>
+World Chain Sepolia is the smallest deployment in this family — 6 vCPU / 24 GiB against the 12 vCPU / 48 GiB the Mainnet deployments take.
+</Note>
 
 ### Exposed ports
 
 | Client | Port | Protocol | Purpose |
 |--------|------|----------|---------|
-| OP-Reth / Base-Reth | 8545 | TCP | HTTP JSON-RPC |
-| OP-Reth / Base-Reth | 8546 | TCP | WS JSON-RPC |
+| OP-Reth / Base-Reth / World-Chain | 8545 | TCP | HTTP JSON-RPC |
+| OP-Reth / Base-Reth / World-Chain | 8546 | TCP | WS JSON-RPC |
 | OP-Node / Base-Node | 9545 | TCP | Rollup HTTP RPC |
 
 The execution client's auth RPC port (8551) is used internally between clients and is not exposed.
@@ -256,6 +267,48 @@ Storage splits into 300 GB for Reth and 50 GB for PlasmaBFT on Mainnet, and 200 
 | PlasmaBFT | 35070 | TCP | Consensus API (HTTP) |
 
 Both Reth listeners serve the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces. The execution client's auth RPC port (8551) carries the engine API between the two clients, and the consensus client's P2P port (34070) and telemetry port (9745) are internal — none of the three are exposed.
+
+## Avalanche
+
+Runs a single AvalancheGo full node as a non-validator in full mode. One node serves the whole Primary Network, so there is no separate client per chain.
+
+Mainnet bootstraps from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. Fuji syncs from genesis over the network's public peers and needs no extra headroom. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Avalanche Mainnet | 43114 | AvalancheGo v1.14.2 | [snowscan.xyz](https://snowscan.xyz) |
+| Avalanche Fuji | 43113 | AvalancheGo v1.15.0-fuji | [testnet.snowscan.xyz](https://testnet.snowscan.xyz) |
+
+The client version is pinned per network, so Mainnet and Fuji run different versions.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| AvalancheGo | 9650 | TCP | HTTP and WS JSON-RPC for all three chains |
+
+All chain endpoints share port 9650 and differ only by path — `/ext/bc/C/rpc` for C-Chain HTTP, `/ext/bc/C/ws` for C-Chain WebSocket, `/ext/bc/X` for X-Chain HTTP, and `/ext/P` for P-Chain HTTP. The node overview lists all four. Only the C-Chain offers a WebSocket endpoint; the X-Chain's pubsub endpoint was removed upstream and nothing replaced it. The P2P port (9651) is internal and is not exposed.
+
+## Arc
+
+Runs a paired execution client and consensus client as a non-validator node in full mode, following the network's public endpoints. Arc-Execution takes 6 vCPU / 24 GiB and Arc-Consensus takes 2 vCPU / 8 GiB.
+
+These deployments bootstrap from a pre-built chain snapshot rather than syncing from genesis. Snapshot bootstrap temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Block explorer |
+|---------|----------|----------------|
+| Arc Testnet | 5042002 | [testnet.arcscan.app](https://testnet.arcscan.app) |
+
+Storage splits into 250 GB for Arc-Execution and 64 GB for Arc-Consensus.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Arc-Execution | 8545 | TCP | HTTP JSON-RPC |
+| Arc-Execution | 8546 | TCP | WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `txpool`, `trace`, and `debug` namespaces. Arc-Consensus publishes nothing of its own — its RPC port is the internal upstream of the execution client's `arc` namespace. The execution client's auth RPC port (8551), the consensus client's RPC (31000) and P2P (27000) ports, and both metrics ports are internal and are not exposed.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -134,6 +134,42 @@
         { "port": 34070, "proto": "TCP", "purpose": "P2P", "exposed": false },
         { "port": 9745, "proto": "TCP", "purpose": "Telemetry", "exposed": false }
       ]
+    },
+    "avalanchego": {
+      "label": "AvalancheGo",
+      "role": "full",
+      "ports": [
+        { "port": 9650, "proto": "TCP", "purpose": "HTTP and WS JSON-RPC for the C-Chain, X-Chain, and P-Chain (one port, per-chain paths)", "exposed": true },
+        { "port": 9651, "proto": "TCP", "purpose": "P2P", "exposed": false }
+      ]
+    },
+    "arc-execution": {
+      "label": "Arc-Execution",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false },
+        { "port": 9001, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "arc-consensus": {
+      "label": "Arc-Consensus",
+      "role": "consensus",
+      "ports": [
+        { "port": 31000, "proto": "TCP", "purpose": "Consensus RPC (upstream of the execution client's arc namespace only)", "exposed": false },
+        { "port": 27000, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 29000, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "world-chain": {
+      "label": "World-Chain",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -211,6 +247,21 @@
       "notes": [
         "Runs a paired execution client and consensus client as a non-validator node. CPU and RAM are split across the two clients.",
         "Syncs from genesis over the network's public peers rather than restoring from a snapshot, so no extra storage headroom is needed for the initial sync."
+      ]
+    },
+    "avalanche": {
+      "label": "Avalanche",
+      "notes": [
+        "Runs a single full node client that serves the Primary Network's C-Chain, X-Chain, and P-Chain on one port, addressed by per-chain paths.",
+        "Mainnet bootstraps from a pre-built chain snapshot and temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted. Fuji syncs from genesis over the network's public peers.",
+        "Client version is pinned per network, so Mainnet and Fuji can run different versions."
+      ]
+    },
+    "arc": {
+      "label": "Arc",
+      "notes": [
+        "Runs a paired execution client and consensus client as a non-validator node that follows the network's public endpoints. CPU and RAM are split across the two clients.",
+        "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted."
       ]
     }
   },
@@ -291,6 +342,28 @@
         { "client": "op-node", "version": "v1.19.0", "cpu": 4, "ramGi": 16, "storageGi": 0 }
       ],
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
+    },
+    {
+      "protocol": "World Chain", "network": "Mainnet", "chainId": 480,
+      "explorer": "https://worldscan.org",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "world-chain", "version": "v2.4.0",  "cpu": 8, "ramGi": 32, "storageGi": 1300 },
+        { "client": "op-node",     "version": "v1.19.3", "cpu": 4, "ramGi": 16, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 12, "ramGi": 48, "storageGi": 1300 }
+    },
+    {
+      "protocol": "World Chain", "network": "Sepolia", "chainId": 4801,
+      "explorer": "https://worldchain-sepolia.explorer.alchemy.com",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "world-chain", "version": "v2.4.0",  "cpu": 4, "ramGi": 16, "storageGi": 100 },
+        { "client": "op-node",     "version": "v1.19.3", "cpu": 2, "ramGi": 8,  "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 100 }
     },
     {
       "protocol": "Arbitrum", "network": "Mainnet", "chainId": 42161,
@@ -434,6 +507,37 @@
         { "client": "plasma", "version": "0.15.0", "cpu": 1, "ramGi": 4, "storageGi": 50 }
       ],
       "totals": { "cpu": 5, "ramGi": 20, "storageGi": 250 }
+    },
+    {
+      "protocol": "Avalanche", "network": "Mainnet", "chainId": 43114,
+      "explorer": "https://snowscan.xyz",
+      "family": "avalanche", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "avalanchego", "version": "v1.14.2", "cpu": 4, "ramGi": 16, "storageGi": 400 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 400 }
+    },
+    {
+      "protocol": "Avalanche", "network": "Fuji", "chainId": 43113,
+      "explorer": "https://testnet.snowscan.xyz",
+      "family": "avalanche", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "avalanchego", "version": "v1.15.0-fuji", "cpu": 4, "ramGi": 16, "storageGi": 300 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 300 }
+    },
+    {
+      "protocol": "Arc", "network": "Testnet", "chainId": 5042002,
+      "explorer": "https://testnet.arcscan.app",
+      "family": "arc", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "arc-execution", "version": "0.7.3", "cpu": 6, "ramGi": 24, "storageGi": 250 },
+        { "client": "arc-consensus", "version": "0.7.3", "cpu": 2, "ramGi": 8,  "storageGi": 64 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 32, "storageGi": 314 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.21.0 release note.

Adds Avalanche, Arc, and World Chain to the supported-deployments catalog.

| Protocol | Network | Clients | vCPU | RAM | Storage |
|---|---|---|---|---|---|
| World Chain | Mainnet | World-Chain v2.4.0 + OP-Node v1.19.3 | 12 | 48 GiB | ~1.3 TB |
| World Chain | Sepolia | World-Chain v2.4.0 + OP-Node v1.19.3 | 6 | 24 GiB | 100 GB |
| Avalanche | Mainnet | AvalancheGo v1.14.2 | 4 | 16 GiB | 400 GB |
| Avalanche | Fuji | AvalancheGo v1.15.0-fuji | 4 | 16 GiB | 300 GB |
| Arc | Testnet | Arc-Execution 0.7.3 + Arc-Consensus 0.7.3 | 8 | 32 GiB | ~315 GB |

World Chain joins the existing OP Stack family; Avalanche and Arc get new family sections. The release note also covers the Grafana monitoring dashboard fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)