### PR TITLE
docs(changelog): announce XRP Ledger protocol support (August 7, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: August 7, 2026" description=" by Ake">
+
+**Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.
+
+<Button href="/changelog/chainstack-updates-august-7-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: August 4, 2026" description=" by Ake">
 
 **Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) for World Chain Mainnet and Stable Mainnet.

--- a/changelog/chainstack-updates-august-7-2026.mdx
+++ b/changelog/chainstack-updates-august-7-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: August 7, 2026"
+description: "XRP Ledger — the payments-focused L1 running the rippled client — is now supported on Chainstack across Global Nodes and Dedicated Nodes, Mainnet and Testnet."
+---
+
+**Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.

--- a/docs.json
+++ b/docs.json
@@ -3290,6 +3290,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-7-2026",
           "changelog/chainstack-updates-august-4-2026",
           "changelog/chainstack-updates-july-27-2026",
           "changelog/chainstack-updates-july-23-2026",


### PR DESCRIPTION
Announces XRP Ledger support. Same three-file shape as #547 (Robinhood): new `changelog/` entry, `<Update>` block on `changelog.mdx`, page registered in `docs.json`.

Live now — chainstack/core#4716 flipped the protocol to ACTIVE and it is deployed, so Global Nodes are deployable from the console for Mainnet and Testnet.

Deliberately narrower than the Robinhood and Arc entries: **Full mode only**, no Archive and no "debug and trace". Archive was out of scope for this onboarding, and `debug_`/`trace_` are EVM namespaces that do not exist on XRPL — it has its own JSON-RPC and WebSocket API rather than `eth_*`, which is the one thing worth flagging to a reader who assumes every new chain is EVM.
