### PR TITLE
CORE-15682 self-hosted release notes v2.23.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3552,6 +3552,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-14-0-july-29-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026.mdx
@@ -1,0 +1,27 @@
+---
+title: "Chainstack Self-Hosted v2.23.0: August 6, 2026"
+description: "XRP Ledger Mainnet and Testnet are now available as deployment targets."
+---
+
+This release adds XRP Ledger as a deployment target, covering both Mainnet and Testnet.
+
+## XRP Ledger support
+
+XRP Ledger Mainnet and Testnet are now available as deployment targets, each running a single xrpld node as a non-validator in full mode.
+
+- XRP Ledger Mainnet — explorer at [livenet.xrpl.org](https://livenet.xrpl.org)
+- XRP Ledger Testnet — explorer at [testnet.xrpl.org](https://testnet.xrpl.org)
+- Endpoints — HTTP JSON-RPC and the WebSocket API. The XRP Ledger subscription methods are available over WebSocket only, so both endpoints are exposed
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.3.0 |
+| cp-workflows | v3.24.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.23.0: August 6, 2026" description="">
+
+This release adds XRP Ledger as a deployment target, covering both Mainnet and Testnet. Each deployment runs a single xrpld node as a non-validator in full mode, serving HTTP JSON-RPC and the WebSocket API.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.21.0: August 4, 2026" description="">
 
 This release adds Avalanche, Arc, and World Chain as deployment targets. Avalanche runs a single node that serves the whole Primary Network, Arc runs a paired execution and consensus node, and World Chain joins the OP Stack deployments. The bundled Kubernetes Grafana dashboards also render correctly again.

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -1,6 +1,15 @@
 {
   "_comment": "Single source of truth for Chainstack Self-Hosted deployments. Hand-maintained from upstream preset/network definitions and client port definitions. When a preset changes, edit this file and regenerate the tables in docs/self-hosted/supported-clients-and-protocols.mdx and docs/self-hosted/requirements.mdx. Storage is given per client in GiB; deployment totals are the sum across the deployment's clients. Light presets use half the CPU/RAM of the standard preset with the same storage.",
   "clients": {
+    "xrpld": {
+      "label": "xrpld",
+      "role": "full",
+      "ports": [
+        { "port": 5005, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 6006, "proto": "TCP", "purpose": "WebSocket API", "exposed": true },
+        { "port": 2459, "proto": "TCP", "purpose": "P2P", "exposed": false }
+      ]
+    },
     "reth": {
       "label": "Reth",
       "role": "execution",
@@ -173,6 +182,13 @@
     }
   },
   "families": {
+    "xrpl": {
+      "label": "XRP Ledger",
+      "notes": [
+        "Runs a single full node client that serves both the JSON-RPC and the WebSocket API.",
+        "Syncs from the network rather than from a snapshot, retaining a minimum practical ledger window."
+      ]
+    },
     "evm-l1-dual": {
       "label": "EVM Layer 1 (execution + consensus)",
       "notes": [
@@ -538,6 +554,26 @@
         { "client": "arc-consensus", "version": "0.7.3", "cpu": 2, "ramGi": 8,  "storageGi": 64 }
       ],
       "totals": { "cpu": 8, "ramGi": 32, "storageGi": 314 }
+    },
+    {
+      "protocol": "XRP Ledger", "network": "Mainnet", "chainId": null,
+      "explorer": "https://livenet.xrpl.org",
+      "family": "xrpl", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "xrpld", "version": "3.2.1", "cpu": 8, "ramGi": 32, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 32, "storageGi": 50 }
+    },
+    {
+      "protocol": "XRP Ledger", "network": "Testnet", "chainId": null,
+      "explorer": "https://testnet.xrpl.org",
+      "family": "xrpl", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "xrpld", "version": "3.2.1", "cpu": 4, "ramGi": 16, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.23.0 release note. Adds XRP Ledger to the supported-deployments catalog.