### PR TITLE
docs: add XRP Ledger to the master list and protocol tables

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -345,6 +345,13 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 | Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 
+## XRP Ledger
+
+| Network | Cloud                     | Region  | Location  | Mode |
+| ------- | ------------------------- | ------- | --------- | ---- |
+| Mainnet | Chainstack Global Network | global1 | Worldwide | Full |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Full |
+
 ## Bitcoin
 
 | Network | Cloud                     | Region  | Location    | Mode |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -102,6 +102,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | World Chain | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | XDC | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | XLayer | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-xlayer/#request) |
+| XRP Ledger | Global Node, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Zcash | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Zircuit | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-zircuit/#request) |
 | zkLink | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-zklink/#request) |

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -28,7 +28,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |
 | Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Polkadot | Most requests are **full**. Sidecar trace endpoints are always **2 RUs**; `chain_getBlockHash` and block-scoped Sidecar endpoints are **archive** when the requested block is more than 128 behind the tip. See [Polkadot method scope](#polkadot-method-scope) below. |
-| Bitcoin, Sui, TRON, opBNB, Harmony | No archive split — every request is billed as full |
+| Bitcoin, Sui, TRON, opBNB, Harmony, XRP Ledger | No archive split — every request is billed as full |
 
 ## Always 2 RUs
 

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3685,7 +3685,7 @@
       "testnets": [
         {
           "network_name": "Testnet",
-          "faucet_url": "N/A",
+          "faucet_url": "https://xrpl.org/resources/dev-tools/xrp-faucets",
           "locations": [
             {
               "cloud": "Chainstack Global Network",

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3652,6 +3652,58 @@
       },
       "testnets": [],
       "additional_notes": "Dedicated nodes only"
+    },
+    "XRP Ledger": {
+      "protocol_name": "XRP Ledger",
+      "supported_modes": [
+        "Full"
+      ],
+      "full_mode_query_limit": "N/A",
+      "archive_mode_available": false,
+      "debug_trace_available": false,
+      "warp_transactions_available": false,
+      "dedicated_node_availability": "Platform",
+      "mainnet": {
+        "network_name": "Mainnet",
+        "faucet_url": "N/A",
+        "locations": [
+          {
+            "cloud": "Chainstack Global Network",
+            "node_type": "Global Node",
+            "region": "global1",
+            "location": "Worldwide",
+            "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": false,
+                "warp_transactions": false
+              }
+            ]
+          }
+        ]
+      },
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "N/A",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Full",
+                  "debug_trace": false,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "additional_notes": "N/A"
     }
   }
 }


### PR DESCRIPTION
## What

The companion to #638. That PR announced XRP Ledger support, but the protocol was absent from `node-options-master-list.json` and from all three tables it drives — so the changelog advertised a chain the Networks page did not list. Same sequencing as #626 → #627.

## Verified against a live node first

I deployed an XRP Ledger Global Node and probed it rather than taking the announcement at face value:

| | Result |
| --- | --- |
| Deploy catalog | `xrpl-mainnet` + `xrpl-testnet`, Global Node, Chainstack Global Network `global1`, features **`["full"]`** — no archive |
| `server_info` | `server_state: full`, `build_version 3.2.0`, validated ledger 2s behind tip, 10 peers |
| Method surface | `server_info`, `server_state`, `ledger`, `ledger_current`, `fee`, `account_info`, `tx_history` all respond |

So the "Full mode only, no Archive" framing in #638 is correct, and XRPL genuinely has its own JSON-RPC rather than an `eth_*` interface.

## Changes

- **`node-options-master-list.json`** — XRP Ledger: `Full` only, `archive_mode_available: false`, `debug_trace_available: false` (XRPL is not EVM; there are no `debug_`/`trace_` namespaces to have), Mainnet and Testnet each a Global Node on `global1`. Modelled on **Bitcoin**, the closest structural match in the file: non-EVM, full-only, no archive.
- **`docs/protocols-networks.mdx`** — row in alphabetical position between XLayer and Zcash, Debug and Trace `No`.
- **`docs/nodes-clouds-regions-and-locations.mdx`** — a section in the non-EVM table format that omits the Debug & trace column, matching Bitcoin and Solana.
- **`docs/request-units.mdx`** — joins the existing `No archive split — every request is billed as full` row.

## Two calls worth surfacing for review

**The RU classification is derived, not invented.** XRPL has no archive tier in the catalog, so there is nothing to bill as archive — Bitcoin, Sui, TRON, opBNB and Harmony sit in that same row for the same reason. I did not make up a threshold. If billing intends something else for XRPL, this is the line to correct.

**`dedicated_node_availability: "Platform"` rests on Ake's confirmation, not on a probe.** `get_deployment_options` only ever exposes `Global` and `Trader` tiers — Dedicated is not enumerated there for *any* protocol — so it cannot be verified from outside. Ake checked and confirmed dedicated is available, which is also what #638's changelog says.

## One observation I deliberately did not encode

The node reported `complete_ledgers` spanning 23,884 ledgers, roughly **26.5 hours** of history at ~4s per ledger. That is a useful figure but it is a single sample of a moving window, so `full_mode_query_limit` is `N/A` (as Bitcoin has) rather than a number I would be enshrining from one observation. Worth confirming with the protocol owner if we want it documented.

## Local validation

- `mintlify broken-links` — clean.
- `node-options-master-list.json` parses, and round-trips byte-identically through `json.dumps(indent=2)`, so the diff is a clean insert with no reformatting churn.
- `mintlify dev` — all three pages return 200; the row, the section (3 rendered rows: header + Mainnet + Testnet), and the RU classification are all present in the rendered output.
