### PR TITLE
docs: add World Chain and Stable as new protocols (Mainnet on Global Nodes)

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -209,12 +209,14 @@ description: Browse the cloud providers, regions, and geographic locations avail
 
 | Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
 | ------- | -------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Partner Network | global2 | Worldwide | Full    | Available     |
 | Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
 
 ## Stable
 
 | Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
 | ------- | -------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Partner Network | global2 | Worldwide | Full    | Available     |
 | Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
 
 ## Polkadot

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -205,6 +205,18 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | ------- | -------------------------- | ------- | --------- | ------- | ------------- |
 | Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
 
+## World Chain
+
+| Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
+| ------- | -------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
+
+## Stable
+
+| Network | Cloud                      | Region  | Location  | Mode    | Debug & trace |
+| ------- | -------------------------- | ------- | --------- | ------- | ------------- |
+| Mainnet | Chainstack Partner Network | global2 | Worldwide | Archive | Available     |
+
 ## Polkadot
 
 | Network | Cloud                      | Region  | Location  | Mode    |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -84,7 +84,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Solana | Global Node, Dedicated | Full, Archive | Full, Archive | Devnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Soneium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Global Node, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Stable | Global Node | Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Stable | Global Node | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Global Node, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Sui | Global Node, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
@@ -99,7 +99,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Unichain | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Vana | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | WEMIX | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
-| World Chain | Global Node | Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| World Chain | Global Node | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | XDC | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | XLayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
 | Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -84,6 +84,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Solana | Global Node, Dedicated | Full, Archive | Full, Archive | Devnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Soneium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Global Node, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Stable | Global Node | Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Global Node, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Sui | Global Node, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
@@ -98,6 +99,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Unichain | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Vana | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | WEMIX | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
+| World Chain | Global Node | Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | XDC | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | XLayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
 | Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -22,7 +22,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 | Protocols | Classification |
 | --- | --- |
-| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Arc, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo, Robinhood Chain | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
+| Ethereum, Polygon, BNB Smart Chain, Arbitrum, Arc, Base, Optimism, Avalanche, Linea, Mantle, Berachain, Scroll, Zora, Sonic, Unichain, Monad, Hyperliquid (HyperEVM), Plasma, Kaia, Cronos, Gnosis Chain, Celo, MegaETH, Ronin, Fantom, zkSync Era, Blast, Tempo, Robinhood Chain, World Chain, Stable | Less than 127 blocks behind the tip is **full**; 127 or more blocks behind is **archive** |
 | Solana | **Archive** billing applies to specific methods when fetching historical slots. See [Solana method scope](#solana-method-scope) below. |
 | TON | Most requests are **full**. `getTransactions` and `getTransactionsStd` are always **archive**; block/seqno methods are **archive** when the requested seqno is more than 128 behind the tip. See [TON method scope](#ton-method-scope) below. |
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1647,6 +1647,72 @@
       ],
       "additional_notes": "N/A"
     },
+    "World Chain": {
+      "protocol_name": "World Chain",
+      "supported_modes": [
+        "Full",
+        "Archive"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": true,
+      "debug_trace_available": true,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "N/A",
+      "mainnet": {
+        "network_name": "Mainnet",
+        "faucet_url": "N/A",
+        "locations": [
+          {
+            "cloud": "Chainstack Partner Network",
+            "node_type": "Global Node",
+            "region": "global2",
+            "location": "Worldwide",
+            "deployment_options": [
+              {
+                "mode": "Archive",
+                "debug_trace": true,
+                "warp_transactions": false
+              }
+            ]
+          }
+        ]
+      },
+      "testnets": [],
+      "additional_notes": "N/A"
+    },
+    "Stable": {
+      "protocol_name": "Stable",
+      "supported_modes": [
+        "Full",
+        "Archive"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": true,
+      "debug_trace_available": true,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "N/A",
+      "mainnet": {
+        "network_name": "Mainnet",
+        "faucet_url": "N/A",
+        "locations": [
+          {
+            "cloud": "Chainstack Partner Network",
+            "node_type": "Global Node",
+            "region": "global2",
+            "location": "Worldwide",
+            "deployment_options": [
+              {
+                "mode": "Archive",
+                "debug_trace": true,
+                "warp_transactions": false
+              }
+            ]
+          }
+        ]
+      },
+      "testnets": [],
+      "additional_notes": "N/A"
+    },
     "Polkadot": {
       "protocol_name": "Polkadot",
       "supported_modes": [

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1669,6 +1669,11 @@
             "location": "Worldwide",
             "deployment_options": [
               {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
+              {
                 "mode": "Archive",
                 "debug_trace": true,
                 "warp_transactions": false
@@ -1701,6 +1706,11 @@
             "region": "global2",
             "location": "Worldwide",
             "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": true,
+                "warp_transactions": false
+              },
               {
                 "mode": "Archive",
                 "debug_trace": true,


### PR DESCRIPTION
## What

Adds **World Chain** and **Stable** as supported protocols. Both are available as Global Nodes on the Chainstack Partner Network, in archive mode with debug and trace, Mainnet only.

| | World Chain | Stable |
| --- | --- | --- |
| Architecture | EVM-compatible OP Stack L2 | EVM-compatible Layer 1 |
| Chain ID | 480 | 988 |
| Node type | Global Node | Global Node |
| Mode | Archive (debug and trace) | Archive (debug and trace) |

## Changes

- `node-options-master-list.json` — World Chain and Stable entries (source of truth): Global Node on the Chainstack Partner Network (`global2`), archive, Mainnet only, no dedicated/testnet.
- `docs/protocols-networks.mdx` — rows (alphabetical): Stable after Sonic, World Chain after WEMIX.
- `docs/nodes-clouds-regions-and-locations.mdx` — World Chain and Stable sections (Mainnet, Partner Network `global2`, archive).
- `docs/request-units.mdx` — both added to the EVM 127-block archive-billing list.

Follows the same shape as the existing MegaETH entry.

## Local validation

- `node-options-master-list.json` — valid JSON, entries parse.
- `mintlify broken-links` — no new broken links.

## Notes

- Global Nodes only, Mainnet only (no dedicated nodes, no testnet).
- The release note shipped separately.