### PR TITLE
fix(docs): update Arbitrum testnet chain ID from 421613 (Goerli) to 421614 (Sepolia)

### DIFF
--- a/docs/arbitrum-tooling.mdx
+++ b/docs/arbitrum-tooling.mdx
@@ -282,7 +282,7 @@ where
 * NETWORK\_ID — Arbitrum network ID:
 
   * Mainnet: `42161`
-  * Testnet: `421613`
+  * Testnet: `421614`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -307,7 +307,7 @@ where
 * NETWORK\_ID — Arbitrum network ID:
 
   * Mainnet: `42161`
-  * Testnet: `421613`
+  * Testnet: `421614`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -333,7 +333,7 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
    * NETWORK\_ID — Arbitrum network ID:
 
      * Mainnet: `42161`
-     * Testnet: `421613`
+     * Testnet: `421614`
 
 Example to run the deployment script:
 

--- a/reference/arbitrum-getting-started.mdx
+++ b/reference/arbitrum-getting-started.mdx
@@ -13,7 +13,7 @@ Arbitrum is a layer 2 scaling solution for Ethereum that enhances transaction pr
 
 To bridge assets between Ethereum and Arbitrum, simply use the [Arbitrum bridge](https://bridge.arbitrum.io/?l2ChainId=42161). The process is easy and takes around 10 minutes to complete. Just connect to MetaMask and follow the steps.
 
-You can also try out Arbitrum on the Chainstack platform by deploying an Arbitrum Sepolia testnet node and bridging some Sepolia ETH using the [testnet Arbitrum bridge](https://bridge.arbitrum.io/?l2ChainId=421613).
+You can also try out Arbitrum on the Chainstack platform by deploying an Arbitrum Sepolia testnet node and bridging some Sepolia ETH using the [testnet Arbitrum bridge](https://bridge.arbitrum.io/?l2ChainId=421614).
 
 Find useful Arbitrum tools in the [Arbitrum tooling](/docs/arbitrum-tooling) section.
 


### PR DESCRIPTION
## What

`docs/arbitrum-tooling.mdx` had the Arbitrum testnet chain ID set to `421613` in three ethers.js code examples. `421613` is the Arbitrum Goerli testnet which was shut down. The correct chain ID for the current Arbitrum Sepolia testnet is `421614`.

Updated lines 285, 310, and 336.

## Why

A developer copying this chain ID into their project would configure their provider to connect to a non existent network, silently failing or producing confusing errors.

Closes #632