### PR TITLE
CORE-15867 self-hosted release notes v2.29.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3553,6 +3553,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -384,6 +384,7 @@
 - [FAQ](/docs/self-hosted/faq.md)
 - [Support and feedback](/docs/self-hosted/support.md)
 - [Chainstack Self-Hosted release notes and version history](/docs/self-hosted/release-notes.md)
+- [Chainstack Self-Hosted v2.29.0: August 11, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026.md)
 - [Chainstack Self-Hosted v2.27.0: August 10, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026.md)
 - [Chainstack Self-Hosted v2.23.0: August 6, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026.md)
 - [Chainstack Self-Hosted v2.21.0: August 4, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-21-0-august-4-2026.md)

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026.mdx
@@ -1,0 +1,28 @@
+---
+title: "Chainstack Self-Hosted v2.29.0: August 11, 2026"
+description: "opBNB is now available as a deployment target, covering both Mainnet and Testnet."
+---
+
+This release adds opBNB as a deployment target, covering both Mainnet and Testnet. Each deployment pairs an op-geth execution node with an opbnb-node consensus client.
+
+## opBNB support
+
+opBNB Mainnet and Testnet are now available as deployment targets, each running a paired op-geth execution node and opbnb-node consensus client.
+
+- opBNB Mainnet — explorer at [opbnbscan.com](https://opbnbscan.com)
+- opBNB Testnet — explorer at [testnet.opbnbscan.com](https://testnet.opbnbscan.com)
+- Architecture — opBNB is an OP Stack chain settling to BNB Smart Chain, so op-geth serves the EVM JSON-RPC and WebSocket APIs while opbnb-node derives the chain from the layer 1
+- Sync — both networks bootstrap from a pre-built chain snapshot, then follow the sequencer
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.9.0 |
+| cp-workflows | v3.28.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.29.0: August 11, 2026" description="">
+
+This release adds opBNB as a deployment target, covering both Mainnet and Testnet. Each deployment pairs an op-geth execution node with an opbnb-node consensus client, serving the EVM JSON-RPC and WebSocket APIs.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.27.0: August 10, 2026" description="">
 
 This release adds Sonic and Stable as deployment targets, covering Mainnet and Testnet on both protocols. Sonic runs the sonicd client, and Stable runs a single stabled node that carries both CometBFT consensus and an embedded EVM. Node workloads now also shut down with a client-appropriate grace period instead of a fixed timeout.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -71,6 +71,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 |--------|---------------------|------|-----|------------------------|
 | EVM Layer 1 (execution + consensus) | Ethereum Mainnet, Sepolia, Hoodi | 8 | 32 GiB | 250 GB–2 TB |
 | EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora, World Chain | 6–12 | 24–48 GiB | 100 GB–3.5 TB |
+| EVM Layer 2 — opBNB | opBNB Mainnet, Testnet | 6–12 | 24–48 GiB | 500 GB–2 TB |
 | EVM Layer 2 — Arbitrum Nitro | Arbitrum One, Arbitrum Sepolia, Robinhood Chain | 4–8 | 32–64 GiB | 200 GB–2.5 TB |
 | Polygon PoS | Polygon Mainnet | 12 | 64 GiB | ~5.5 TB |
 | Starknet | Starknet Mainnet | 8 | 32 GiB | ~1 TB |
@@ -91,7 +92,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -18,6 +18,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Zora | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
 | World Chain | Mainnet | World-Chain v2.4.0 + OP-Node v1.19.3 | 12 | 48 GiB | ~1.3 TB |
 | World Chain | Sepolia | World-Chain v2.4.0 + OP-Node v1.19.3 | 6 | 24 GiB | 100 GB |
+| opBNB | Mainnet | OP-Geth v0.5.10 + OpBNB-Node v0.5.5 | 12 | 48 GiB | ~2 TB |
+| opBNB | Testnet | OP-Geth v0.5.10 + OpBNB-Node v0.5.5 | 6 | 24 GiB | 500 GB |
 | Arbitrum | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | ~2.5 TB |
 | Arbitrum | Sepolia | Nitro v3.11.2 | 4 | 32 GiB | ~1.5 TB |
 | Robinhood Chain | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | 200 GB |
@@ -103,6 +105,35 @@ World Chain Sepolia is the smallest deployment in this family — 6 vCPU / 24 Gi
 | OP-Reth / Base-Reth / World-Chain | 8545 | TCP | HTTP JSON-RPC |
 | OP-Reth / Base-Reth / World-Chain | 8546 | TCP | WS JSON-RPC |
 | OP-Node / Base-Node | 9545 | TCP | Rollup HTTP RPC |
+
+The execution client's auth RPC port (8551) is used internally between clients and is not exposed.
+
+## EVM Layer 2 — opBNB
+
+Runs a paired execution client and rollup (consensus) client. vCPU and RAM are split across the two clients.
+
+<Warning>
+opBNB deployments require a BNB Smart Chain Layer 1 **RPC endpoint** that you supply. opBNB settles to BNB Smart Chain rather than Ethereum, so no Beacon API endpoint is needed.
+</Warning>
+
+Both networks bootstrap from a pre-built chain snapshot rather than syncing from genesis. Snapshot bootstrap temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Block explorer |
+|---------|----------|----------------|
+| opBNB Mainnet | 204 | [opbnbscan.com](https://opbnbscan.com) |
+| opBNB Testnet | 5611 | [testnet.opbnbscan.com](https://testnet.opbnbscan.com) |
+
+<Note>
+Testnet runs at half the Mainnet footprint — 6 vCPU / 24 GiB against 12 vCPU / 48 GiB — and needs 500 GB against ~2 TB.
+</Note>
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| OP-Geth | 8545 | TCP | HTTP JSON-RPC |
+| OP-Geth | 8546 | TCP | WS JSON-RPC |
+| OpBNB-Node | 9545 | TCP | Rollup HTTP RPC |
 
 The execution client's auth RPC port (8551) is used internally between clients and is not exposed.
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -199,6 +199,22 @@
         { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
         { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false }
       ]
+    },
+    "op-geth": {
+      "label": "OP-Geth",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false }
+      ]
+    },
+    "opbnb-node": {
+      "label": "OpBNB-Node",
+      "role": "consensus",
+      "ports": [
+        { "port": 9545, "proto": "TCP", "purpose": "Rollup HTTP RPC", "exposed": true }
+      ]
     }
   },
   "families": {
@@ -214,6 +230,14 @@
       "notes": [
         "Runs a single full node client that serves both the HTTP and the WebSocket JSON-RPC.",
         "Mainnet bootstraps from a pre-built chain snapshot. Testnet starts from a pruned genesis export and syncs the remainder from the network, so expect a longer first sync."
+      ]
+    },
+    "opbnb": {
+      "label": "EVM Layer 2 — opBNB",
+      "notes": [
+        "Runs a paired execution client and rollup (consensus) client. CPU and RAM are split across the two clients.",
+        "Requires a BNB Smart Chain Layer 1 RPC endpoint that you supply. opBNB settles to BNB Smart Chain, so no Beacon API endpoint is needed.",
+        "Both networks bootstrap from a pre-built chain snapshot."
       ]
     },
     "stable": {
@@ -416,6 +440,28 @@
         { "client": "op-node",     "version": "v1.19.3", "cpu": 2, "ramGi": 8,  "storageGi": 0 }
       ],
       "totals": { "cpu": 6, "ramGi": 24, "storageGi": 100 }
+    },
+    {
+      "protocol": "opBNB", "network": "Mainnet", "chainId": 204,
+      "explorer": "https://opbnbscan.com",
+      "family": "opbnb", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "op-geth",    "version": "v0.5.10", "cpu": 8, "ramGi": 32, "storageGi": 2000 },
+        { "client": "opbnb-node", "version": "v0.5.5",  "cpu": 4, "ramGi": 16, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
+    },
+    {
+      "protocol": "opBNB", "network": "Testnet", "chainId": 5611,
+      "explorer": "https://testnet.opbnbscan.com",
+      "family": "opbnb", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "op-geth",    "version": "v0.5.10", "cpu": 4, "ramGi": 16, "storageGi": 500 },
+        { "client": "opbnb-node", "version": "v0.5.5",  "cpu": 2, "ramGi": 8,  "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 500 }
     },
     {
       "protocol": "Arbitrum", "network": "Mainnet", "chainId": 42161,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.29.0 release note. Adds opBNB Mainnet and Testnet to the supported-deployments catalog.