### PR TITLE
CORE-15902 self-hosted release notes v2.37.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3554,6 +3554,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-29-0-august-11-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026.mdx
@@ -1,0 +1,39 @@
+---
+title: "Chainstack Self-Hosted v2.37.0: August 13, 2026"
+description: "Blast and Mantle are now available as deployment targets, each covering Mainnet and Sepolia with an execution and rollup node pair."
+---
+
+This release adds Blast and Mantle as deployment targets, each covering Mainnet and Sepolia. Both are OP-Stack rollups, so every deployment pairs an execution node with a rollup node that derives the chain from Ethereum.
+
+## Blast support
+
+Blast Mainnet and Blast Sepolia are now available as deployment targets, pairing a blast-geth execution node with a blast-node rollup node.
+
+- Blast Mainnet — chain ID 81457, explorer at [blastscan.io](https://blastscan.io)
+- Blast Sepolia — chain ID 168587773, explorer at [testnet.blastscan.io](https://testnet.blastscan.io)
+- Architecture — blast-geth serves the EVM JSON-RPC and WebSocket APIs, while blast-node derives the rollup from Ethereum and drives the execution node over the engine API
+- Storage — blast-geth uses the Pebble backend with path-based state and full sync
+- Sync — Mainnet bootstraps from a pre-built chain snapshot, and Sepolia syncs from genesis
+
+## Mantle support
+
+Mantle Mainnet and Mantle Sepolia are now available as deployment targets, pairing a mantle-geth execution node with a mantle-node rollup node.
+
+- Mantle Mainnet — chain ID 5000, explorer at [mantlescan.xyz](https://mantlescan.xyz)
+- Mantle Sepolia — chain ID 5003, explorer at [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz)
+- Architecture — mantle-geth serves the EVM JSON-RPC and WebSocket APIs, while mantle-node derives the rollup from Ethereum and drives the execution node over the engine API
+- Peering — Mantle publishes no execution-layer bootnodes, so payloads reach mantle-geth over the engine API and mantle-node connects to the network's static peers
+- Sync — both networks bootstrap from a pre-built chain snapshot
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.10.1 |
+| cp-deployments-api | v1.17.0 |
+| cp-workflows | v3.32.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.37.0: August 13, 2026" description="">
+
+This release adds Blast and Mantle as deployment targets, each covering Mainnet and Sepolia. Both are OP-Stack rollups, so every deployment pairs an execution node with a rollup node that derives the chain from Ethereum and serves the EVM JSON-RPC and WebSocket APIs.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.33.0: August 12, 2026" description="">
 
 This release adds Cronos Mainnet as a deployment target, completing Cronos coverage after Testnet shipped in the previous release. A single cronosd node carries both CometBFT consensus and the embedded EVM, and bootstraps from a pre-built chain snapshot.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -70,7 +70,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Family | Example deployments | vCPU | RAM | Storage (steady state) |
 |--------|---------------------|------|-----|------------------------|
 | EVM Layer 1 (execution + consensus) | Ethereum Mainnet, Sepolia, Hoodi | 8 | 32 GiB | 250 GB–2 TB |
-| EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora, World Chain | 6–12 | 24–48 GiB | 100 GB–3.5 TB |
+| EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle | 6–12 | 24–48 GiB | 100 GB–3.5 TB |
 | EVM Layer 2 — opBNB | opBNB Mainnet, Testnet | 6–12 | 24–48 GiB | 500 GB–2 TB |
 | EVM Layer 2 — Arbitrum Nitro | Arbitrum One, Arbitrum Sepolia, Robinhood Chain | 4–8 | 32–64 GiB | 200 GB–2.5 TB |
 | Polygon PoS | Polygon Mainnet | 12 | 64 GiB | ~5.5 TB |
@@ -94,7 +94,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -18,6 +18,10 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Zora | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
 | World Chain | Mainnet | World-Chain v2.4.0 + OP-Node v1.19.3 | 12 | 48 GiB | ~1.3 TB |
 | World Chain | Sepolia | World-Chain v2.4.0 + OP-Node v1.19.3 | 6 | 24 GiB | 100 GB |
+| Blast | Mainnet | Blast-Geth v1.8.0 + Blast-Node v1.8.0 | 6 | 24 GiB | 500 GB |
+| Blast | Sepolia | Blast-Geth v1.7.0 + Blast-Node v1.7.0 | 6 | 24 GiB | 200 GB |
+| Mantle | Mainnet | Mantle-Geth v1.5.5 + Mantle-Node v1.5.4 | 6 | 24 GiB | 600 GB |
+| Mantle | Sepolia | Mantle-Geth v1.5.5 + Mantle-Node v1.5.4 | 6 | 24 GiB | 300 GB |
 | opBNB | Mainnet | OP-Geth v0.5.10 + OpBNB-Node v0.5.5 | 12 | 48 GiB | ~2 TB |
 | opBNB | Testnet | OP-Geth v0.5.10 + OpBNB-Node v0.5.5 | 6 | 24 GiB | 500 GB |
 | Arbitrum | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | ~2.5 TB |
@@ -95,20 +99,26 @@ OP Stack deployments require an Ethereum Layer 1 **RPC endpoint** and a **Beacon
 | Zora Mainnet | 7777777 | OP-Reth + OP-Node | [explorer.zora.energy](https://explorer.zora.energy) |
 | World Chain Mainnet | 480 | World-Chain + OP-Node | [worldscan.org](https://worldscan.org) |
 | World Chain Sepolia | 4801 | World-Chain + OP-Node | [worldchain-sepolia.explorer.alchemy.com](https://worldchain-sepolia.explorer.alchemy.com) |
+| Blast Mainnet | 81457 | Blast-Geth + Blast-Node | [blastscan.io](https://blastscan.io) |
+| Blast Sepolia | 168587773 | Blast-Geth + Blast-Node | [testnet.blastscan.io](https://testnet.blastscan.io) |
+| Mantle Mainnet | 5000 | Mantle-Geth + Mantle-Node | [mantlescan.xyz](https://mantlescan.xyz) |
+| Mantle Sepolia | 5003 | Mantle-Geth + Mantle-Node | [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz) |
 
-Optimism Mainnet and both World Chain networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy). Base, Unichain, and Zora sync without a snapshot.
+Optimism Mainnet, both World Chain networks, Blast Mainnet, and both Mantle networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy). Base, Unichain, Zora, and Blast Sepolia sync without a snapshot.
 
 <Note>
-World Chain Sepolia is the smallest deployment in this family — 6 vCPU / 24 GiB against the 12 vCPU / 48 GiB the Mainnet deployments take.
+This family spans 6–12 vCPU. The smaller deployments — World Chain Sepolia, both Blast networks, and both Mantle networks — run 6 vCPU / 24 GiB, against the 12 vCPU / 48 GiB the Optimism, Base, Unichain, Zora, and World Chain Mainnet deployments take.
 </Note>
+
+Blast pins its client versions per network, so Mainnet and Sepolia run different versions — see the [Available deployments](#available-deployments) table above.
 
 ### Exposed ports
 
 | Client | Port | Protocol | Purpose |
 |--------|------|----------|---------|
-| OP-Reth / Base-Reth / World-Chain | 8545 | TCP | HTTP JSON-RPC |
-| OP-Reth / Base-Reth / World-Chain | 8546 | TCP | WS JSON-RPC |
-| OP-Node / Base-Node | 9545 | TCP | Rollup HTTP RPC |
+| OP-Reth / Base-Reth / World-Chain / Blast-Geth / Mantle-Geth | 8545 | TCP | HTTP JSON-RPC |
+| OP-Reth / Base-Reth / World-Chain / Blast-Geth / Mantle-Geth | 8546 | TCP | WS JSON-RPC |
+| OP-Node / Base-Node / Blast-Node / Mantle-Node | 9545 | TCP | Rollup HTTP RPC |
 
 The execution client's auth RPC port (8551) is used internally between clients and is not exposed.
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -248,6 +248,48 @@
       "ports": [
         { "port": 9545, "proto": "TCP", "purpose": "Rollup HTTP RPC", "exposed": true }
       ]
+    },
+    "blast-geth": {
+      "label": "Blast-Geth",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false },
+        { "port": 30303, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 30303, "proto": "UDP", "purpose": "P2P discovery", "exposed": false }
+      ]
+    },
+    "blast-node": {
+      "label": "Blast-Node",
+      "role": "consensus",
+      "ports": [
+        { "port": 9545, "proto": "TCP", "purpose": "Rollup HTTP RPC", "exposed": true },
+        { "port": 9222, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 9222, "proto": "UDP", "purpose": "P2P discovery", "exposed": false }
+      ]
+    },
+    "mantle-geth": {
+      "label": "Mantle-Geth",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Auth RPC (engine API, execution to consensus only)", "exposed": false },
+        { "port": 30300, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 30300, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
+        { "port": 9001, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "mantle-node": {
+      "label": "Mantle-Node",
+      "role": "consensus",
+      "ports": [
+        { "port": 9545, "proto": "TCP", "purpose": "Rollup HTTP RPC", "exposed": true },
+        { "port": 9003, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 9003, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
+        { "port": 7300, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -489,6 +531,50 @@
         { "client": "op-node",     "version": "v1.19.3", "cpu": 2, "ramGi": 8,  "storageGi": 0 }
       ],
       "totals": { "cpu": 6, "ramGi": 24, "storageGi": 100 }
+    },
+    {
+      "protocol": "Blast", "network": "Mainnet", "chainId": 81457,
+      "explorer": "https://blastscan.io",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "blast-geth", "version": "v1.8.0", "cpu": 4, "ramGi": 16, "storageGi": 500 },
+        { "client": "blast-node", "version": "v1.8.0", "cpu": 2, "ramGi": 8,  "storageGi": 1 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 501 }
+    },
+    {
+      "protocol": "Blast", "network": "Sepolia", "chainId": 168587773,
+      "explorer": "https://testnet.blastscan.io",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "blast-geth", "version": "v1.7.0", "cpu": 4, "ramGi": 16, "storageGi": 200 },
+        { "client": "blast-node", "version": "v1.7.0", "cpu": 2, "ramGi": 8,  "storageGi": 1 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 201 }
+    },
+    {
+      "protocol": "Mantle", "network": "Mainnet", "chainId": 5000,
+      "explorer": "https://mantlescan.xyz",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "mantle-geth", "version": "v1.5.5", "cpu": 4, "ramGi": 16, "storageGi": 600 },
+        { "client": "mantle-node", "version": "v1.5.4", "cpu": 2, "ramGi": 8,  "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 600 }
+    },
+    {
+      "protocol": "Mantle", "network": "Sepolia", "chainId": 5003,
+      "explorer": "https://sepolia.mantlescan.xyz",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "mantle-geth", "version": "v1.5.5", "cpu": 4, "ramGi": 16, "storageGi": 300 },
+        { "client": "mantle-node", "version": "v1.5.4", "cpu": 2, "ramGi": 8,  "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 300 }
     },
     {
       "protocol": "opBNB", "network": "Mainnet", "chainId": 204,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.37.0 release note. Adds Blast and Mantle to the supported-deployments catalog, each covering Mainnet and Sepolia.