### PR TITLE
CORE-15882 self-hosted release notes v2.33.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3554,6 +3554,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-27-0-august-10-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026.mdx
@@ -1,0 +1,28 @@
+---
+title: "Chainstack Self-Hosted v2.33.0: August 12, 2026"
+description: "Cronos Mainnet is now available as a deployment target, completing Cronos coverage alongside Testnet."
+---
+
+This release adds Cronos Mainnet as a deployment target, completing Cronos coverage after Testnet shipped in the previous release.
+
+## Cronos Mainnet support
+
+Cronos Mainnet is now available as a deployment target, running a single cronosd node.
+
+- Cronos Mainnet — chain ID 25, explorer at [explorer.cronos.org](https://explorer.cronos.org)
+- Architecture — Cronos is a Cosmos SDK chain with an embedded EVM, so one cronosd node carries both CometBFT consensus and the EVM JSON-RPC and WebSocket APIs
+- Storage — the node uses the RocksDB backend with default pruning
+- Sync — the network bootstraps from a pre-built chain snapshot, then follows the network's peers
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.13.0 |
+| cp-workflows | v3.30.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -17,7 +17,7 @@ Yes. Chainstack Self-Hosted is generally available and supports production deplo
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos Testnet presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.33.0: August 12, 2026" description="">
+
+This release adds Cronos Mainnet as a deployment target, completing Cronos coverage after Testnet shipped in the previous release. A single cronosd node carries both CometBFT consensus and the embedded EVM, and bootstraps from a pre-built chain snapshot.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.32.0: August 12, 2026" description="">
 
 This release adds Berachain and Cronos as deployment targets. Berachain covers Mainnet and the Bepolia testnet, each pairing a Bera-Reth execution node with a Beacond consensus node over CometBFT, and Cronos Testnet runs a single cronosd node that carries both consensus and an embedded EVM.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -85,7 +85,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Sonic | Sonic Mainnet, Testnet | 4–8 | 32–64 GiB | 800 GB–2.5 TB |
 | Stable | Stable Mainnet, Testnet | 4 | 16 GiB | 50–200 GB |
 | Berachain | Berachain Mainnet, Bepolia | 6–8 | 24–36 GiB | ~165–250 GB |
-| Cronos | Cronos Testnet | 4 | 16 GiB | 50 GB |
+| Cronos | Cronos Mainnet, Testnet | 4–8 | 16–32 GiB | 50–100 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -94,7 +94,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos Testnet — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -43,6 +43,7 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Stable | Testnet | stabled 1.8.0-rc0 | 4 | 16 GiB | 50 GB |
 | Berachain | Mainnet | Bera-Reth 1.4.4 + Beacond 1.4.1 | 6 | 24 GiB | 250 GB |
 | Berachain | Bepolia | Bera-Reth 1.4.4 + Beacond 1.4.2-rc.0 | 8 | 36 GiB | ~165 GB |
+| Cronos | Mainnet | cronosd 1.7.8 | 8 | 32 GiB | 100 GB |
 | Cronos | Testnet | cronosd 1.7.8 | 4 | 16 GiB | 50 GB |
 
 <Note>
@@ -416,13 +417,14 @@ Both listeners serve the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces.
 
 Runs a single cronosd full node as a non-validator in full mode. One process carries both the CometBFT consensus engine and an embedded EVM, so a single node serves the chain end to end and there is no separate consensus client to provision.
 
-This deployment bootstraps from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+Both networks bootstrap from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
 
 | Network | Chain ID | Client | Block explorer |
 |---------|----------|--------|----------------|
+| Cronos Mainnet | 25 | cronosd 1.7.8 | [explorer.cronos.org](https://explorer.cronos.org) |
 | Cronos Testnet | 338 | cronosd 1.7.8 | [explorer.cronos.org/testnet](https://explorer.cronos.org/testnet) |
 
-The node stores state with the RocksDB backend and versioned state enabled, under the network's default pruning policy.
+The node stores state with the RocksDB backend, under the network's default pruning policy. Cronos Testnet additionally enables versioned state.
 
 ### Exposed ports
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -769,6 +769,16 @@
       "totals": { "cpu": 8, "ramGi": 36, "storageGi": 164 }
     },
     {
+      "protocol": "Cronos", "network": "Mainnet", "chainId": 25,
+      "explorer": "https://explorer.cronos.org",
+      "family": "cronos", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "cronosd", "version": "1.7.8", "cpu": 8, "ramGi": 32, "storageGi": 100 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 32, "storageGi": 100 }
+    },
+    {
       "protocol": "Cronos", "network": "Testnet", "chainId": 338,
       "explorer": "https://explorer.cronos.org/testnet",
       "family": "cronos", "status": "available", "snapshotBootstrap": true,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.33.0 release note. Adds Cronos Mainnet to the supported-deployments catalog.