### PR TITLE
Document installing the Chainstack MCP server in VS Code from the registry

### DIFF
--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -149,7 +149,13 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 
 ### GitHub Copilot (VS Code)
 
-Edit `.vscode/mcp.json` (workspace) or use Command Palette > "MCP: Open User Configuration" (global):
+Chainstack is listed in the GitHub MCP Registry, so VS Code can install it for you. There are two ways to do it.
+
+**From inside VS Code** — open the Extensions view (**⇧⌘X** on macOS, **Ctrl+Shift+X** on Windows and Linux), search `@mcp chainstack`, and click **Install** on the Chainstack entry. To install into the workspace rather than your user profile, right-click the entry and select **Install in Workspace**, which writes `.vscode/mcp.json`.
+
+**From the registry in your browser** — open the [Chainstack entry in the GitHub MCP Registry](https://github.com/mcp/com.chainstack/chainstack) and click **Install** > **Install in VS Code**. VS Code opens and asks you to confirm.
+
+Both paths add the server without an API key, which covers every tool that works unauthenticated. To add your key, or to configure by hand, edit `.vscode/mcp.json` (workspace) or run **MCP: Open User Configuration** from the Command Palette (global):
 
 ```json
 {
@@ -168,6 +174,8 @@ Edit `.vscode/mcp.json` (workspace) or use Command Palette > "MCP: Open User Con
 <Note>
 GitHub Copilot uses `servers` as the root key, not `mcpServers`.
 </Note>
+
+Installed servers appear under **MCP SERVERS - INSTALLED** in the Extensions view, and **MCP: List Servers** in the Command Palette enables, disables, and shows logs for them. To use the tools, open the Chat view in agent mode and click **Configure Tools** to toggle the Chainstack tools on.
 
 ### Gemini CLI
 
@@ -226,6 +234,11 @@ Settings > Apps & Connectors > Developer mode > Create > paste `https://mcp.chai
 ## Discovery
 
 Visit [mcp.chainstack.com](https://mcp.chainstack.com/) for an agent-readable onboarding page. Point any agent at this URL (e.g., "get mcp.chainstack.com") and it can read the page and self-configure.
+
+The server is also listed in two public registries, where it appears as `com.chainstack/chainstack`:
+
+- [GitHub MCP Registry](https://github.com/mcp/com.chainstack/chainstack) — the catalog GitHub Copilot and VS Code surface, with one-click install into VS Code
+- [MCP Registry](https://registry.modelcontextprotocol.io/?search=chainstack) — the official registry that MCP clients read from
 
 ## Endpoints
 


### PR DESCRIPTION
Chainstack was listed in the [GitHub MCP Registry](https://github.com/mcp/com.chainstack/chainstack) on 2026-08-12 as `com.chainstack/chainstack`. That gives VS Code users a one-click install, which this page did not mention — it only documented hand-editing `.vscode/mcp.json`.

## Changes

**GitHub Copilot (VS Code)** now leads with the two install routes, then falls back to the JSON config for adding an API key:

- **From inside VS Code** — Extensions view, search `@mcp chainstack`, **Install**. Plus **Install in Workspace** via right-click for a workspace-scoped install.
- **From the registry in your browser** — **Install** > **Install in VS Code** on the registry entry.

Both add the server with no API key, which covers every tool that works unauthenticated — so a reader can install and use `search_docs`, `get_platform_status`, and pricing immediately.

The section now also closes with where the server appears afterwards: **MCP SERVERS - INSTALLED** in the Extensions view, **MCP: List Servers** to manage it, and **Configure Tools** in agent mode to switch the tools on. That was the first question asked once the install worked.

**Discovery** now lists both registries the server is published to, rather than only the discovery page.

## Verification

- Install steps and the `@mcp` filter check out against [the VS Code MCP docs](https://code.visualstudio.com/docs/agent-customization/mcp-servers), and the in-editor flow was confirmed against a live VS Code install.
- Both new links return 200.
- `generate_llms_txt.py --check` clean.
