### PR TITLE
docs: Sui is a full node, not archive

### DIFF
--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -176,7 +176,7 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | Network | Cloud                      | Region    | Location  | Mode      |
 | ------- | -------------------------- | --------- | --------- | --------- |
 | Mainnet | Chainstack Global Network  | global1   | Worldwide | Full      |
-| Testnet | Chainstack Global Network  | global1   | Worldwide | Archive   |
+| Testnet | Chainstack Global Network  | global1   | Worldwide | Full      |
 
 ## Berachain
 

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -87,7 +87,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Stable | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Global Node, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
-| Sui | Global Node, Dedicated | Full | Archive | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
+| Sui (see note below) | Global Node, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Superseed | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | Taiko | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-taiko/#request) |
@@ -108,6 +108,8 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | zkLink | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/build-better-with-zklink/#request) |
 | ZKsync Era | Global Node, Dedicated | Full, Archive | Full, Archive | zkSync Era Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Zora | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
+
+Sui nodes are full nodes carrying up to about 6 months of historical state, with transaction history back to genesis. Every Sui request is billed as full.
 
 <Note>
   Chainstack also deploys bespoke Dedicated Nodes for chains not listed here. [Contact us](https://chainstack.com/contact/) to discuss your chain.

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -28,7 +28,8 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Aptos | Most requests are **full**. `/v1/accounts/{address}/transactions` is always **archive**; block-height methods are **archive** when the requested height is more than 128 behind the tip, and ledger-version methods when the requested version is more than 256 behind. See [Aptos method scope](#aptos-method-scope) below. |
 | Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Polkadot | Most requests are **full**. Sidecar trace endpoints are always **2 RUs**; `chain_getBlockHash` and block-scoped Sidecar endpoints are **archive** when the requested block is more than 128 behind the tip. See [Polkadot method scope](#polkadot-method-scope) below. |
-| Bitcoin, Sui, TRON, opBNB, Harmony, XRP Ledger | No archive split — every request is billed as full |
+| Sui | Full nodes carrying up to about 6 months of historical state. No archive split — every request is billed as **full** |
+| Bitcoin, TRON, opBNB, Harmony, XRP Ledger | No archive split — every request is billed as full |
 
 ## Always 2 RUs
 

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -1312,11 +1312,10 @@
     "Sui": {
       "protocol_name": "Sui",
       "supported_modes": [
-        "Full",
-        "Archive"
+        "Full"
       ],
       "full_mode_query_limit": "N/A",
-      "archive_mode_available": true,
+      "archive_mode_available": false,
       "debug_trace_available": false,
       "warp_transactions_available": false,
       "dedicated_node_availability": "Platform",
@@ -1351,7 +1350,7 @@
               "location": "Worldwide",
               "deployment_options": [
                 {
-                  "mode": "Archive",
+                  "mode": "Full",
                   "debug_trace": false,
                   "warp_transactions": false
                 }


### PR DESCRIPTION
## What

The tables said Sui **Mainnet was Full** and Sui **Testnet was Archive**. Neither was right, and the split between them was arbitrary — both networks run the same thing.

Sui nodes are **full nodes carrying up to about 6 months of historical state**, with transaction history back to genesis, and **every Sui request is billed as full (1 RU)**. Calling that Archive sets an expectation it misses on both counts.

## Where this came from

The [#product thread](https://chainstackhq.slack.com/archives/CHK4Q7MMK/p1779366745579429) Martin opened in May. Vova described the offering as *"kinda 'extended Full' — full transaction history back to genesis, plus ~5.5+ mo of historical state"*, Eugene pointed out on Jul 2 that the docs table said Archive, and last week Eugene asked whether any of it is explained in the docs. It wasn't — "extended full" had zero hits across `docs/` and `reference/`.

## Measured rather than taken from the thread

I deployed Sui Mainnet and Testnet Global Nodes and probed the two kinds of history separately, since they prune differently. For state, I sampled real checkpoints by age, pulled a transaction from each, and asked for the exact object version it produced:

| Age of the object version | Mainnet | Testnet |
| --- | --- | --- |
| 1 day, 1 week, 1 month | Served | Served |
| 3 months | Served | Served |
| 6 months | Served | Not served |
| 12 months | Not served | Not served |

Checkpoint `0` reads on both networks (Mainnet genesis 2023-04-12, Testnet 2023-05-10), so transaction and checkpoint history really is complete. Historical object state is a moving window — `sui_tryGetPastObject` returns `VersionFound` inside it and `VersionNotFound` past it — and it grows, because state is retained from the point a node launches.

## Changes

- **`node-options-master-list.json`** — `supported_modes: ["Full"]`, `archive_mode_available: false`, every deployment option Full. This is the file the two tables regenerate from, so leaving Archive here would have reintroduced it on the next regeneration.
- **`protocols-networks.mdx`** — Full for both networks. The Chain cell reads `Sui (see note below)`, because a note under a 90-row table is otherwise easy to miss when you are scanning for one protocol.
- **`nodes-clouds-regions-and-locations.mdx`** — one Full row per network.
- **`request-units.mdx`** — Sui pulled out of the shared no-split row into its own, stating the retention alongside the billing so the two are read together.

Kept deliberately short and free of callouts: a plain statement on each page where someone would actually be looking, rather than one long explainer.

## One thing to be aware of before merging

The console wizard reports **"Included features: Full, Archive"** for both Sui networks, and `get_deployment_options` returns `["full","archive"]`. **These docs now disagree with that on purpose.**

Since Sui bills as full and has no genesis-deep state, the wizard is the surface that overstates it — but a customer reading the docs and then opening the console will see a contradiction. That is a platform-side fix rather than a docs one. Worth raising with @CSFeo in particular, since he suggested the opposite conclusion in the thread (that "Full" *under*-sells the offering and it might warrant an "Extended Full" or "Full+" label).

I did not introduce any new mode label. That would touch the master-list schema, both generated tables, and the wizard, and needs product agreement first.

## Local validation

- `mintlify broken-links` — clean.
- `node-options-master-list.json` parses and round-trips byte-identically through `json.dumps(indent=2)`, so the diff is the four intended value changes with no reformatting churn.
- `mintlify dev` — all three pages render; the Sui row reads `Sui (see note below) | Global Node, Dedicated | Full | Full`, the clouds table shows one Full row per network, and the RU row is in place.
