### PR TITLE
CORE-16054 self-hosted release notes v2.53.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3554,6 +3554,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-33-0-august-12-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026.mdx
@@ -1,0 +1,33 @@
+---
+title: "Chainstack Self-Hosted v2.53.0: August 20, 2026"
+description: "Ten new networks join the deployment catalog, including Hyperliquid Mainnet, and snapshot bootstrapping now accepts pre-extracted archives."
+---
+
+This release broadens protocol coverage and improves snapshot-based node bootstrapping.
+
+## More supported networks
+
+You can now deploy ten new networks straight from the new-node flow:
+
+- Base Sepolia, Optimism Sepolia, Zora Sepolia, and Unichain Sepolia — OP-Stack rollup testnets
+- Polygon Amoy — Bor and Heimdall testnet
+- Starknet Sepolia — Pathfinder-based testnet
+- TRON Nile — java-tron testnet
+- Bitcoin Signet and Bitcoin Testnet4 — core bitcoind testnets
+- Hyperliquid Mainnet — completes mainnet coverage alongside the existing Hyperliquid Testnet
+
+See [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the full deployment catalog.
+
+## Snapshot bootstrapping
+
+Snapshot-based bootstrapping now accepts an already-unpacked archive as a data source, so nodes that have unpacked snapshot data available can skip the extract step.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.13.0 |
+| cp-deployments-api | v1.33.0 |
+| cp-workflows | v3.41.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.13.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.53.0: August 20, 2026" description="">
+
+This release adds ten new networks to the deployment catalog — Base Sepolia, Optimism Sepolia, Zora Sepolia, Unichain Sepolia, Polygon Amoy, Starknet Sepolia, TRON Nile, Bitcoin Signet, Bitcoin Testnet4, and Hyperliquid Mainnet. Snapshot-based bootstrapping now also accepts an already-unpacked archive as a data source.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.43.0: August 18, 2026" description="">
 
 This release adds BNB Smart Chain, Kaia, Ronin, and Hyperliquid as deployment targets, covering six networks in total. BNB Smart Chain and Kaia each run a single execution node across mainnet and testnet, Ronin Saigon runs an OP-Stack rollup that reads its batch data from EigenDA, and Hyperliquid Testnet runs a single node. The Control Panel can now also serve the Grafana monitoring dashboards.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -73,10 +73,10 @@ The table below summarizes the standard preset totals by architecture family. Us
 | EVM Layer 2 — OP Stack | Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle | 6–12 | 24–48 GiB | 100 GB–3.5 TB |
 | EVM Layer 2 — opBNB | opBNB Mainnet, Testnet | 6–12 | 24–48 GiB | 500 GB–2 TB |
 | EVM Layer 2 — Arbitrum Nitro | Arbitrum One, Arbitrum Sepolia, Robinhood Chain | 4–8 | 32–64 GiB | 200 GB–2.5 TB |
-| Polygon PoS | Polygon Mainnet | 12 | 64 GiB | ~5.5 TB |
-| Starknet | Starknet Mainnet | 8 | 32 GiB | ~1 TB |
-| TRON | TRON Mainnet | 8 | 32 GiB | ~3 TB |
-| Bitcoin | Bitcoin Mainnet | 4 | 8 GiB | ~1 TB |
+| Polygon PoS | Polygon Mainnet, Amoy | 6–12 | 24–64 GiB | 170 GB–5.5 TB |
+| Starknet | Starknet Mainnet, Sepolia | 4–8 | 16–32 GiB | 400 GB–1 TB |
+| TRON | TRON Mainnet, Nile | 4–8 | 16–32 GiB | 200 GB–3 TB |
+| Bitcoin | Bitcoin Mainnet, Signet, Testnet4 | 4 | 8 GiB | 100 GB–1 TB |
 | Sui | Sui Mainnet, Testnet | 16 | 64 GiB | 400 GB–2.2 TB |
 | Tempo | Tempo Mainnet, Testnet | 4 | 16 GiB | 70 GB–1.1 TB |
 | Plasma | Plasma Mainnet, Testnet | 5 | 20 GiB | 250–350 GB |
@@ -89,7 +89,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | BNB Smart Chain | BNB Smart Chain Mainnet, Testnet | 4 | 16 GiB | 900 GB–5.5 TB |
 | Kaia | Kaia Mainnet, Kairos | 4–8 | 16–32 GiB | ~1.2–2.75 TB |
 | Ronin | Ronin Saigon | 7 | 28 GiB | 220 GB |
-| Hyperliquid | Hyperliquid Testnet | 4 | 16 GiB | 300 GB |
+| Hyperliquid | Hyperliquid Testnet, Mainnet | 4–8 | 16–32 GiB | 250–300 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -98,7 +98,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism Mainnet, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), and BNB Smart Chain (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism (both networks), Base Sepolia, Unichain Sepolia, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Polygon Amoy, Starknet Sepolia, Bitcoin Signet, Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), and BNB Smart Chain (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -13,9 +13,13 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Ethereum | Sepolia | Reth v2.2.0 + Prysm v7.1.3 | 8 | 32 GiB | ~1.3 TB |
 | Ethereum | Hoodi | Reth v2.2.0 + Prysm v7.1.3 | 8 | 32 GiB | 250 GB |
 | Optimism | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
+| Optimism | Sepolia | OP-Reth v2.4.2 + OP-Node v1.19.4 | 6 | 24 GiB | 400 GB |
 | Base | Mainnet | Base-Reth v1.1.0 + Base-Node v1.1.0 | 12 | 48 GiB | ~3.5 TB |
+| Base | Sepolia | Base-Reth v1.2.0 + Base-Node v1.2.0 | 6 | 24 GiB | ~1 TB |
 | Unichain | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
+| Unichain | Sepolia | OP-Reth v2.4.0 + OP-Node v1.19.2 | 6 | 24 GiB | 300 GB |
 | Zora | Mainnet | OP-Reth v2.3.1 + OP-Node v1.19.0 | 12 | 48 GiB | ~2 TB |
+| Zora | Sepolia | OP-Reth v2.4.0 + OP-Node v1.19.2 | 6 | 24 GiB | 500 GB |
 | World Chain | Mainnet | World-Chain v2.4.0 + OP-Node v1.19.3 | 12 | 48 GiB | ~1.3 TB |
 | World Chain | Sepolia | World-Chain v2.4.0 + OP-Node v1.19.3 | 6 | 24 GiB | 100 GB |
 | Blast | Mainnet | Blast-Geth v1.8.0 + Blast-Node v1.8.0 | 6 | 24 GiB | 500 GB |
@@ -29,9 +33,14 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Robinhood Chain | Mainnet | Nitro v3.11.2 | 8 | 64 GiB | 200 GB |
 | Robinhood Chain | Testnet | Nitro v3.11.2 | 4 | 32 GiB | 300 GB |
 | Polygon PoS | Mainnet | Bor v2.8.3 + Heimdall v0.9.0 | 12 | 64 GiB | ~5.5 TB |
+| Polygon PoS | Amoy | Bor 2.10.0 + Heimdall 0.11.0 | 6 | 24 GiB | 170 GB |
 | Starknet | Mainnet | Pathfinder v0.22.5 | 8 | 32 GiB | ~1 TB |
+| Starknet | Sepolia | Pathfinder v0.23.1 | 4 | 16 GiB | 400 GB |
 | TRON | Mainnet | Java-Tron GreatVoyage-v4.8.1.1 | 8 | 32 GiB | ~3 TB |
+| TRON | Nile | Java-Tron GreatVoyage-Nile-v4.8.2.1-PQ1-build1 | 4 | 16 GiB | 200 GB |
 | Bitcoin | Mainnet | Bitcoin Core 31 | 4 | 8 GiB | ~1 TB |
+| Bitcoin | Signet | Bitcoin Core 31 | 4 | 8 GiB | 100 GB |
+| Bitcoin | Testnet4 | Bitcoin Core 31 | 4 | 8 GiB | 100 GB |
 | Sui | Mainnet | Sui-Node v1.75.2 | 16 | 64 GiB | 400 GB |
 | Sui | Testnet | Sui-Node v1.76.0 | 16 | 64 GiB | ~2.2 TB |
 | Tempo | Mainnet | Tempo v1.11.0 | 4 | 16 GiB | 70 GB |
@@ -54,6 +63,7 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Kaia | Mainnet | kend v2.2.2 | 8 | 32 GiB | ~2.75 TB |
 | Kaia | Kairos | kend v2.2.2 | 4 | 16 GiB | ~1.2 TB |
 | Ronin | Saigon | Conduit-Reth v2.1.2 + OP-Node v1.19.0 + EigenDA-Proxy 2.7.0 | 7 | 28 GiB | 220 GB |
+| Hyperliquid | Mainnet | hyperliquid mainnet-full | 8 | 32 GiB | 250 GB |
 | Hyperliquid | Testnet | hyperliquid testnet-full | 4 | 16 GiB | 300 GB |
 
 <Note>
@@ -100,9 +110,13 @@ OP Stack deployments require an Ethereum Layer 1 **RPC endpoint** and a **Beacon
 | Network | Chain ID | Clients | Block explorer |
 |---------|----------|---------|----------------|
 | Optimism Mainnet | 10 | OP-Reth + OP-Node | [optimistic.etherscan.io](https://optimistic.etherscan.io) |
+| Optimism Sepolia | 11155420 | OP-Reth + OP-Node | [sepolia-optimism.etherscan.io](https://sepolia-optimism.etherscan.io) |
 | Base Mainnet | 8453 | Base-Reth + Base-Node | [basescan.org](https://basescan.org) |
+| Base Sepolia | 84532 | Base-Reth + Base-Node | [sepolia.basescan.org](https://sepolia.basescan.org) |
 | Unichain Mainnet | 130 | OP-Reth + OP-Node | [uniscan.xyz](https://uniscan.xyz) |
+| Unichain Sepolia | 1301 | OP-Reth + OP-Node | [sepolia.uniscan.xyz](https://sepolia.uniscan.xyz) |
 | Zora Mainnet | 7777777 | OP-Reth + OP-Node | [explorer.zora.energy](https://explorer.zora.energy) |
+| Zora Sepolia | 999999999 | OP-Reth + OP-Node | [sepolia.explorer.zora.energy](https://sepolia.explorer.zora.energy) |
 | World Chain Mainnet | 480 | World-Chain + OP-Node | [worldscan.org](https://worldscan.org) |
 | World Chain Sepolia | 4801 | World-Chain + OP-Node | [worldchain-sepolia.explorer.alchemy.com](https://worldchain-sepolia.explorer.alchemy.com) |
 | Blast Mainnet | 81457 | Blast-Geth + Blast-Node | [blastscan.io](https://blastscan.io) |
@@ -110,10 +124,10 @@ OP Stack deployments require an Ethereum Layer 1 **RPC endpoint** and a **Beacon
 | Mantle Mainnet | 5000 | Mantle-Geth + Mantle-Node | [mantlescan.xyz](https://mantlescan.xyz) |
 | Mantle Sepolia | 5003 | Mantle-Geth + Mantle-Node | [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz) |
 
-Optimism Mainnet, both World Chain networks, Blast Mainnet, and both Mantle networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy). Base, Unichain, Zora, and Blast Sepolia sync without a snapshot.
+Optimism (both networks), Base Sepolia, Unichain Sepolia, both World Chain networks, Blast Mainnet, and both Mantle networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy). Base Mainnet, Unichain Mainnet, both Zora networks, and Blast Sepolia sync without a snapshot.
 
 <Note>
-This family spans 6–12 vCPU. The smaller deployments — World Chain Sepolia, both Blast networks, and both Mantle networks — run 6 vCPU / 24 GiB, against the 12 vCPU / 48 GiB the Optimism, Base, Unichain, Zora, and World Chain Mainnet deployments take.
+This family spans 6–12 vCPU. The smaller deployments — Optimism, Base, Unichain, and Zora Sepolia, World Chain Sepolia, both Blast networks, and both Mantle networks — run 6 vCPU / 24 GiB, against the 12 vCPU / 48 GiB the Optimism, Base, Unichain, Zora, and World Chain Mainnet deployments take.
 </Note>
 
 Blast pins its client versions per network, so Mainnet and Sepolia run different versions — see the [Available deployments](#available-deployments) table above.
@@ -192,6 +206,9 @@ Polygon PoS requires an Ethereum Layer 1 **RPC endpoint** that you supply. Heimd
 | Network | Chain ID | Block explorer |
 |---------|----------|----------------|
 | Polygon Mainnet | 137 | [polygonscan.com](https://polygonscan.com) |
+| Polygon Amoy | 80002 | [amoy.polygonscan.com](https://amoy.polygonscan.com) |
+
+Polygon Amoy bootstraps from a pre-built snapshot (plan for ~2× storage during deploy); Polygon Mainnet syncs without one.
 
 ### Exposed ports
 
@@ -205,7 +222,7 @@ The Bor P2P port (30303) and the Heimdall CometBFT RPC (26657) and P2P (26656) p
 
 ## Starknet
 
-Runs a single full node client (Pathfinder v0.22.5).
+Runs a single full node client. The client version is pinned per network, so Mainnet and Sepolia can run different versions — see the [Available deployments](#available-deployments) table above.
 
 <Warning>
 Starknet requires an Ethereum Layer 1 **RPC endpoint** that you supply.
@@ -214,6 +231,9 @@ Starknet requires an Ethereum Layer 1 **RPC endpoint** that you supply.
 | Network | Block explorer |
 |---------|----------------|
 | Starknet Mainnet | [starkscan.co](https://starkscan.co) |
+| Starknet Sepolia | [sepolia.voyager.online](https://sepolia.voyager.online) |
+
+Starknet Sepolia bootstraps from a pre-built snapshot (plan for ~2× storage during deploy); Starknet Mainnet syncs without one.
 
 ### Exposed ports
 
@@ -223,11 +243,12 @@ Starknet requires an Ethereum Layer 1 **RPC endpoint** that you supply.
 
 ## TRON
 
-Runs a single full node client (Java-Tron GreatVoyage-v4.8.1.1).
+Runs a single full node client. The client version is pinned per network, so Mainnet and Nile can run different versions — see the [Available deployments](#available-deployments) table above.
 
 | Network | Block explorer |
 |---------|----------------|
 | TRON Mainnet | [tronscan.org](https://tronscan.org) |
+| TRON Nile | [nile.tronscan.org](https://nile.tronscan.org) |
 
 ### Exposed ports
 
@@ -244,6 +265,10 @@ Runs a single full node client (Bitcoin Core 31) with the transaction index (`tx
 | Network | Block explorer |
 |---------|----------------|
 | Bitcoin Mainnet | [blockstream.info](https://blockstream.info) |
+| Bitcoin Signet | [mempool.space/signet](https://mempool.space/signet/) |
+| Bitcoin Testnet4 | [mempool.space/testnet4](https://mempool.space/testnet4/) |
+
+Bitcoin Signet bootstraps from a pre-built snapshot (plan for ~2× storage during deploy); Bitcoin Mainnet and Testnet4 sync without one.
 
 ### Exposed ports
 
@@ -527,6 +552,7 @@ The network syncs from its public peers rather than from a snapshot. See [Initia
 
 | Network | Chain ID | Client | Block explorer |
 |---------|----------|--------|----------------|
+| Hyperliquid Mainnet | 999 | hyperliquid mainnet-full | [hyperevmscan.io](https://hyperevmscan.io) |
 | Hyperliquid Testnet | 998 | hyperliquid testnet-full | [app.hyperliquid-testnet.xyz/explorer](https://app.hyperliquid-testnet.xyz/explorer) |
 
 The node prunes its logs on a rolling 48-hour window, so steady-state disk use stays flat over long runs rather than growing with uptime.

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -558,6 +558,17 @@
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
     },
     {
+      "protocol": "Optimism", "network": "Sepolia", "chainId": 11155420,
+      "explorer": "https://sepolia-optimism.etherscan.io",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "op-reth", "version": "v2.4.2", "cpu": 4, "ramGi": 16, "storageGi": 400 },
+        { "client": "op-node", "version": "v1.19.4", "cpu": 2, "ramGi": 8, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 400 }
+    },
+    {
       "protocol": "Base", "network": "Mainnet", "chainId": 8453,
       "explorer": "https://basescan.org",
       "family": "op-stack-l2", "status": "available", "snapshotBootstrap": false,
@@ -567,6 +578,17 @@
         { "client": "base-node", "version": "v1.1.0", "cpu": 4, "ramGi": 16, "storageGi": 0 }
       ],
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 3500 }
+    },
+    {
+      "protocol": "Base", "network": "Sepolia", "chainId": 84532,
+      "explorer": "https://sepolia.basescan.org",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "base-reth", "version": "v1.2.0", "cpu": 4, "ramGi": 16, "storageGi": 1000 },
+        { "client": "base-node", "version": "v1.2.0", "cpu": 2, "ramGi": 8, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 1000 }
     },
     {
       "protocol": "Unichain", "network": "Mainnet", "chainId": 130,
@@ -580,6 +602,17 @@
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
     },
     {
+      "protocol": "Unichain", "network": "Sepolia", "chainId": 1301,
+      "explorer": "https://sepolia.uniscan.xyz",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "op-reth", "version": "v2.4.0", "cpu": 4, "ramGi": 16, "storageGi": 300 },
+        { "client": "op-node", "version": "v1.19.2", "cpu": 2, "ramGi": 8, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 300 }
+    },
+    {
       "protocol": "Zora", "network": "Mainnet", "chainId": 7777777,
       "explorer": "https://explorer.zora.energy",
       "family": "op-stack-l2", "status": "available", "snapshotBootstrap": false,
@@ -589,6 +622,17 @@
         { "client": "op-node", "version": "v1.19.0", "cpu": 4, "ramGi": 16, "storageGi": 0 }
       ],
       "totals": { "cpu": 12, "ramGi": 48, "storageGi": 2000 }
+    },
+    {
+      "protocol": "Zora", "network": "Sepolia", "chainId": 999999999,
+      "explorer": "https://sepolia.explorer.zora.energy",
+      "family": "op-stack-l2", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "op-reth", "version": "v2.4.0", "cpu": 4, "ramGi": 16, "storageGi": 500 },
+        { "client": "op-node", "version": "v1.19.2", "cpu": 2, "ramGi": 8, "storageGi": 0 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 500 }
     },
     {
       "protocol": "World Chain", "network": "Mainnet", "chainId": 480,
@@ -730,6 +774,17 @@
       "totals": { "cpu": 12, "ramGi": 64, "storageGi": 5620 }
     },
     {
+      "protocol": "Polygon PoS", "network": "Amoy", "chainId": 80002,
+      "explorer": "https://amoy.polygonscan.com",
+      "family": "polygon", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "bor",      "version": "2.10.0", "cpu": 4, "ramGi": 16, "storageGi": 150 },
+        { "client": "heimdall", "version": "0.11.0",  "cpu": 2, "ramGi": 8,  "storageGi": 20 }
+      ],
+      "totals": { "cpu": 6, "ramGi": 24, "storageGi": 170 }
+    },
+    {
       "protocol": "Starknet", "network": "Mainnet", "chainId": null,
       "explorer": "https://starkscan.co",
       "family": "starknet", "status": "available", "snapshotBootstrap": false,
@@ -738,6 +793,16 @@
         { "client": "pathfinder", "version": "v0.22.5", "cpu": 8, "ramGi": 32, "storageGi": 1000 }
       ],
       "totals": { "cpu": 8, "ramGi": 32, "storageGi": 1000 }
+    },
+    {
+      "protocol": "Starknet", "network": "Sepolia", "chainId": null,
+      "explorer": "https://sepolia.voyager.online",
+      "family": "starknet", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "pathfinder", "version": "v0.23.1", "cpu": 4, "ramGi": 16, "storageGi": 400 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 400 }
     },
     {
       "protocol": "TRON", "network": "Mainnet", "chainId": null,
@@ -750,6 +815,16 @@
       "totals": { "cpu": 8, "ramGi": 32, "storageGi": 3000 }
     },
     {
+      "protocol": "TRON", "network": "Nile", "chainId": null,
+      "explorer": "https://nile.tronscan.org",
+      "family": "tron", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "java-tron", "version": "GreatVoyage-Nile-v4.8.2.1-PQ1-build1", "cpu": 4, "ramGi": 16, "storageGi": 200 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 200 }
+    },
+    {
       "protocol": "Bitcoin", "network": "Mainnet", "chainId": null,
       "explorer": "https://blockstream.info",
       "family": "bitcoin", "status": "available", "snapshotBootstrap": false,
@@ -758,6 +833,26 @@
         { "client": "bitcoind", "version": "31", "cpu": 4, "ramGi": 8, "storageGi": 1000 }
       ],
       "totals": { "cpu": 4, "ramGi": 8, "storageGi": 1000 }
+    },
+    {
+      "protocol": "Bitcoin", "network": "Signet", "chainId": null,
+      "explorer": "https://mempool.space/signet/",
+      "family": "bitcoin", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "bitcoind", "version": "31", "cpu": 4, "ramGi": 8, "storageGi": 100 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 8, "storageGi": 100 }
+    },
+    {
+      "protocol": "Bitcoin", "network": "Testnet4", "chainId": null,
+      "explorer": "https://mempool.space/testnet4/",
+      "family": "bitcoin", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "bitcoind", "version": "31", "cpu": 4, "ramGi": 8, "storageGi": 100 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 8, "storageGi": 100 }
     },
     {
       "protocol": "Sui", "network": "Mainnet", "chainId": null,
@@ -1005,6 +1100,16 @@
         { "client": "eigenda-proxy", "version": "2.7.0", "cpu": 1, "ramGi": 4, "storageGi": 0 }
       ],
       "totals": { "cpu": 7, "ramGi": 28, "storageGi": 220 }
+    },
+    {
+      "protocol": "Hyperliquid", "network": "Mainnet", "chainId": 999,
+      "explorer": "https://hyperevmscan.io",
+      "family": "hyperliquid", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "hyperliquid", "version": "mainnet-full", "cpu": 8, "ramGi": 32, "storageGi": 250 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 32, "storageGi": 250 }
     },
     {
       "protocol": "Hyperliquid", "network": "Testnet", "chainId": 998,


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.53.0 release note. Adds Base Sepolia, Optimism Sepolia, Zora Sepolia, Unichain Sepolia, Polygon Amoy, Starknet Sepolia, TRON Nile, Bitcoin Signet, Bitcoin Testnet4, and Hyperliquid Mainnet to the supported-deployments catalog.