### PR TITLE
CORE-15697 self-hosted release notes v2.27.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3553,6 +3553,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-16-0-july-30-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026.mdx
@@ -1,0 +1,41 @@
+---
+title: "Chainstack Self-Hosted v2.27.0: August 10, 2026"
+description: "Sonic and Stable are now available as deployment targets, covering both Mainnet and Testnet on each protocol."
+---
+
+This release adds Sonic and Stable as deployment targets, covering Mainnet and Testnet on both protocols. Node workloads also get a client-appropriate shutdown window.
+
+## Sonic support
+
+Sonic Mainnet and Testnet are now available as deployment targets, each running a single sonicd node from Sonic Labs.
+
+- Sonic Mainnet — explorer at [sonicscan.org](https://sonicscan.org)
+- Sonic Testnet — explorer at [testnet.sonicscan.org](https://testnet.sonicscan.org)
+- Sync — Mainnet bootstraps from a pre-built chain snapshot, while Testnet starts from a pruned genesis export and syncs the remainder from the network
+
+## Stable support
+
+Stable Mainnet and Testnet are now available as deployment targets, each running a single stabled node.
+
+- Stable Mainnet — explorer at [stablescan.xyz](https://stablescan.xyz)
+- Stable Testnet — explorer at [testnet.stablescan.xyz](https://testnet.stablescan.xyz)
+- Architecture — one stabled process carries both the CometBFT consensus engine and an embedded EVM, and the node exposes the EVM JSON-RPC while its CometBFT RPC and Cosmos gRPC stay internal
+- Consensus timing — tuned per network, so Mainnet and Testnet each run on their own vendor-recommended values
+- Sync — both networks bootstrap from a snapshot
+
+## Graceful node shutdown
+
+Node workloads now shut down with a client-appropriate grace period instead of a fixed timeout. Clients that need time to flush state to disk get it, which reduces the chance of a corrupted database after a restart, a rescale, or a node upgrade.
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.7.0 |
+| cp-workflows | v3.27.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, and Arc Testnet presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.27.0: August 10, 2026" description="">
+
+This release adds Sonic and Stable as deployment targets, covering Mainnet and Testnet on both protocols. Sonic runs the sonicd client, and Stable runs a single stabled node that carries both CometBFT consensus and an embedded EVM. Node workloads now also shut down with a client-appropriate grace period instead of a fixed timeout.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.23.0: August 6, 2026" description="">
 
 This release adds XRP Ledger as a deployment target, covering both Mainnet and Testnet. Each deployment runs a single xrpld node as a non-validator in full mode, serving HTTP JSON-RPC and the WebSocket API.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -81,6 +81,8 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Plasma | Plasma Mainnet, Testnet | 5 | 20 GiB | 250–350 GB |
 | Avalanche | Avalanche Mainnet, Fuji | 4 | 16 GiB | 300–400 GB |
 | Arc | Arc Testnet | 8 | 32 GiB | ~315 GB |
+| Sonic | Sonic Mainnet, Testnet | 4–8 | 32–64 GiB | 800 GB–2.5 TB |
+| Stable | Stable Mainnet, Testnet | 4 | 16 GiB | 50–200 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -89,7 +91,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, and Arc Testnet — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.
@@ -110,7 +112,7 @@ For a deep dive on SSD selection for Ethereum nodes, see [yorickdowne's SSD guid
 
 ### Initial sync time
 
-Snapshot-bootstrapped deployments (Ethereum, Optimism Mainnet, Arbitrum, Robinhood Chain, Sui, and Tempo) start from a chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
+Snapshot-bootstrapped deployments — listed under [Snapshot bootstrap and storage headroom](#snapshot-bootstrap-and-storage-headroom) above — start from a chain snapshot rather than syncing from genesis. Initial bootstrap completes in minutes to hours depending on network conditions; the node then catches up to the chain head in the background. Other deployments sync conventionally and reach the chain head over a longer period. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times) for the breakdown.
 
 ## Network requirements
 

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -35,6 +35,10 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Avalanche | Mainnet | AvalancheGo v1.14.2 | 4 | 16 GiB | 400 GB |
 | Avalanche | Fuji | AvalancheGo v1.15.0-fuji | 4 | 16 GiB | 300 GB |
 | Arc | Testnet | Arc-Execution 0.7.3 + Arc-Consensus 0.7.3 | 8 | 32 GiB | ~315 GB |
+| Sonic | Mainnet | sonicd v2.2.1 | 8 | 64 GiB | ~2.5 TB |
+| Sonic | Testnet | sonicd v2.2.1 | 4 | 32 GiB | 800 GB |
+| Stable | Mainnet | stabled 1.3.3 | 4 | 16 GiB | 200 GB |
+| Stable | Testnet | stabled 1.8.0-rc0 | 4 | 16 GiB | 50 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -309,6 +313,48 @@ Storage splits into 250 GB for Arc-Execution and 64 GB for Arc-Consensus.
 | Arc-Execution | 8546 | TCP | WS JSON-RPC |
 
 Both listeners serve the `eth`, `net`, `web3`, `txpool`, `trace`, and `debug` namespaces. Arc-Consensus publishes nothing of its own — its RPC port is the internal upstream of the execution client's `arc` namespace. The execution client's auth RPC port (8551), the consensus client's RPC (31000) and P2P (27000) ports, and both metrics ports are internal and are not exposed.
+
+## Sonic
+
+Runs a single sonicd full node as a non-validator in full mode. One process serves both the HTTP and the WebSocket JSON-RPC.
+
+Mainnet bootstraps from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. Testnet starts from a pruned genesis export and syncs the remainder from the network, so expect a longer first sync and no extra storage headroom. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Sonic Mainnet | 146 | sonicd v2.2.1 | [sonicscan.org](https://sonicscan.org) |
+| Sonic Testnet | 14601 | sonicd v2.2.1 | [testnet.sonicscan.org](https://testnet.sonicscan.org) |
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| sonicd | 18545 | TCP | HTTP JSON-RPC |
+| sonicd | 18546 | TCP | WS JSON-RPC |
+
+Both listeners serve the `eth`, `web3`, `net`, `ftm`, `txpool`, `abft`, `dag`, `trace`, and `debug` namespaces. The P2P port (5050, TCP and UDP) and the metrics port (6060) are internal and are not exposed.
+
+## Stable
+
+Runs a single stabled full node as a non-validator in full mode. One process carries both the CometBFT consensus engine and an embedded EVM, so a single node serves the chain end to end and there is no separate consensus client to provision.
+
+Both networks bootstrap from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Stable Mainnet | 988 | stabled 1.3.3 | [stablescan.xyz](https://stablescan.xyz) |
+| Stable Testnet | 2201 | stabled 1.8.0-rc0 | [testnet.stablescan.xyz](https://testnet.stablescan.xyz) |
+
+The client version and the consensus timing are pinned per network, so Mainnet and Testnet run different versions and different values.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| stabled | 8545 | TCP | EVM HTTP JSON-RPC |
+| stabled | 8546 | TCP | EVM WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `debug`, and `txpool` namespaces. The CometBFT RPC port (26657) is internal — it carries the node health surface, not a customer endpoint. The CometBFT P2P port (26656) and the metrics port (26660) are internal as well, and the Cosmos gRPC server is bound to loopback, so none of them are exposed.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -10,6 +10,26 @@
         { "port": 2459, "proto": "TCP", "purpose": "P2P", "exposed": false }
       ]
     },
+    "sonicd": {
+      "label": "sonicd",
+      "role": "full",
+      "ports": [
+        { "port": 18545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 18546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 5050, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 5050, "proto": "UDP", "purpose": "P2P discovery", "exposed": false }
+      ]
+    },
+    "stabled": {
+      "label": "stabled",
+      "role": "full",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "EVM HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "EVM WS JSON-RPC", "exposed": true },
+        { "port": 26657, "proto": "TCP", "purpose": "CometBFT RPC (node health surface only)", "exposed": false },
+        { "port": 26656, "proto": "TCP", "purpose": "CometBFT P2P", "exposed": false }
+      ]
+    },
     "reth": {
       "label": "Reth",
       "role": "execution",
@@ -187,6 +207,22 @@
       "notes": [
         "Runs a single full node client that serves both the JSON-RPC and the WebSocket API.",
         "Syncs from the network rather than from a snapshot, retaining a minimum practical ledger window."
+      ]
+    },
+    "sonic": {
+      "label": "Sonic",
+      "notes": [
+        "Runs a single full node client that serves both the HTTP and the WebSocket JSON-RPC.",
+        "Mainnet bootstraps from a pre-built chain snapshot. Testnet starts from a pruned genesis export and syncs the remainder from the network, so expect a longer first sync."
+      ]
+    },
+    "stable": {
+      "label": "Stable",
+      "notes": [
+        "Runs a single client process that carries both the CometBFT consensus engine and an embedded EVM, so one node serves the chain end to end.",
+        "Only the EVM JSON-RPC is user-facing. The CometBFT RPC stays internal as the node health surface, and the Cosmos gRPC server is bound to loopback.",
+        "Both networks bootstrap from a pre-built chain snapshot.",
+        "Client version and consensus timing are pinned per network, so Mainnet and Testnet can differ."
       ]
     },
     "evm-l1-dual": {
@@ -572,6 +608,46 @@
       "presets": ["standard"],
       "clients": [
         { "client": "xrpld", "version": "3.2.1", "cpu": 4, "ramGi": 16, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
+    },
+    {
+      "protocol": "Sonic", "network": "Mainnet", "chainId": 146,
+      "explorer": "https://sonicscan.org",
+      "family": "sonic", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "sonicd", "version": "v2.2.1", "cpu": 8, "ramGi": 64, "storageGi": 2500 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 64, "storageGi": 2500 }
+    },
+    {
+      "protocol": "Sonic", "network": "Testnet", "chainId": 14601,
+      "explorer": "https://testnet.sonicscan.org",
+      "family": "sonic", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "sonicd", "version": "v2.2.1", "cpu": 4, "ramGi": 32, "storageGi": 800 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 32, "storageGi": 800 }
+    },
+    {
+      "protocol": "Stable", "network": "Mainnet", "chainId": 988,
+      "explorer": "https://stablescan.xyz",
+      "family": "stable", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "stabled", "version": "1.3.3", "cpu": 4, "ramGi": 16, "storageGi": 200 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 200 }
+    },
+    {
+      "protocol": "Stable", "network": "Testnet", "chainId": 2201,
+      "explorer": "https://testnet.stablescan.xyz",
+      "family": "stable", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "stabled", "version": "1.8.0-rc0", "cpu": 4, "ramGi": 16, "storageGi": 50 }
       ],
       "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
     },


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.27.0 release note. Adds Sonic and Stable (Mainnet and Testnet on each) to the supported-deployments catalog, with the matching requirements and protocol-enumeration updates.