### PR TITLE
docs: retire dead testnet chain IDs on the Optimism and Polygon tooling pages

### DIFF
--- a/docs/optimism-tooling.mdx
+++ b/docs/optimism-tooling.mdx
@@ -282,7 +282,7 @@ where
 * NETWORK\_ID — Optimism network ID:
 
   * Mainnet: `10`
-  * Testnet: `420`
+  * Testnet: `11155420`
 
 See [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -311,7 +311,7 @@ where
 * NETWORK\_ID — Optimism network ID:
 
   * Mainnet: `10`
-  * Testnet: `420`
+  * Testnet: `11155420`
 
 See [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -338,7 +338,7 @@ where
 * NETWORK\_ID — Optimism network ID:
 
   * Mainnet: `10`
-  * Testnet: `420`
+  * Testnet: `11155420`
 
 Example to run the deployment script:
 

--- a/docs/polygon-tooling.mdx
+++ b/docs/polygon-tooling.mdx
@@ -342,7 +342,7 @@ where
 * NETWORK\_ID — Polygon network ID:
 
   * Mainnet: `137`
-  * Mumbai testnet: `80001`
+  * Amoy testnet: `80002`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -367,7 +367,7 @@ where
 * NETWORK\_ID — Polygon network ID:
 
   * Mainnet: `137`
-  * Mumbai testnet: `80001`
+  * Amoy testnet: `80002`
 
 See also [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
@@ -387,7 +387,8 @@ See also [node access details](/docs/manage-your-node#view-node-access-and-crede
    * YOUR\_CHAINSTACK\_ENDPOINT — your node HTTPS or WSS endpoint protected either with the key or password
    * NETWORK\_ID — Polygon network ID:
      * Mainnet: `137`
-     * Mumbai testnet: `80001`
+     * Amoy testnet: `80002`
+
 Example to run the deployment script:
 
 <CodeGroup>


### PR DESCRIPTION
## What

Two live tooling pages hand out a chain ID for a testnet that no longer exists. A developer copying either one configures a provider against a network that isn't there.

| Page | Says | Network | Should be |
| --- | --- | --- | --- |
| `docs/optimism-tooling.mdx` ×3 | `420` | Optimism Goerli | `11155420` (OP Sepolia) |
| `docs/polygon-tooling.mdx` ×3 | `80001` | Mumbai — shut down | `80002` (Amoy) |

On the Polygon page the label changes with the number, since it named the network: `Mumbai testnet: 80001` → `Amoy testnet: 80002`.

## Verified three ways each

1. The [ethereum-lists/chains](https://chainid.network/chains.json) registry: `420` = Optimism Goerli, `11155420` = OP Sepolia; `80001` = Mumbai, `80002` = Amoy.
2. The Chainstack deploy catalog offers only `optimism-sepolia` and `polygon-pos-amoy` — the old testnets are not deployable at all, so the docs named networks a reader could not have used even if they wanted to.
3. Our own [Networks](/docs/protocols-networks) table already says **Optimism Sepolia Testnet** and **Amoy Testnet**.

Neither page carries a deprecation notice, and neither mentioned the current testnet name anywhere before this change — Amoy appeared zero times in `polygon-tooling.mdx`, Sepolia zero times in `optimism-tooling.mdx`.

## How these were found

Sertug17 reported the identical bug on Arbitrum (`421613`, Arbitrum Goerli) in #632 / #633. That report is correct and is being handled in his PR. It prompted me to sweep all 58 tooling and getting-started pages for chain IDs that the registry maps to a retired testnet, which turned up these two. Pages that carry a deprecation notice were excluded — the Goerli-era tutorials are deliberately preserved as historical and are correctly flagged.

The sweep found nothing else: the remaining `goerli` hits in the repo are changelog entries (historical records), platform-API network enums in `openapi.json`, and a redirect, none of which should change.

## One adjacent fix

`polygon-tooling.mdx` was missing a blank line before "Example to run the deployment script:", which made that sentence a lazy continuation of the preceding list item instead of its own paragraph. The Optimism page already has the blank line. Since the change sits on the line directly above, it is fixed here.

## Local validation

- `mintlify broken-links` — clean.
- `mintlify dev` — both pages return 200, render the new IDs, and contain no remaining `420`, `80001`, or "Mumbai".
- Mainnet IDs (`10`, `137`) confirmed untouched.
