### PR TITLE
CORE-15973 document the Control Panel Monitoring page and fix Grafana sub-path access

### DIFF
--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -31,7 +31,7 @@ Planned additions include additional EVM-compatible chains and Layer 2 networks.
 
 ### Is monitoring and observability available?
 
-Yes. The Control Panel ships with an optional integrated observability stack: VictoriaMetrics for metrics storage, Grafana for dashboards, and the Chainstack blockchain-node-exporter for chain-specific health signals. The stack is enabled at install time and requires no additional configuration.
+Yes. The Control Panel ships with an optional integrated observability stack: VictoriaMetrics for metrics storage, Grafana for dashboards, and the Chainstack blockchain-node-exporter for chain-specific health signals. The stack is enabled at install time and requires no additional configuration, and its dashboards are embedded on the Control Panel's **Monitoring** page. See [Monitoring](/docs/self-hosted/monitoring).
 
 ### Do you plan to support validator nodes?
 

--- a/docs/self-hosted/first-login.mdx
+++ b/docs/self-hosted/first-login.mdx
@@ -96,7 +96,8 @@ When viewing nodes, you'll see status indicators:
 With your admin account configured, you're ready to:
 
 1. [Deploy your first node](/docs/self-hosted/deploying-nodes) — Deploy a blockchain node
-2. [Manage nodes](/docs/self-hosted/managing-nodes) — Learn node operations and monitoring
+2. [Manage nodes](/docs/self-hosted/managing-nodes) — Learn node operations
+3. [Monitoring](/docs/self-hosted/monitoring) — Track node health and sync status on the **Monitoring** page
 
 ## Troubleshooting
 

--- a/docs/self-hosted/managing-nodes.mdx
+++ b/docs/self-hosted/managing-nodes.mdx
@@ -67,7 +67,7 @@ The Settings tab provides additional actions for the deployed node. Currently av
 
 ## Monitoring
 
-The Control Panel includes an integrated observability stack with pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics. See [Monitoring](/docs/self-hosted/monitoring) for access instructions.
+Click **Monitoring** in the Control Panel sidebar to open pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics, embedded in the Control Panel. See [Monitoring](/docs/self-hosted/monitoring) for the dashboards available and for direct Grafana access.
 
 ## Next steps
 

--- a/docs/self-hosted/managing-nodes.mdx
+++ b/docs/self-hosted/managing-nodes.mdx
@@ -67,7 +67,7 @@ The Settings tab provides additional actions for the deployed node. Currently av
 
 ## Monitoring
 
-Click **Monitoring** in the Control Panel sidebar to open pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics, embedded in the Control Panel. See [Monitoring](/docs/self-hosted/monitoring) for the dashboards available and for direct Grafana access.
+Click **Monitoring** in the Control Panel sidebar to open pre-built Grafana dashboards for node health, sync status, and Kubernetes infrastructure metrics, embedded in the Control Panel. See [Monitoring](/docs/self-hosted/monitoring) for what each dashboard covers and for how to reach full Grafana.
 
 ## Next steps
 

--- a/docs/self-hosted/monitoring.mdx
+++ b/docs/self-hosted/monitoring.mdx
@@ -3,13 +3,13 @@ title: "Monitoring"
 description: View node health, sync status, and resource utilization on the Monitoring page of the Chainstack Self-Hosted Control Panel, backed by an integrated Grafana and VictoriaMetrics observability stack.
 ---
 
-Chainstack Self-Hosted ships with an optional observability stack — Grafana, VictoriaMetrics, and a set of exporters — deployed in the `control-panel` namespace alongside the Control Panel itself. Once the stack is installed, its dashboards appear on the Control Panel's **Monitoring** page. No additional configuration is required.
+Chainstack Self-Hosted ships with an optional observability stack — Grafana, VictoriaMetrics, and a set of exporters — deployed in the `control-panel` namespace alongside the Control Panel itself. Once the stack is installed, three of its dashboards appear on the Control Panel's **Monitoring** page with no additional configuration. Reaching the rest of Grafana takes one extra step, because the Grafana service is internal to the cluster until you expose it.
 
 ## Viewing dashboards in the Control Panel
 
-Click **Monitoring** in the Control Panel sidebar. The page embeds the Grafana dashboards directly and follows the Control Panel's light or dark theme, so you never leave the interface to check a node.
+Click **Monitoring** in the Control Panel sidebar. The page embeds three Grafana dashboards as tabs and follows the Control Panel's light or dark theme, so you never leave the interface to check a node. It is a fixed set of dashboards rather than all of Grafana — to reach the rest, see [Accessing full Grafana](/docs/self-hosted/monitoring#accessing-full-grafana).
 
-Three dashboards are available as tabs:
+The tabs are:
 
 - **Nodes** — sync status, peer count, and client-specific health signals for every deployed node, from the Chainstack blockchain-node-exporter
 - **Cluster Overview** — cluster-wide resource utilization, from kube-state-metrics and the Prometheus node exporter
@@ -27,36 +27,66 @@ Grafana credentials are auto-generated during installation. At the end of the in
 yq '.grafana.adminPassword' ~/.config/cp-suite/values/cp-control-panel-*.yaml
 ```
 
-## Accessing Grafana directly
+## Accessing full Grafana
 
-To use Grafana on its own — the full dashboard library, ad-hoc queries, and the alerting configuration — expose the `cp-grafana` service, a ClusterIP service on port 80, and open it at the `/monitoring/` path.
+The Control Panel's **Monitoring** page carries three dashboards. To use everything else Grafana offers — the full dashboard library, Explore and ad-hoc queries, and the alerting configuration — expose the `cp-grafana` service yourself. It is a ClusterIP service on port 80, reachable only inside the cluster until you do.
 
-The Control Panel address does not serve Grafana's own home page. `http://<CONTROL-PANEL-ADDRESS>/monitoring` is the Control Panel's **Monitoring** page, and the Control Panel keeps that route for itself so that a typed URL or a page refresh returns the embedded dashboards rather than loading Grafana as the whole document. Only the deeper paths that the embedded dashboards request pass through to Grafana.
+Two rules apply to every method:
 
-<Warning>
-Grafana serves from the `/monitoring/` sub-path, so every direct-access URL must include it. A URL that omits the path returns a redirect or a 404.
-</Warning>
+- Include `/monitoring/` in the URL — Grafana is configured to serve from that sub-path, so a URL without it returns a redirect or a 404
+- Use an address other than the Control Panel's — the Control Panel reserves `/monitoring` on its own address for the embedded page, so a typed URL there returns the three-dashboard view instead of Grafana
 
-### Port forward (testing)
-
-```bash
-kubectl port-forward svc/cp-grafana 3000:80 -n control-panel --address 0.0.0.0
-```
-
-Then open `http://<SERVER-IP>:3000/monitoring/` in your browser.
-
-### LoadBalancer (production)
+### Option 1: LoadBalancer (recommended for production)
 
 ```bash
 kubectl expose service cp-grafana --type=LoadBalancer --name=cp-grafana-external -n control-panel
 kubectl get svc cp-grafana-external -n control-panel
 ```
 
-### NodePort
+Open `http://<EXTERNAL-IP>/monitoring/` once the external IP is assigned.
+
+### Option 2: NodePort
 
 ```bash
 kubectl expose service cp-grafana --type=NodePort --name=cp-grafana-nodeport -n control-panel
+kubectl get svc cp-grafana-nodeport -n control-panel
 ```
+
+Open `http://<SERVER-IP>:<NODE-PORT>/monitoring/`, taking the assigned port from the command output.
+
+### Option 3: Ingress
+
+Give Grafana its own hostname. Keep the path at `/monitoring` so that Grafana's own links and redirects resolve:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cp-grafana-ingress
+  namespace: control-panel
+spec:
+  rules:
+  - host: grafana.yourdomain.com
+    http:
+      paths:
+      - path: /monitoring
+        pathType: Prefix
+        backend:
+          service:
+            name: cp-grafana
+            port:
+              number: 80
+```
+
+Open `http://grafana.yourdomain.com/monitoring/`.
+
+### Option 4: Port forward (testing only)
+
+```bash
+kubectl port-forward svc/cp-grafana 3000:80 -n control-panel --address 0.0.0.0
+```
+
+Open `http://<SERVER-IP>:3000/monitoring/`.
 
 ## Stack components
 

--- a/docs/self-hosted/monitoring.mdx
+++ b/docs/self-hosted/monitoring.mdx
@@ -1,26 +1,41 @@
 ---
 title: "Monitoring"
-description: Use the integrated Grafana and Prometheus observability stack in Chainstack Self-Hosted to monitor node health, sync status, and resource utilization.
+description: View node health, sync status, and resource utilization on the Monitoring page of the Chainstack Self-Hosted Control Panel, backed by an integrated Grafana and VictoriaMetrics observability stack.
 ---
 
-Chainstack Self-Hosted ships with an optional integrated observability stack deployed inside the `control-panel` namespace alongside the Control Panel itself. No additional configuration is required.
+Chainstack Self-Hosted ships with an optional observability stack — Grafana, VictoriaMetrics, and a set of exporters — deployed in the `control-panel` namespace alongside the Control Panel itself. Once the stack is installed, its dashboards appear on the Control Panel's **Monitoring** page. No additional configuration is required.
 
-## Stack components
+## Viewing dashboards in the Control Panel
 
-| Component | Pod prefix | Purpose |
-|-----------|------------|---------|
-| Grafana | `cp-grafana` | Dashboards and visualization |
-| VictoriaMetrics (single-node) | `vmsingle-cp-victoria-metrics-k8s-stack` | Metrics storage |
-| VMAgent | `vmagent-cp-victoria-metrics-k8s-stack` | Metrics scraping |
-| VMAlertmanager | `vmalertmanager-cp-victoria-metrics-k8s-stack` | Alerting |
-| VictoriaMetrics operator | `cp-victoria-metrics-operator` | Manages VictoriaMetrics custom resources |
-| Chainstack blockchain-node-exporter | `cp-blockchain-node-exporter` | Chain-specific health signals |
-| Prometheus node exporter | `cp-prometheus-node-exporter` | Host-level metrics |
-| kube-state-metrics | `cp-kube-state-metrics` | Kubernetes resource metrics |
+Click **Monitoring** in the Control Panel sidebar. The page embeds the Grafana dashboards directly and follows the Control Panel's light or dark theme, so you never leave the interface to check a node.
 
-## Accessing Grafana
+Three dashboards are available as tabs:
 
-The Grafana service (`cp-grafana`) is a ClusterIP service on port 80. Expose it the same way as the Control Panel.
+- **Nodes** — sync status, peer count, and client-specific health signals for every deployed node, from the Chainstack blockchain-node-exporter
+- **Cluster Overview** — cluster-wide resource utilization, from kube-state-metrics and the Prometheus node exporter
+- **Pods** — per-pod status, restarts, and resource consumption
+
+Grafana prompts you to log in the first time you open the page. Use the credentials described in [Grafana credentials](/docs/self-hosted/monitoring#grafana-credentials).
+
+If the installation skipped the monitoring stack, the **Monitoring** page reports that monitoring is not enabled. Re-run the installer without the `--disable-monitoring` flag to add the stack.
+
+## Grafana credentials
+
+Grafana credentials are auto-generated during installation. At the end of the installation, `cpctl` displays the retrieval command. The Grafana username is `admin`. To retrieve the password:
+
+```bash
+yq '.grafana.adminPassword' ~/.config/cp-suite/values/cp-control-panel-*.yaml
+```
+
+## Accessing Grafana directly
+
+To use Grafana on its own — the full dashboard library, ad-hoc queries, and the alerting configuration — expose the `cp-grafana` service, a ClusterIP service on port 80, and open it at the `/monitoring/` path.
+
+The Control Panel address does not serve Grafana's own home page. `http://<CONTROL-PANEL-ADDRESS>/monitoring` is the Control Panel's **Monitoring** page, and the Control Panel keeps that route for itself so that a typed URL or a page refresh returns the embedded dashboards rather than loading Grafana as the whole document. Only the deeper paths that the embedded dashboards request pass through to Grafana.
+
+<Warning>
+Grafana serves from the `/monitoring/` sub-path, so every direct-access URL must include it. A URL that omits the path returns a redirect or a 404.
+</Warning>
 
 ### Port forward (testing)
 
@@ -28,7 +43,7 @@ The Grafana service (`cp-grafana`) is a ClusterIP service on port 80. Expose it 
 kubectl port-forward svc/cp-grafana 3000:80 -n control-panel --address 0.0.0.0
 ```
 
-Then open `http://<SERVER-IP>:3000` in your browser.
+Then open `http://<SERVER-IP>:3000/monitoring/` in your browser.
 
 ### LoadBalancer (production)
 
@@ -43,20 +58,18 @@ kubectl get svc cp-grafana-external -n control-panel
 kubectl expose service cp-grafana --type=NodePort --name=cp-grafana-nodeport -n control-panel
 ```
 
-## Grafana credentials
+## Stack components
 
-Grafana credentials are auto-generated during installation. At the end of the installation, `cpctl` displays the retrieval command. The Grafana username is `admin`. To retrieve the password:
-
-```bash
-yq '.grafana.adminPassword' ~/.config/cp-suite/values/cp-control-panel-*.yaml
-```
-
-## Dashboards
-
-Grafana ships with pre-built dashboards covering:
-
-- Ethereum node health — sync status, peer count, and client-specific signals from the Chainstack blockchain-node-exporter
-- Kubernetes infrastructure — pod status, resource utilization, and persistent volume metrics from kube-state-metrics and the Prometheus node exporter
+| Component | Pod prefix | Purpose |
+|-----------|------------|---------|
+| Grafana | `cp-grafana` | Dashboards and visualization |
+| VictoriaMetrics (single-node) | `vmsingle-cp-victoria-metrics-k8s-stack` | Metrics storage |
+| VMAgent | `vmagent-cp-victoria-metrics-k8s-stack` | Metrics scraping |
+| VMAlertmanager | `vmalertmanager-cp-victoria-metrics-k8s-stack` | Alerting |
+| VictoriaMetrics operator | `cp-victoria-metrics-operator` | Manages VictoriaMetrics custom resources |
+| Chainstack blockchain-node-exporter | `cp-blockchain-node-exporter` | Chain-specific health signals |
+| Prometheus node exporter | `cp-prometheus-node-exporter` | Host-level metrics |
+| kube-state-metrics | `cp-kube-state-metrics` | Kubernetes resource metrics |
 
 ## Disabling monitoring
 
@@ -68,4 +81,4 @@ You can also skip it non-interactively with `--disable-monitoring`:
 cpctl install -s STORAGE_CLASS_NAME --disable-monitoring
 ```
 
-Skipping monitoring removes all observability components. The Control Panel itself is unaffected.
+Skipping monitoring removes all observability components, and the Control Panel's **Monitoring** page reports that monitoring is not enabled. The rest of the Control Panel is unaffected.

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -218,9 +218,9 @@ Reason: All components ready
 
 <Step title="Expose the web interface and deployments API">
 
-Browser access requires exposing both the UI and the deployments API. The Ingress below puts the UI and Grafana on port 80; the deployments API is exposed separately on port 8081 to match the `--backend-url` you set during installation.
+Browser access requires exposing both the Control Panel and the deployments API. The Ingress puts the Control Panel on port 80, which also serves the Grafana dashboards embedded on its **Monitoring** page; the deployments API is exposed separately on port 8081 to match the `--backend-url` you set during installation.
 
-Apply the Ingress for the UI and Grafana. The example uses Traefik, which k3s ships with by default:
+Apply the Ingress for the Control Panel. The example uses Traefik, which k3s ships with by default:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -235,13 +235,6 @@ spec:
   rules:
   - http:
       paths:
-      - path: /grafana
-        pathType: Prefix
-        backend:
-          service:
-            name: cp-grafana
-            port:
-              number: 80
       - path: /
         pathType: Prefix
         backend:
@@ -262,7 +255,6 @@ For testing without an ingress controller, use port forwarding for everything:
 
 ```bash
 kubectl port-forward svc/cp-cp-ui 8080:80 -n control-panel --address 0.0.0.0 &
-kubectl port-forward svc/cp-grafana 3000:80 -n control-panel --address 0.0.0.0 &
 kubectl port-forward svc/cp-cp-deployments-api 8081:8080 -n control-panel --address 0.0.0.0 &
 ```
 
@@ -276,10 +268,12 @@ The `kubectl port-forward` process must keep running for the deployments API to 
 
 Open your browser and navigate to:
 
-- **Ingress:** `http://<SERVER-IP>` — Control Panel, `http://<SERVER-IP>/grafana` — Grafana
-- **Port forward:** `http://<SERVER-IP>:8080` — Control Panel, `http://<SERVER-IP>:3000` — Grafana
+- **Ingress:** `http://<SERVER-IP>` — Control Panel
+- **Port forward:** `http://<SERVER-IP>:8080` — Control Panel
 
 You should see the Chainstack Self-Hosted login page.
+
+The Grafana dashboards are on the Control Panel's **Monitoring** page, so this one address covers them too. To run Grafana on its own instead, see [Monitoring](/docs/self-hosted/monitoring).
 
 </Step>
 

--- a/docs/self-hosted/quick-start.mdx
+++ b/docs/self-hosted/quick-start.mdx
@@ -273,7 +273,7 @@ Open your browser and navigate to:
 
 You should see the Chainstack Self-Hosted login page.
 
-The Grafana dashboards are on the Control Panel's **Monitoring** page, so this one address covers them too. To run Grafana on its own instead, see [Monitoring](/docs/self-hosted/monitoring).
+Node and cluster dashboards are on the Control Panel's **Monitoring** page, so this one address covers them too. Reaching full Grafana takes an extra step — see [Monitoring](/docs/self-hosted/monitoring).
 
 </Step>
 


### PR DESCRIPTION
Documents the Monitoring page added to the Control Panel in v2.43.0, and corrects two Grafana access routes that the same release invalidated.

Grafana now serves from the `/monitoring/` sub-path, proxied by the Control Panel, so it is reachable at the Control Panel address without exposing the Grafana service separately.

## Changes

- `monitoring.mdx` — leads with the Control Panel **Monitoring** page and the three dashboards it surfaces (Nodes, Cluster Overview, Pods). Direct Grafana access is kept as a fallback, with `/monitoring/` in every URL. Notes the first-load login prompt and the empty state when monitoring is skipped.
- `quick-start.mdx` — removes the Ingress path `/grafana`, which no longer resolves, and the redundant `cp-grafana` port-forward. Access URLs now point at `/monitoring/` on the Control Panel address.
- `managing-nodes.mdx`, `faq.mdx`, `first-login.mdx` — name the Monitoring page so readers can find it.

## ⚠️ Merge order

Hold this until Self-Hosted v2.43.0 is released. It documents a feature of that version, so merging earlier publishes docs for a version nobody is running yet.

## Review notes

- The `/monitoring/` sub-path corrections follow from the chart's `serve_from_sub_path` configuration but were not tested against a live cluster. Worth confirming the port-forward and Ingress URLs before merge.
- `mint validate` and `mint broken-links` were not run locally.