### PR TITLE
docs: World Chain and Stable offer Dedicated Nodes on request

### DIFF
--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -84,7 +84,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Solana | Global Node, Dedicated | Full, Archive | Full, Archive | Devnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Soneium | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-soneium/#request) |
 | Sonic | Global Node, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Stable | Global Node | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| Stable | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Global Node, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Sui | Global Node, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
@@ -99,7 +99,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Unichain | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Vana | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | WEMIX | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-wemix/#request) |
-| World Chain | Global Node | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+| World Chain | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | XDC | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | XLayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
 | Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1657,7 +1657,7 @@
       "archive_mode_available": true,
       "debug_trace_available": true,
       "warp_transactions_available": false,
-      "dedicated_node_availability": "N/A",
+      "dedicated_node_availability": "Contact us",
       "mainnet": {
         "network_name": "Mainnet",
         "faucet_url": "N/A",
@@ -1695,7 +1695,7 @@
       "archive_mode_available": true,
       "debug_trace_available": true,
       "warp_transactions_available": false,
-      "dedicated_node_availability": "N/A",
+      "dedicated_node_availability": "Contact us",
       "mainnet": {
         "network_name": "Mainnet",
         "faucet_url": "N/A",


### PR DESCRIPTION
## What

Closes the one open question left over from #627.

Both protocols shipped with `dedicated_node_availability: "N/A"`, which made the docs read **Global Node only** with no request-deployment path. I flagged it on #627 rather than deciding a commercial claim myself, and @CSFeo confirmed:

> Dedicated: let's go with `Contact us` for both World Chain and Stable — so the Support column flips to `Global Node, Dedicated` with a Request deployment path, matching Linea/Mantle/Zora/Polkadot. Please push it.

## Changes

- `node-options-master-list.json` — `"N/A"` → `"Contact us"` for World Chain and Stable.
- `docs/protocols-networks.mdx` — the Support column follows: `Global Node` → `Global Node, Dedicated`.

Four lines total.

## Matching the named comparators

Linea, Mantle, Zora, and Polkadot all carry `Contact us` in the master list with a `Global Node, Dedicated` Support cell, while keeping **`Deploy through platform`** in the Deploy column — they are platform-deployable as Global Nodes, and the dedicated path is the request one. So:

- The Deploy column stays `Deploy through platform` on both rows.
- `nodes-clouds-regions-and-locations.mdx` needs nothing — those four list only their Global Node rows there, with no dedicated rows.

## Note

The master list round-trips byte-identically through `json.dumps(indent=2)`, so this is a genuine two-line change to that file rather than a reformat.

`mintlify broken-links` clean. Follows #627, #628, #629, #630.
