### PR TITLE
CORE-15876 self-hosted release notes v2.32.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3554,6 +3554,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-23-0-august-6-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026.mdx
@@ -1,0 +1,38 @@
+---
+title: "Chainstack Self-Hosted v2.32.0: August 12, 2026"
+description: "Berachain and Cronos are now available as deployment targets, covering Berachain Mainnet, Berachain Bepolia, and Cronos Testnet."
+---
+
+This release adds two protocols as deployment targets. Berachain covers Mainnet and the Bepolia testnet, each pairing a Bera-Reth execution node with a Beacond consensus node, and Cronos covers Testnet with a single cronosd node.
+
+## Berachain support
+
+Berachain Mainnet and Berachain Bepolia are now available as deployment targets, each running a paired Bera-Reth execution node and Beacond consensus node.
+
+- Berachain Mainnet — chain ID 80094, explorer at [berascan.com](https://berascan.com)
+- Berachain Bepolia — chain ID 80069, explorer at [testnet.berascan.com](https://testnet.berascan.com)
+- Architecture — Bera-Reth is a Reth-based execution client that serves the EVM JSON-RPC and WebSocket APIs, while Beacond, Berachain's BeaconKit consensus client, provides consensus over CometBFT
+- Mode — the node runs as a non-validator in full mode, with block building disabled on the consensus client
+- Sync — both networks bootstrap from a pre-built chain snapshot, then follow the network's peers
+
+## Cronos support
+
+Cronos Testnet is now available as a deployment target, running a single cronosd node.
+
+- Cronos Testnet — chain ID 338, explorer at [explorer.cronos.org/testnet](https://explorer.cronos.org/testnet)
+- Architecture — Cronos is a Cosmos SDK chain with an embedded EVM, so one cronosd node carries both CometBFT consensus and the EVM JSON-RPC and WebSocket APIs
+- Storage — the node uses the RocksDB backend with versioned state enabled and default pruning
+- Sync — the network bootstraps from a pre-built chain snapshot, then follows the network's peers
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.12.0 |
+| cp-workflows | v3.30.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos Testnet presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.32.0: August 12, 2026" description="">
+
+This release adds Berachain and Cronos as deployment targets. Berachain covers Mainnet and the Bepolia testnet, each pairing a Bera-Reth execution node with a Beacond consensus node over CometBFT, and Cronos Testnet runs a single cronosd node that carries both consensus and an embedded EVM.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.29.0: August 11, 2026" description="">
 
 This release adds opBNB as a deployment target, covering both Mainnet and Testnet. Each deployment pairs an op-geth execution node with an opbnb-node consensus client, serving the EVM JSON-RPC and WebSocket APIs.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -84,6 +84,8 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Arc | Arc Testnet | 8 | 32 GiB | ~315 GB |
 | Sonic | Sonic Mainnet, Testnet | 4–8 | 32–64 GiB | 800 GB–2.5 TB |
 | Stable | Stable Mainnet, Testnet | 4 | 16 GiB | 50–200 GB |
+| Berachain | Berachain Mainnet, Bepolia | 6–8 | 24–36 GiB | ~165–250 GB |
+| Cronos | Cronos Testnet | 4 | 16 GiB | 50 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -92,7 +94,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, and Stable (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos Testnet — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -41,6 +41,9 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Sonic | Testnet | sonicd v2.2.1 | 4 | 32 GiB | 800 GB |
 | Stable | Mainnet | stabled 1.3.3 | 4 | 16 GiB | 200 GB |
 | Stable | Testnet | stabled 1.8.0-rc0 | 4 | 16 GiB | 50 GB |
+| Berachain | Mainnet | Bera-Reth 1.4.4 + Beacond 1.4.1 | 6 | 24 GiB | 250 GB |
+| Berachain | Bepolia | Bera-Reth 1.4.4 + Beacond 1.4.2-rc.0 | 8 | 36 GiB | ~165 GB |
+| Cronos | Testnet | cronosd 1.7.8 | 4 | 16 GiB | 50 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -386,6 +389,49 @@ The client version and the consensus timing are pinned per network, so Mainnet a
 | stabled | 8546 | TCP | EVM WS JSON-RPC |
 
 Both listeners serve the `eth`, `net`, `web3`, `debug`, and `txpool` namespaces. The CometBFT RPC port (26657) is internal — it carries the node health surface, not a customer endpoint. The CometBFT P2P port (26656) and the metrics port (26660) are internal as well, and the Cosmos gRPC server is bound to loopback, so none of them are exposed.
+
+## Berachain
+
+Runs a paired execution client and consensus client as a non-validator node in full mode. Bera-Reth is a Reth-based execution client that serves the JSON-RPC, and Beacond is Berachain's BeaconKit consensus client running on CometBFT with block building disabled.
+
+These deployments bootstrap from a pre-built chain snapshot rather than syncing from genesis. Snapshot bootstrap temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Berachain Mainnet | 80094 | Bera-Reth 1.4.4 + Beacond 1.4.1 | [berascan.com](https://berascan.com) |
+| Berachain Bepolia | 80069 | Bera-Reth 1.4.4 + Beacond 1.4.2-rc.0 | [testnet.berascan.com](https://testnet.berascan.com) |
+
+The Beacond version is pinned per network, so Mainnet and Bepolia run different versions. Compute and storage also differ per network — Mainnet splits 4 vCPU / 16 GiB and 200 GB for Bera-Reth with 2 vCPU / 8 GiB and 50 GB for Beacond, and Bepolia splits 6 vCPU / 24 GiB and 100 GB for Bera-Reth with 2 vCPU / 12 GiB and 64 GB for Beacond.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Bera-Reth | 8545 | TCP | HTTP JSON-RPC |
+| Bera-Reth | 8546 | TCP | WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces. Beacond publishes nothing of its own — its CometBFT RPC port carries the node health surface, and its ABCI proxy app is bound to loopback. The execution client's auth RPC port (8551), its P2P port (30303, TCP and UDP), Beacond's RPC (26657) and P2P (26656) ports, and both metrics ports are internal and are not exposed.
+
+## Cronos
+
+Runs a single cronosd full node as a non-validator in full mode. One process carries both the CometBFT consensus engine and an embedded EVM, so a single node serves the chain end to end and there is no separate consensus client to provision.
+
+This deployment bootstraps from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Cronos Testnet | 338 | cronosd 1.7.8 | [explorer.cronos.org/testnet](https://explorer.cronos.org/testnet) |
+
+The node stores state with the RocksDB backend and versioned state enabled, under the network's default pruning policy.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| cronosd | 8545 | TCP | EVM HTTP JSON-RPC |
+| cronosd | 8546 | TCP | EVM WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `debug`, and `txpool` namespaces. The CometBFT RPC port (26657) is internal — it carries the node health surface, not a customer endpoint. The CometBFT P2P port (26656) and the metrics port (26660) are internal as well.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -30,6 +30,39 @@
         { "port": 26656, "proto": "TCP", "purpose": "CometBFT P2P", "exposed": false }
       ]
     },
+    "bera-reth": {
+      "label": "Bera-Reth",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false },
+        { "port": 30303, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 30303, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
+        { "port": 6060, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "beacond": {
+      "label": "Beacond",
+      "role": "consensus",
+      "ports": [
+        { "port": 26656, "proto": "TCP", "purpose": "CometBFT P2P", "exposed": false },
+        { "port": 26657, "proto": "TCP", "purpose": "CometBFT RPC (node health surface only)", "exposed": false },
+        { "port": 26658, "proto": "TCP", "purpose": "ABCI proxy app (loopback only)", "exposed": false },
+        { "port": 26660, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "cronosd": {
+      "label": "cronosd",
+      "role": "full",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "EVM HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "EVM WS JSON-RPC", "exposed": true },
+        { "port": 26657, "proto": "TCP", "purpose": "CometBFT RPC (node health surface only)", "exposed": false },
+        { "port": 26656, "proto": "TCP", "purpose": "CometBFT P2P", "exposed": false },
+        { "port": 26660, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
     "reth": {
       "label": "Reth",
       "role": "execution",
@@ -247,6 +280,22 @@
         "Only the EVM JSON-RPC is user-facing. The CometBFT RPC stays internal as the node health surface, and the Cosmos gRPC server is bound to loopback.",
         "Both networks bootstrap from a pre-built chain snapshot.",
         "Client version and consensus timing are pinned per network, so Mainnet and Testnet can differ."
+      ]
+    },
+    "berachain": {
+      "label": "Berachain",
+      "notes": [
+        "Runs a paired execution client and consensus client as a non-validator node with block building disabled. CPU and RAM are split across the two clients.",
+        "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted.",
+        "Client version is pinned per network, so Mainnet and Bepolia can run different versions."
+      ]
+    },
+    "cronos": {
+      "label": "Cronos",
+      "notes": [
+        "Runs a single client process that carries both the CometBFT consensus engine and an embedded EVM, so one node serves the chain end to end.",
+        "Only the EVM JSON-RPC is user-facing. The CometBFT RPC stays internal as the node health surface.",
+        "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted."
       ]
     },
     "evm-l1-dual": {
@@ -694,6 +743,38 @@
       "presets": ["standard"],
       "clients": [
         { "client": "stabled", "version": "1.8.0-rc0", "cpu": 4, "ramGi": 16, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
+    },
+    {
+      "protocol": "Berachain", "network": "Mainnet", "chainId": 80094,
+      "explorer": "https://berascan.com",
+      "family": "berachain", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "bera-reth", "version": "1.4.4", "cpu": 4, "ramGi": 16, "storageGi": 200 },
+        { "client": "beacond", "version": "1.4.1", "cpu": 2, "ramGi": 8, "storageGi": 50 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 250 }
+    },
+    {
+      "protocol": "Berachain", "network": "Bepolia", "chainId": 80069,
+      "explorer": "https://testnet.berascan.com",
+      "family": "berachain", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "bera-reth", "version": "1.4.4", "cpu": 6, "ramGi": 24, "storageGi": 100 },
+        { "client": "beacond", "version": "1.4.2-rc.0", "cpu": 2, "ramGi": 12, "storageGi": 64 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 36, "storageGi": 164 }
+    },
+    {
+      "protocol": "Cronos", "network": "Testnet", "chainId": 338,
+      "explorer": "https://explorer.cronos.org/testnet",
+      "family": "cronos", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "cronosd", "version": "1.7.8", "cpu": 4, "ramGi": 16, "storageGi": 50 }
       ],
       "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
     },


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.32.0 release note.

Adds Berachain (Mainnet, Bepolia) and Cronos (Testnet) to the supported-deployments catalog, with the new Bera-Reth, Beacond, and cronosd clients and two new deployment families.