### PR TITLE
docs(changelog): World Chain and Stable Mainnet on Global Nodes (August 4, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: August 4, 2026" description=" by Ake">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for World Chain Mainnet and Stable Mainnet.
+
+<Button href="/changelog/chainstack-updates-august-4-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 27, 2026" description=" by Ake">
 
 **Protocols**. Chainstack now supports Arc — Circle's USDC-native, EVM-compatible L1 for stablecoin payments. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Arc testnet, in Full and Archive modes with debug and trace.

--- a/changelog/chainstack-updates-august-4-2026.mdx
+++ b/changelog/chainstack-updates-august-4-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: August 4, 2026"
+description: "You can now deploy Global Nodes for World Chain Mainnet and Stable Mainnet."
+---
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for World Chain Mainnet and Stable Mainnet.

--- a/docs.json
+++ b/docs.json
@@ -3288,6 +3288,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-4-2026",
           "changelog/chainstack-updates-july-27-2026",
           "changelog/chainstack-updates-july-23-2026",
           "changelog/chainstack-updates-july-22-2026",


### PR DESCRIPTION
## What

Adds the **August 4, 2026** Cloud release note: World Chain Mainnet and Stable Mainnet are now deployable as Global Nodes.

> **Protocols**. Now, you can deploy Global Nodes for World Chain Mainnet and Stable Mainnet.

## Changes

- `changelog.mdx` — new `<Update>` entry at the top.
- `changelog/chainstack-updates-august-4-2026.mdx` — standalone release note page.
- `docs.json` — page added to the Release notes tab.

## Local validation

- `docs.json` — valid JSON.
- `mintlify broken-links` — the `/docs/global-elastic-node` link resolves; no new broken links.