### PR TITLE
Scope the registry claim and the install section to VS Code

### DIFF
--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -147,7 +147,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-### GitHub Copilot (VS Code)
+### VS Code
 
 Chainstack is listed in the GitHub MCP Registry, so VS Code can install it for you. There are two ways to do it.
 
@@ -172,7 +172,7 @@ Both paths add the server without an API key, which covers every tool that works
 ```
 
 <Note>
-GitHub Copilot uses `servers` as the root key, not `mcpServers`.
+VS Code uses `servers` as the root key, not `mcpServers`.
 </Note>
 
 Installed servers appear under **MCP SERVERS - INSTALLED** in the Extensions view, and **MCP: List Servers** in the Command Palette enables, disables, and shows logs for them. To use the tools, open the Chat view in agent mode and click **Configure Tools** to toggle the Chainstack tools on.

--- a/docs/chainstack-mcp-server.mdx
+++ b/docs/chainstack-mcp-server.mdx
@@ -237,7 +237,7 @@ Visit [mcp.chainstack.com](https://mcp.chainstack.com/) for an agent-readable on
 
 The server is also listed in two public registries, where it appears as `com.chainstack/chainstack`:
 
-- [GitHub MCP Registry](https://github.com/mcp/com.chainstack/chainstack) — the catalog GitHub Copilot and VS Code surface, with one-click install into VS Code
+- [GitHub MCP Registry](https://github.com/mcp/com.chainstack/chainstack) — the catalog VS Code surfaces in its Extensions view, with one-click install
 - [MCP Registry](https://registry.modelcontextprotocol.io/?search=chainstack) — the official registry that MCP clients read from
 
 ## Endpoints


### PR DESCRIPTION
Corrects a claim introduced in #654. The **Discovery** section described the GitHub MCP Registry as "the catalog GitHub Copilot and VS Code surface." Only the VS Code half holds.

## What's actually true

The VS Code Extensions view `@mcp` gallery is fed by the GitHub registry — that install path works and is documented correctly under **GitHub Copilot (VS Code)**.

The GitHub Copilot desktop app is a different surface with its own **Popular MCP servers** catalog, and the registry does not feed it. Searching it for `chainstack` returns no results.

That is not a Chainstack-specific gap: QuickNode is in the registry too and is likewise absent from the Copilot app's catalog. So this is a separate curated list with its own inclusion path, not a ranked view of the registry.

"GitHub Copilot" also spans the CLI, github.com, JetBrains, and Xcode, each with its own MCP configuration — so attributing the registry integration to Copilot broadly overstates it.

The line now reads: *the catalog VS Code surfaces in its Extensions view, with one-click install.*

No other content changes; `generate_llms_txt.py --check` clean.

## Also renamed the section

The install section was headed **GitHub Copilot (VS Code)**, and its note read *"GitHub Copilot uses `servers` as the root key."* Both describe VS Code behavior — the `@mcp` gallery and the `servers` key in `mcp.json` are VS Code's, not Copilot's. The heading is now **VS Code** and the note attributes the key to VS Code.

Copilot remains where it is accurate: the supported-agents list in the intro, and the shared skill directory table, since the skill install genuinely covers it.

Note the anchor changes from `#github-copilot-vs-code` to `#vs-code`. Nothing in the repo links to the old anchor.
