### PR TITLE
docs(changelog): announce Faucet in Console

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -10,7 +10,7 @@ import { Button } from '/snippets/button.mdx';
 
 **Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.
 
-**Faucet**. The Chainstack faucet is now built into the console. Open [Faucet](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save the wallets you fund most often — each can carry a recurring auto-claim on the schedule you set.
+**Faucet**. The Chainstack faucet is now built into the console. Open [**Faucet**](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save wallets with a recurring auto-claim.
 
 <Button href="/changelog/chainstack-updates-august-7-2026">Read more</Button>
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -10,6 +10,8 @@ import { Button } from '/snippets/button.mdx';
 
 **Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.
 
+**Faucet**. The Chainstack faucet is now built into the console. Open [Faucet](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save the wallets you fund most often — each can carry a recurring auto-claim on the schedule you set.
+
 <Button href="/changelog/chainstack-updates-august-7-2026">Read more</Button>
 </Update>
 

--- a/changelog/chainstack-updates-august-7-2026.mdx
+++ b/changelog/chainstack-updates-august-7-2026.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Chainstack updates: August 7, 2026"
-description: "XRP Ledger — the payments-focused L1 running the rippled client — is now supported on Chainstack across Global Nodes and Dedicated Nodes, Mainnet and Testnet, and the faucet is now built into the Chainstack console with saved wallets and scheduled auto-claims."
+description: "XRP Ledger — the payments-focused L1 running the rippled client — is now supported on Chainstack across Global Nodes and Dedicated Nodes, Mainnet and Testnet, and the faucet is now built into the console with saved wallets and scheduled auto-claims."
 ---
 
 **Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.
 
-**Faucet**. The Chainstack faucet is now built into the console. Open [Faucet](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save the wallets you fund most often. Each saved wallet can carry a recurring auto-claim, so a development wallet tops itself up on the schedule you set instead of you returning to the faucet by hand. The standalone [faucet.chainstack.com](https://faucet.chainstack.com/) is unchanged and still available, and both serve the same [supported networks](/docs/faucets).
+**Faucet**. The Chainstack faucet is now built into the console. Open [**Faucet**](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save the wallets you fund most often — each can carry a recurring auto-claim that tops it up on the schedule you set. The standalone [faucet.chainstack.com](https://faucet.chainstack.com/) is unchanged, and both serve the same [supported networks](/docs/faucets).

--- a/changelog/chainstack-updates-august-7-2026.mdx
+++ b/changelog/chainstack-updates-august-7-2026.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Chainstack updates: August 7, 2026"
-description: "XRP Ledger — the payments-focused L1 running the rippled client — is now supported on Chainstack across Global Nodes and Dedicated Nodes, Mainnet and Testnet."
+description: "XRP Ledger — the payments-focused L1 running the rippled client — is now supported on Chainstack across Global Nodes and Dedicated Nodes, Mainnet and Testnet, and the faucet is now built into the Chainstack console with saved wallets and scheduled auto-claims."
 ---
 
 **Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.
+
+**Faucet**. The Chainstack faucet is now built into the console. Open [Faucet](https://console.chainstack.com/faucet) to request testnet tokens without a separate sign-in, and save the wallets you fund most often. Each saved wallet can carry a recurring auto-claim, so a development wallet tops itself up on the schedule you set instead of you returning to the faucet by hand. The standalone [faucet.chainstack.com](https://faucet.chainstack.com/) is unchanged and still available, and both serve the same [supported networks](/docs/faucets).

--- a/docs/faucets.mdx
+++ b/docs/faucets.mdx
@@ -28,6 +28,15 @@ The [Chainstack faucet](https://faucet.chainstack.com/) dispenses free testnet t
 
 The faucet tops up your address to a per-network cap. Each address can request once every 24 hours.
 
+### Request tokens from the console
+
+The faucet is also built into the Chainstack console, so you can request tokens without a separate sign-in.
+
+1. Open [Faucet](https://console.chainstack.com/faucet) in the console.
+2. Select a testnet, paste the destination address, and submit.
+
+You can save the wallets you fund most often. Each saved wallet can carry a recurring auto-claim, which tops it up on the schedule you set instead of you returning to the faucet by hand.
+
 ### Request tokens via the MCP server
 
 The [Chainstack MCP server](/docs/chainstack-mcp-server) exposes a `request_testnet_funds` tool so AI agents can fund a testnet address directly from your coding environment. Authentication uses your Chainstack API key.

--- a/docs/faucets.mdx
+++ b/docs/faucets.mdx
@@ -32,7 +32,7 @@ The faucet tops up your address to a per-network cap. Each address can request o
 
 The faucet is also built into the Chainstack console, so you can request tokens without a separate sign-in.
 
-1. Open [Faucet](https://console.chainstack.com/faucet) in the console.
+1. Open [**Faucet**](https://console.chainstack.com/faucet) in the console.
 2. Select a testnet, paste the destination address, and submit.
 
 You can save the wallets you fund most often. Each saved wallet can carry a recurring auto-claim, which tops it up on the schedule you set instead of you returning to the faucet by hand.


### PR DESCRIPTION
Adds a changelog entry for the faucet being built into the Chainstack console, which shipped but was never announced.

## Changes

- **`changelog/chainstack-updates-august-7-2026.mdx`** — adds a `**Faucet**` paragraph and extends the frontmatter description.
- **`changelog.mdx`** — the same paragraph, trimmed for the index card.
- **`docs/faucets.mdx`** — new "Request tokens from the console" section. The page only documented the standalone faucet, so the changelog would otherwise link to a page that doesn't mention the console flow.

No `docs.json` change needed — the August 7 entry is already registered in the nav.

## What the entry covers

Beyond being reachable in the console, the console faucet also offers saved wallets and a recurring auto-claim per wallet — that's the substance of the announcement. The standalone faucet is unchanged.

## Placement — please confirm

The convention is one entry per date, and August 7 already exists. Multi-topic entries are normal (July 27 carries both **Protocols** and **MCP Server**), so this appends rather than creating a new file — but it does edit an entry published the same day.

The alternative is the July 23 entry, which matches the actual ship date. I went with August 7 so the note is actually seen rather than landing behind already-published content. Happy to move the paragraph if you'd prefer the accurate date.

## Checks

`mint broken-links` — none of the three changed files appear in the report.

## Unrelated issue spotted

`docs/faucets.mdx` still lists Scroll Sepolia under supported networks, but the July 27 entry says it was retired from the faucet. Pre-existing and left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)