### PR TITLE
docs: add World Chain and Stable tooling pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1500,7 +1500,9 @@
               "docs/plasma-tooling",
               "docs/tempo-tooling",
               "docs/robinhood-tooling",
-                    "docs/arc-tooling",
+              "docs/arc-tooling",
+              "docs/worldchain-tooling",
+              "docs/stable-tooling",
               "docs/near-tooling"
             ]
           }

--- a/docs/stable-tooling.mdx
+++ b/docs/stable-tooling.mdx
@@ -1,0 +1,156 @@
+---
+title: "Stable tooling"
+description: "Connect MetaMask, ethers.js, viem, and web3.py to a Stable node on Chainstack. Chain configuration, the USDT0 gas token and its two decimal counts, and the behaviors that affect tooling."
+---
+
+Stable is EVM-compatible, so the standard Ethereum libraries work against a Stable node without modification. The differences are in the chain configuration and in a handful of methods the client does not implement.
+
+## Chain configuration
+
+| Property | Value |
+|----------|-------|
+| Network | Stable Mainnet |
+| Chain ID | `988` |
+| Native gas currency | USDT0 |
+| Decimals | `18` |
+| Block time | ~0.7 seconds |
+| RPC URL | your Chainstack [Stable endpoint](/docs/manage-your-node#view-node-access-and-credentials) |
+| Multicall3 | `0xcA11bde05977b3631167028862bE2a173976CA11` |
+| Explorer | [stablescan.xyz](https://stablescan.xyz) |
+
+<Warning>
+  **Two different USDT0 decimal counts on one chain.** The native gas currency carries **18 decimals**, so gas balances are wei-denominated exactly as on Ethereum and `formatEther` and `from_wei(..., "ether")` are the correct helpers.
+
+  The USDT0 **ERC-20 token** at `0x779Ded0c9e1022225f8E0630b35a9b54bE713736` reports **6 decimals**. Format that one with `formatUnits(value, 6)`, not `formatEther`.
+
+  Both are called USDT0, so the mistake is easy to make and puts you out by a factor of 10<sup>12</sup> in whichever direction you got it wrong.
+</Warning>
+
+See [Stable methods](/docs/stable-methods) for per-method availability and [Debug and trace APIs](/docs/debug-and-trace-apis#stable) for the tracing namespaces.
+
+## MetaMask
+
+Add Stable Mainnet as a custom network. On Chainstack, get your [Stable endpoint](/docs/manage-your-node#view-node-access-and-credentials), then in MetaMask select **Add a custom network** and fill in:
+
+* Network name — Stable
+* Default RPC URL — your Chainstack Stable endpoint
+* Chain ID — `988`
+* Currency symbol — USDT0
+* Block explorer URL — `https://stablescan.xyz`
+
+## ethers.js
+
+Install [ethers.js](https://docs.ethers.org/):
+
+<CodeGroup>
+```shell Shell
+npm install ethers
+```
+</CodeGroup>
+
+<CodeGroup>
+```javascript index.js
+const { JsonRpcProvider, formatEther } = require("ethers");
+
+const provider = new JsonRpcProvider("CHAINSTACK_NODE_URL");
+
+async function main() {
+  const network = await provider.getNetwork();
+  console.log("Chain ID:", network.chainId.toString());
+
+  const block = await provider.getBlockNumber();
+  console.log("Block:", block);
+
+  const balance = await provider.getBalance("0x71B7c43c004D99A1091A532808b8E9c812eC51F8");
+  console.log("Balance:", formatEther(balance), "USDT0");
+}
+
+main();
+```
+</CodeGroup>
+
+## viem
+
+Stable ships in viem's bundled chain list as `stable`, so you do not need `defineChain`:
+
+<CodeGroup>
+```shell Shell
+npm install viem
+```
+</CodeGroup>
+
+<CodeGroup>
+```javascript index.mjs
+import { createPublicClient, http, formatEther, formatUnits } from "viem";
+import { stable } from "viem/chains";
+
+const client = createPublicClient({
+  chain: stable,
+  transport: http("CHAINSTACK_NODE_URL"),
+});
+
+console.log("Chain ID:", await client.getChainId());
+console.log("Block:", await client.getBlockNumber());
+
+// Native USDT0 — 18 decimals.
+const balance = await client.getBalance({
+  address: "0x71B7c43c004D99A1091A532808b8E9c812eC51F8",
+});
+console.log("Gas balance:", formatEther(balance), "USDT0");
+
+// The USDT0 ERC-20 — 6 decimals.
+const totalSupply = await client.readContract({
+  address: "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+  abi: [{
+    name: "totalSupply", type: "function", inputs: [],
+    outputs: [{ type: "uint256" }], stateMutability: "view",
+  }],
+  functionName: "totalSupply",
+});
+console.log("USDT0 token supply:", formatUnits(totalSupply, 6));
+```
+</CodeGroup>
+
+Pass your Chainstack endpoint to `http()` as above. The bundled chain definition carries a public RPC URL, and `http()` with no argument would use that instead of your node.
+
+## web3.py
+
+Install [web3.py](https://web3py.readthedocs.io/):
+
+<CodeGroup>
+```shell Shell
+pip install web3
+```
+</CodeGroup>
+
+<CodeGroup>
+```python main.py
+from web3 import Web3
+
+web3 = Web3(Web3.HTTPProvider("CHAINSTACK_NODE_URL"))
+
+print("Connected:", web3.is_connected())
+print("Chain ID:", web3.eth.chain_id)
+print("Block:", web3.eth.block_number)
+
+address = Web3.to_checksum_address("0x71b7c43c004d99a1091a532808b8e9c812ec51f8")
+balance = web3.eth.get_balance(address)
+print("Gas balance:", web3.from_wei(balance, "ether"), "USDT0")
+```
+</CodeGroup>
+
+<Note>
+  web3.py rejects lowercase addresses with `InvalidAddress`. Wrap any address you did not get from the library itself in `Web3.to_checksum_address()`, as above.
+</Note>
+
+## Stable behaviors that affect tooling
+
+**No `trace_*` namespace.** All nine Parity-style trace methods return `-32601`. Any library helper or indexer that reaches for `trace_block` or `trace_transaction` will fail. Use `debug_traceBlockByNumber` and `debug_traceTransaction` with the `callTracer` instead — see [Stable methods](/docs/stable-methods#the-trace-namespace-is-not-served) for the full swap table.
+
+**The transaction pool responds but is always empty.** `txpool_status`, `txpool_content`, `txpool_contentFrom`, and `txpool_inspect` all return successfully and report nothing pending. Pending-transaction subscriptions and filters behave the same way: they hand back an ID and then deliver no transactions. Do not build a pending-transaction feed on Stable. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+
+**Three methods behave unlike Geth.** `eth_getProof` returns a Cosmos IAVL proof rather than an Ethereum Merkle-Patricia proof, and needs an explicit block number — passing `latest` returns `-32000 proof queries at height <= 2 are not supported`. `eth_createAccessList` returns `-32603 method handler crashed`; since Stable charges a flat base fee, an access list buys you nothing here anyway. `eth_simulateV1` is not implemented.
+
+**`eth_getLogs` is capped at 10,000 blocks.** Exceeding it returns `-32000 maximum [from, to] blocks distance: 10000`, and a query that matches too much returns `-32000 query returned more than 10000 results`. Paginate on both. See [EVM range limits](/docs/limits#evm-range-limits).
+
+**Filters are node-local.** A [Global Node](/docs/global-elastic-node) endpoint is load balanced across backends, and a filter created by `eth_newFilter` or `eth_newBlockFilter` lives on the backend that created it. A follow-up `eth_getFilterChanges` that lands elsewhere returns `-32000 filter not found`. Poll [eth\_getLogs](/reference/ethereum-getlogs) over an explicit block range instead, or hold a WSS subscription, which keeps one connection to one backend for its lifetime.

--- a/docs/worldchain-tooling.mdx
+++ b/docs/worldchain-tooling.mdx
@@ -1,0 +1,132 @@
+---
+title: "World Chain tooling"
+description: "Connect MetaMask, ethers.js, viem, and web3.py to a World Chain node on Chainstack. Chain configuration, and the three behaviors that affect tooling."
+---
+
+World Chain is an [OP Stack](https://docs.optimism.io/) layer 2, so the standard Ethereum libraries work against a World Chain node without modification. Gas is paid in ETH exactly as on Ethereum mainnet.
+
+## Chain configuration
+
+| Property | Value |
+|----------|-------|
+| Network | World Chain Mainnet |
+| Chain ID | `480` |
+| Native gas currency | ETH |
+| Decimals | `18` |
+| Block time | ~2 seconds |
+| RPC URL | your Chainstack [World Chain endpoint](/docs/manage-your-node#view-node-access-and-credentials) |
+| Multicall3 | `0xcA11bde05977b3631167028862bE2a173976CA11` |
+| Explorer | [worldscan.org](https://worldscan.org) |
+
+See [World Chain methods](/docs/worldchain-methods) for per-method availability and [Debug and trace APIs](/docs/debug-and-trace-apis#world-chain) for the tracing namespaces.
+
+## MetaMask
+
+Add World Chain Mainnet as a custom network. On Chainstack, get your [World Chain endpoint](/docs/manage-your-node#view-node-access-and-credentials), then in MetaMask select **Add a custom network** and fill in:
+
+* Network name — World Chain
+* Default RPC URL — your Chainstack World Chain endpoint
+* Chain ID — `480`
+* Currency symbol — ETH
+* Block explorer URL — `https://worldscan.org`
+
+## ethers.js
+
+Install [ethers.js](https://docs.ethers.org/):
+
+<CodeGroup>
+```shell Shell
+npm install ethers
+```
+</CodeGroup>
+
+<CodeGroup>
+```javascript index.js
+const { JsonRpcProvider, formatEther } = require("ethers");
+
+const provider = new JsonRpcProvider("CHAINSTACK_NODE_URL");
+
+async function main() {
+  const network = await provider.getNetwork();
+  console.log("Chain ID:", network.chainId.toString());
+
+  const block = await provider.getBlockNumber();
+  console.log("Block:", block);
+
+  const balance = await provider.getBalance("0xC2Ca6E8f5764E377F72A206Ab6E2805607aC405a");
+  console.log("Balance:", formatEther(balance), "ETH");
+}
+
+main();
+```
+</CodeGroup>
+
+## viem
+
+World Chain ships in viem's bundled chain list as `worldchain`, so you do not need `defineChain`:
+
+<CodeGroup>
+```shell Shell
+npm install viem
+```
+</CodeGroup>
+
+<CodeGroup>
+```javascript index.mjs
+import { createPublicClient, http, formatEther } from "viem";
+import { worldchain } from "viem/chains";
+
+const client = createPublicClient({
+  chain: worldchain,
+  transport: http("CHAINSTACK_NODE_URL"),
+});
+
+console.log("Chain ID:", await client.getChainId());
+console.log("Block:", await client.getBlockNumber());
+
+const balance = await client.getBalance({
+  address: "0xC2Ca6E8f5764E377F72A206Ab6E2805607aC405a",
+});
+console.log("Balance:", formatEther(balance), "ETH");
+```
+</CodeGroup>
+
+Pass your Chainstack endpoint to `http()` as above. The bundled chain definition carries a public RPC URL, and `http()` with no argument would use that instead of your node.
+
+## web3.py
+
+Install [web3.py](https://web3py.readthedocs.io/):
+
+<CodeGroup>
+```shell Shell
+pip install web3
+```
+</CodeGroup>
+
+<CodeGroup>
+```python main.py
+from web3 import Web3
+
+web3 = Web3(Web3.HTTPProvider("CHAINSTACK_NODE_URL"))
+
+print("Connected:", web3.is_connected())
+print("Chain ID:", web3.eth.chain_id)
+print("Block:", web3.eth.block_number)
+
+address = Web3.to_checksum_address("0xc2ca6e8f5764e377f72a206ab6e2805607ac405a")
+balance = web3.eth.get_balance(address)
+print("Balance:", web3.from_wei(balance, "ether"), "ETH")
+```
+</CodeGroup>
+
+<Note>
+  web3.py rejects lowercase addresses with `InvalidAddress`. Wrap any address you did not get from the library itself in `Web3.to_checksum_address()`, as above.
+</Note>
+
+## Three World Chain behaviors that affect tooling
+
+**There is no transaction pool to read.** The `txpool_*` namespace is not served — `txpool_status`, `txpool_content`, `txpool_contentFrom`, and `txpool_inspect` all return `-32601`. No mode or plan change turns them on, because World Chain is an OP Stack chain and pending transactions stay with the sequencer.
+
+**Pending-transaction subscriptions succeed and then deliver nothing.** `eth_subscribe("newPendingTransactions")` returns a subscription ID and `eth_newPendingTransactionFilter` returns a filter ID, so neither call looks like it failed. No transaction ever arrives. `newHeads` and `logs` subscriptions both work normally. See [What gives you mempool access](/docs/mempool-configuration#what-gives-you-mempool-access).
+
+**Filters are node-local.** A [Global Node](/docs/global-elastic-node) endpoint is load balanced across backends, and a filter created by `eth_newFilter` or `eth_newBlockFilter` lives on the backend that created it. A follow-up `eth_getFilterChanges` that lands elsewhere returns `-32602 filter not found`. Poll [eth\_getLogs](/reference/ethereum-getlogs) over an explicit block range instead, or hold a WSS subscription, which keeps one connection to one backend for its lifetime.


### PR DESCRIPTION
## What

The tooling pages for World Chain and Stable, completing the Arc-style set (methods + tooling) for both. Follows #627, #628, and #629.

Every snippet on both pages was run against live Chainstack Global Nodes with **ethers 6.17.0**, **viem 2.55.10**, and **web3.py 7.16.0**.

## Chain parameters came from two independent sources, then a sanity check

Getting a native-currency decimal count wrong is a factor-of-10<sup>12</sup> error, so I did not take it on trust. The [ethereum-lists/chains](https://chainid.network/chains.json) registry and viem's bundled chain definitions agree on both chains, and the magnitudes confirm it:

| | World Chain | Stable |
| --- | --- | --- |
| Chain ID | 480 | 988 |
| Native currency | ETH, 18 decimals | USDT0, **18 decimals** |
| Block time | ~2s | ~0.7s |
| Multicall3 | canonical address, verified deployed | canonical address, verified deployed |
| Explorer | [worldscan.org](https://worldscan.org) | [stablescan.xyz](https://stablescan.xyz) |

On Stable, a real value transfer of `34.8975` USDT0 reads as `3.49 × 10¹³` if you assume 6 decimals, and a 21,000-gas transfer costs `0.0000236` USDT0 at 18 decimals versus a nonsensical `23,625,000` at 6. Both point the same way as the registries.

## The Stable decimals trap

`stable-tooling.mdx` leads with this because it is the thing most likely to cost someone money:

- The **native gas currency** is USDT0 with **18 decimals** — `formatEther` / `from_wei(..., "ether")`.
- The **USDT0 ERC-20** at `0x779Ded0c9e1022225f8E0630b35a9b54bE713736` reports **6 decimals** — `formatUnits(value, 6)`.

Both are called USDT0. I read both counts off the live chain rather than inferring one from the other.

## A viem gotcha worth the warning

Both chains ship in viem's bundled list (`worldchain`, `stable`), so the snippets import them directly instead of calling `defineChain`. But each definition carries a public RPC — `worldchain-mainnet.g.alchemy.com/public` and `rpc.stable.xyz` — and I verified that `http()` with no argument silently resolves to it and works. A reader following a stock viem example would end up querying Alchemy rather than their Chainstack node without any error to hint at it, so both pages say to pass the endpoint to `http()` explicitly.

## What each page closes with

Behaviours that break tooling specifically, all verified:

- **World Chain** — no `txpool_*` namespace at all; pending-transaction subscriptions that return an ID and then deliver nothing; node-local filters on a load-balanced endpoint (`-32602 filter not found`).
- **Stable** — no `trace_*` namespace; a transaction pool that responds but is always empty; `eth_getProof` returning a Cosmos IAVL proof and rejecting `latest`; `eth_createAccessList` returning `-32603 method handler crashed`; no `eth_simulateV1`; the 10,000-block `eth_getLogs` cap; node-local filters.

## One thing I deliberately left out

I tested the ethers v6 log-subscription issue where a load-balanced endpoint delivers zero log events unless you pass `staticNetwork`. It **did not reproduce** on World Chain — 195 log events in 16 seconds without it, 222 with. So there is no warning about it on these pages; documenting a gotcha that does not occur here would send readers chasing a non-problem.

## Local validation

- `mintlify broken-links` — clean.
- `docs.json` — parses; both pages added to the tooling nav group, and the stray indentation on the neighbouring `arc-tooling` entry straightened while there.
- Every internal link and heading anchor resolves.
- `mintlify dev` — both pages return 200 with every value, address, and code block present in the rendered output.
- Every address is EIP-55 checksummed. viem enforces this at call time, so an unchecksummed address in a snippet would fail for the reader — one of mine did during testing, which is why they are all computed rather than typed.
