### PR TITLE
CORE-15968 self-hosted release notes v2.43.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3554,6 +3554,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-32-0-august-12-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026.mdx
@@ -1,0 +1,60 @@
+---
+title: "Chainstack Self-Hosted v2.43.0: August 18, 2026"
+description: "BNB Smart Chain, Kaia, Ronin Saigon, and Hyperliquid Testnet are now available as deployment targets, and the Control Panel can serve the monitoring dashboards."
+---
+
+This release adds four protocols to the deployment catalog — BNB Smart Chain, Kaia, Ronin, and Hyperliquid — covering six networks in total. The Control Panel can now also serve the Grafana monitoring dashboards, so node metrics open in the same interface as the deployments they describe.
+
+## BNB Smart Chain support
+
+BNB Smart Chain (BSC) Mainnet and Testnet are now available as deployment targets, running a single reth-bsc node.
+
+- BNB Smart Chain Mainnet — chain ID 56, explorer at [bscscan.com](https://bscscan.com)
+- BNB Smart Chain Testnet — chain ID 97, explorer at [testnet.bscscan.com](https://testnet.bscscan.com)
+- Architecture — a single reth-bsc node serves the EVM JSON-RPC and WebSocket APIs, exposing the eth, net, web3, txpool, and debug namespaces
+- Storage — the node runs in pruned mode, keeping recent state rather than the full history
+- Sync — both networks bootstrap from a pre-built chain snapshot
+
+## Kaia support
+
+Kaia Mainnet and the Kairos testnet are now available as deployment targets, running a single kend node.
+
+- Kaia Mainnet — chain ID 8217, explorer at [kaiascan.io](https://kaiascan.io)
+- Kaia Kairos — chain ID 1001, explorer at [kairos.kaiascan.io](https://kairos.kaiascan.io)
+- Architecture — a single kend node serves both JSON-RPC and WebSocket, exposing Kaia's native klay namespace alongside the standard eth, net, web3, and debug namespaces
+- Storage — the node runs full sync with full garbage collection, so it retains the state needed to serve current-block queries
+- Sync — both networks sync from genesis
+
+## Ronin Saigon support
+
+The Ronin Saigon testnet is now available as a deployment target, and is the first deployment to run an OP-Stack rollup on an alternative data-availability layer.
+
+- Ronin Saigon — chain ID 202601, explorer at [saigon-explorer.roninchain.com](https://saigon-explorer.roninchain.com)
+- Architecture — a conduit-reth execution node serves the EVM JSON-RPC and WebSocket APIs, an op-node rollup node derives the chain from Ethereum and drives the execution node over the engine API, and an EigenDA proxy retrieves the rollup's batch data
+- Data availability — Ronin Saigon posts batches to EigenDA instead of Ethereum calldata, so the rollup node reads generic commitments and resolves the underlying blobs through the proxy
+- Sync — the execution node bootstraps from a published state export, reaching the chain head without replaying history
+
+## Hyperliquid Testnet support
+
+The Hyperliquid testnet is now available as a deployment target, running a single node.
+
+- Hyperliquid Testnet — chain ID 998, explorer at [app.hyperliquid-testnet.xyz/explorer](https://app.hyperliquid-testnet.xyz/explorer)
+- Architecture — a single node serves the EVM JSON-RPC API
+- Storage — the node prunes its logs on a rolling 48-hour window, keeping disk use flat over long runs
+
+## Monitoring dashboards in the Control Panel
+
+When you install the monitoring stack, the Control Panel now proxies Grafana at `/monitoring/`, so node dashboards open in the same interface as the deployments they describe. Installations that skip monitoring are unaffected — the proxy route only renders when Grafana is deployed.
+
+See [System requirements](/docs/self-hosted/requirements) for the full specification and [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.13.0 |
+| cp-deployments-api | v1.23.0 |
+| cp-workflows | v3.36.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.12.0 |
+| blockchain-node-exporter | v1.4.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,13 +11,13 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 
 ### Is snapshot-based deployment available?
 
-Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
+Yes — Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Tempo (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), and BNB Smart Chain (both networks) presets ship with snapshot bootstrap pre-configured. Those nodes deploy from a chain snapshot rather than syncing from genesis, reducing initial sync from days to hours. Tempo restores using its own client tooling rather than a pre-built Chainstack snapshot, so its storage figures already cover the bootstrap peak. Other deployments sync without a snapshot.
 
 See [Deploying nodes](/docs/self-hosted/deploying-nodes) for details.
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.43.0: August 18, 2026" description="">
+
+This release adds BNB Smart Chain, Kaia, Ronin, and Hyperliquid as deployment targets, covering six networks in total. BNB Smart Chain and Kaia each run a single execution node across mainnet and testnet, Ronin Saigon runs an OP-Stack rollup that reads its batch data from EigenDA, and Hyperliquid Testnet runs a single node. The Control Panel can now also serve the Grafana monitoring dashboards.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.37.0: August 13, 2026" description="">
 
 This release adds Blast and Mantle as deployment targets, each covering Mainnet and Sepolia. Both are OP-Stack rollups, so every deployment pairs an execution node with a rollup node that derives the chain from Ethereum and serves the EVM JSON-RPC and WebSocket APIs.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -86,6 +86,10 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Stable | Stable Mainnet, Testnet | 4 | 16 GiB | 50–200 GB |
 | Berachain | Berachain Mainnet, Bepolia | 6–8 | 24–36 GiB | ~165–250 GB |
 | Cronos | Cronos Mainnet, Testnet | 4–8 | 16–32 GiB | 50–100 GB |
+| BNB Smart Chain | BNB Smart Chain Mainnet, Testnet | 4 | 16 GiB | 900 GB–5.5 TB |
+| Kaia | Kaia Mainnet, Kairos | 4–8 | 16–32 GiB | ~1.2–2.75 TB |
+| Ronin | Ronin Saigon | 7 | 28 GiB | 220 GB |
+| Hyperliquid | Hyperliquid Testnet | 4 | 16 GiB | 300 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -94,7 +98,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), and Cronos (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), and BNB Smart Chain (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -49,6 +49,12 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Berachain | Bepolia | Bera-Reth 1.4.4 + Beacond 1.4.2-rc.0 | 8 | 36 GiB | ~165 GB |
 | Cronos | Mainnet | cronosd 1.7.8 | 8 | 32 GiB | 100 GB |
 | Cronos | Testnet | cronosd 1.7.8 | 4 | 16 GiB | 50 GB |
+| BNB Smart Chain | Mainnet | Reth-BSC v0.1.1 | 4 | 16 GiB | ~5.5 TB |
+| BNB Smart Chain | Testnet | Reth-BSC v0.1.1 | 4 | 16 GiB | 900 GB |
+| Kaia | Mainnet | kend v2.2.2 | 8 | 32 GiB | ~2.75 TB |
+| Kaia | Kairos | kend v2.2.2 | 4 | 16 GiB | ~1.2 TB |
+| Ronin | Saigon | Conduit-Reth v2.1.2 + OP-Node v1.19.0 + EigenDA-Proxy 2.7.0 | 7 | 28 GiB | 220 GB |
+| Hyperliquid | Testnet | hyperliquid testnet-full | 4 | 16 GiB | 300 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -444,6 +450,94 @@ The node stores state with the RocksDB backend, under the network's default prun
 | cronosd | 8546 | TCP | EVM WS JSON-RPC |
 
 Both listeners serve the `eth`, `net`, `web3`, `debug`, and `txpool` namespaces. The CometBFT RPC port (26657) is internal — it carries the node health surface, not a customer endpoint. The CometBFT P2P port (26656) and the metrics port (26660) are internal as well.
+
+## BNB Smart Chain
+
+Runs a single reth-bsc full node in pruned mode. One process serves the chain end to end, so there is no separate consensus client to provision.
+
+Both networks bootstrap from a pre-built chain snapshot, which temporarily requires about **2× the steady-state storage** while the archive is downloaded and extracted — provision the node's volume at the peak. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| BNB Smart Chain Mainnet | 56 | Reth-BSC v0.1.1 | [bscscan.com](https://bscscan.com) |
+| BNB Smart Chain Testnet | 97 | Reth-BSC v0.1.1 | [testnet.bscscan.com](https://testnet.bscscan.com) |
+
+The node runs in pruned mode, keeping recent state rather than the full history. Mainnet is the larger of the two by a wide margin — size the volume from the catalog figures above, not from the testnet.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Reth-BSC | 8545 | TCP | HTTP JSON-RPC |
+| Reth-BSC | 8546 | TCP | WS JSON-RPC |
+
+Both listeners serve the `eth`, `net`, `web3`, `txpool`, and `debug` namespaces. The P2P port (30303, TCP and UDP) and the metrics port (9001) are internal.
+
+## Kaia
+
+Runs a single kend full node with full sync and full garbage collection. One process serves the chain end to end, so there is no separate consensus client to provision.
+
+Both networks sync from genesis rather than from a snapshot, so expect a long first sync. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Kaia Mainnet | 8217 | kend v2.2.2 | [kaiascan.io](https://kaiascan.io) |
+| Kaia Kairos | 1001 | kend v2.2.2 | [kairos.kaiascan.io](https://kairos.kaiascan.io) |
+
+Full garbage collection keeps the state needed to serve current-block queries. The node's transaction pool is sized well above the client default, so it holds a deeper queue of pending transactions under load.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| kend | 8551 | TCP | HTTP JSON-RPC |
+| kend | 8552 | TCP | WS JSON-RPC |
+
+Both listeners serve Kaia's native `klay` namespace alongside the standard `eth`, `net`, `web3`, and `debug` namespaces, so Kaia-specific and Ethereum-compatible calls reach the same endpoint. The P2P port (32323, TCP and UDP), its subport (32324), and the metrics port (61001) are internal.
+
+## Ronin
+
+Runs an OP Stack execution client and rollup client alongside a data-availability proxy. Ronin posts its rollup batches to EigenDA rather than to Ethereum calldata, so the rollup client reads generic commitments and resolves the underlying blobs through the proxy. CPU and RAM are split across the three clients.
+
+<Warning>
+This family needs three endpoints you supply: an Ethereum Layer 1 RPC endpoint, a Beacon API endpoint, and outbound reachability to the EigenDA disperser. The rollup stalls at the last derived block if any of the three is unavailable.
+</Warning>
+
+| Network | Chain ID | Clients | Block explorer |
+|---------|----------|---------|----------------|
+| Ronin Saigon | 202601 | Conduit-Reth v2.1.2 + OP-Node v1.19.0 + EigenDA-Proxy 2.7.0 | [saigon-explorer.roninchain.com](https://saigon-explorer.roninchain.com) |
+
+The execution client bootstraps from a published state export instead of replaying history from genesis, so it reaches the chain head without a full sync. Transactions submitted to the node are forwarded to the network's sequencer.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Conduit-Reth | 8545 | TCP | HTTP JSON-RPC |
+| Conduit-Reth | 8546 | TCP | WS JSON-RPC |
+| OP-Node | 9545 | TCP | Rollup HTTP RPC |
+
+Both execution listeners serve the `eth`, `net`, `web3`, `trace`, `debug`, and `txpool` namespaces. The engine auth RPC port (8551), the execution P2P port (30303), and the proxy's REST (3100) and metrics (7300) ports are internal — the rollup client reaches the proxy inside the deployment, not from outside it.
+
+## Hyperliquid
+
+Runs a single full node that serves the EVM JSON-RPC. One process serves the chain end to end, so there is no separate consensus client to provision.
+
+The network syncs from its public peers rather than from a snapshot. See [Initial sync times](/docs/self-hosted/deploying-nodes#initial-sync-times).
+
+| Network | Chain ID | Client | Block explorer |
+|---------|----------|--------|----------------|
+| Hyperliquid Testnet | 998 | hyperliquid testnet-full | [app.hyperliquid-testnet.xyz/explorer](https://app.hyperliquid-testnet.xyz/explorer) |
+
+The node prunes its logs on a rolling 48-hour window, so steady-state disk use stays flat over long runs rather than growing with uptime.
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| hyperliquid | 3001 | TCP | HTTP JSON-RPC |
+
+The single HTTP listener carries the EVM JSON-RPC. There is no separate WebSocket listener on this deployment. The gossip ports (4001 and 4002) are internal.
 
 ## Coming soon
 

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -290,6 +290,56 @@
         { "port": 9003, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
         { "port": 7300, "proto": "TCP", "purpose": "Metrics", "exposed": false }
       ]
+    },
+    "reth-bsc": {
+      "label": "Reth-BSC",
+      "role": "full",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 30303, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 30303, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
+        { "port": 9001, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "kend": {
+      "label": "kend",
+      "role": "full",
+      "ports": [
+        { "port": 8551, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8552, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 32323, "proto": "TCP", "purpose": "P2P", "exposed": false },
+        { "port": 32323, "proto": "UDP", "purpose": "P2P discovery", "exposed": false },
+        { "port": 32324, "proto": "TCP", "purpose": "P2P subport", "exposed": false },
+        { "port": 61001, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "conduit-reth": {
+      "label": "Conduit-Reth",
+      "role": "execution",
+      "ports": [
+        { "port": 8545, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 8546, "proto": "TCP", "purpose": "WS JSON-RPC", "exposed": true },
+        { "port": 8551, "proto": "TCP", "purpose": "Engine auth RPC", "exposed": false },
+        { "port": 30303, "proto": "TCP", "purpose": "P2P", "exposed": false }
+      ]
+    },
+    "eigenda-proxy": {
+      "label": "EigenDA-Proxy",
+      "role": "data-availability",
+      "ports": [
+        { "port": 3100, "proto": "TCP", "purpose": "Alt-DA REST", "exposed": false },
+        { "port": 7300, "proto": "TCP", "purpose": "Metrics", "exposed": false }
+      ]
+    },
+    "hyperliquid": {
+      "label": "hyperliquid",
+      "role": "full",
+      "ports": [
+        { "port": 3001, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true },
+        { "port": 4001, "proto": "TCP", "purpose": "Gossip", "exposed": false },
+        { "port": 4002, "proto": "TCP", "purpose": "Gossip", "exposed": false }
+      ]
     }
   },
   "families": {
@@ -429,6 +479,36 @@
       "notes": [
         "Runs a paired execution client and consensus client as a non-validator node that follows the network's public endpoints. CPU and RAM are split across the two clients.",
         "Bootstraps from a pre-built chain snapshot. Snapshot bootstrap temporarily needs about 2x the steady-state storage while the archive is downloaded and extracted."
+      ]
+    },
+    "bsc": {
+      "label": "BNB Smart Chain",
+      "notes": [
+        "Runs a single full node client in pruned mode that serves both the HTTP and the WebSocket JSON-RPC.",
+        "Both networks bootstrap from a pre-built chain snapshot and temporarily need about 2x the steady-state storage while the archive is downloaded and extracted."
+      ]
+    },
+    "kaia": {
+      "label": "Kaia",
+      "notes": [
+        "Runs a single full node client with full sync and full garbage collection, serving both the HTTP and the WebSocket JSON-RPC.",
+        "Both listeners expose the native klay namespace alongside the standard eth, net, web3, and debug namespaces.",
+        "Both networks sync from genesis rather than from a snapshot, so expect a long first sync."
+      ]
+    },
+    "ronin": {
+      "label": "Ronin",
+      "notes": [
+        "Runs an OP Stack execution client and rollup client alongside a data-availability proxy, because the rollup posts its batch data to EigenDA instead of Ethereum calldata. CPU and RAM are split across the three clients.",
+        "Requires an Ethereum Layer 1 RPC endpoint and a Beacon API endpoint that you supply, plus outbound reachability to the EigenDA disperser.",
+        "The execution client bootstraps from a published state export rather than replaying history from genesis."
+      ]
+    },
+    "hyperliquid": {
+      "label": "Hyperliquid",
+      "notes": [
+        "Runs a single full node client that serves the EVM HTTP JSON-RPC. There is no separate WebSocket listener.",
+        "The node prunes its logs on a rolling 48-hour window, so steady-state disk use stays flat over long runs."
       ]
     }
   },
@@ -873,6 +953,68 @@
         { "client": "cronosd", "version": "1.7.8", "cpu": 4, "ramGi": 16, "storageGi": 50 }
       ],
       "totals": { "cpu": 4, "ramGi": 16, "storageGi": 50 }
+    },
+    {
+      "protocol": "BNB Smart Chain", "network": "Mainnet", "chainId": 56,
+      "explorer": "https://bscscan.com",
+      "family": "bsc", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "reth-bsc", "version": "v0.1.1", "cpu": 4, "ramGi": 16, "storageGi": 5600 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 5600 }
+    },
+    {
+      "protocol": "BNB Smart Chain", "network": "Testnet", "chainId": 97,
+      "explorer": "https://testnet.bscscan.com",
+      "family": "bsc", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "reth-bsc", "version": "v0.1.1", "cpu": 4, "ramGi": 16, "storageGi": 900 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 900 }
+    },
+    {
+      "protocol": "Kaia", "network": "Mainnet", "chainId": 8217,
+      "explorer": "https://kaiascan.io",
+      "family": "kaia", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "kend", "version": "v2.2.2", "cpu": 8, "ramGi": 32, "storageGi": 2800 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 32, "storageGi": 2800 }
+    },
+    {
+      "protocol": "Kaia", "network": "Kairos", "chainId": 1001,
+      "explorer": "https://kairos.kaiascan.io",
+      "family": "kaia", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "kend", "version": "v2.2.2", "cpu": 4, "ramGi": 16, "storageGi": 1200 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 1200 }
+    },
+    {
+      "protocol": "Ronin", "network": "Saigon", "chainId": 202601,
+      "explorer": "https://saigon-explorer.roninchain.com",
+      "family": "ronin", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "conduit-reth", "version": "v2.1.2", "cpu": 4, "ramGi": 16, "storageGi": 200 },
+        { "client": "op-node", "version": "v1.19.0", "cpu": 2, "ramGi": 8, "storageGi": 20 },
+        { "client": "eigenda-proxy", "version": "2.7.0", "cpu": 1, "ramGi": 4, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 7, "ramGi": 28, "storageGi": 220 }
+    },
+    {
+      "protocol": "Hyperliquid", "network": "Testnet", "chainId": 998,
+      "explorer": "https://app.hyperliquid-testnet.xyz/explorer",
+      "family": "hyperliquid", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "hyperliquid", "version": "testnet-full", "cpu": 4, "ramGi": 16, "storageGi": 300 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 300 }
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.43.0 release note. Adds BNB Smart Chain, Kaia, Ronin, and Hyperliquid to the supported-deployments catalog, covering six networks.