### PR TITLE
docs: add World Chain and Stable release notes (August 20, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: August 20, 2026" description=" by Ake">
+
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.
+
+<Button href="/changelog/chainstack-updates-august-20-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: July 27, 2026" description=" by Ake">
 
 **Protocols**. Chainstack now supports Arc — Circle's USDC-native, EVM-compatible L1 for stablecoin payments. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Arc testnet, in Full and Archive modes with debug and trace.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,7 +8,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: August 20, 2026" description=" by Ake">
 
-**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.
 
 <Button href="/changelog/chainstack-updates-august-20-2026">Read more</Button>
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,7 +8,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: August 20, 2026" description=" by Ake">
 
-**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.
+**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.
 
 <Button href="/changelog/chainstack-updates-august-20-2026">Read more</Button>
 </Update>

--- a/changelog/chainstack-updates-august-20-2026.mdx
+++ b/changelog/chainstack-updates-august-20-2026.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Chainstack updates: August 20, 2026"
-description: "Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization — is now supported on Chainstack across Global Nodes and Dedicated Nodes."
+description: "World Chain Mainnet and Stable Mainnet archive nodes with debug & trace APIs are now deployable as Chainstack Global Nodes."
 ---
-
-**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.

--- a/changelog/chainstack-updates-august-20-2026.mdx
+++ b/changelog/chainstack-updates-august-20-2026.mdx
@@ -1,0 +1,5 @@
+---
+title: "Chainstack updates: August 20, 2026"
+description: "World Chain Mainnet and Stable Mainnet archive nodes with debug & trace APIs are now deployable as Chainstack Global Nodes."
+---
+**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.

--- a/changelog/chainstack-updates-august-20-2026.mdx
+++ b/changelog/chainstack-updates-august-20-2026.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chainstack updates: August 20, 2026"
-description: "World Chain Mainnet and Stable Mainnet archive nodes with debug & trace APIs are now deployable as Chainstack Global Nodes."
+description: "Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization — is now supported on Chainstack across Global Nodes and Dedicated Nodes."
 ---
-**Protocols**. Now, you can deploy [Global Nodes](/docs/global-elastic-node) in archive mode with debug & trace APIs for World Chain Mainnet and Stable Mainnet.
+
+**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.

--- a/docs.json
+++ b/docs.json
@@ -3288,6 +3288,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-20-2026",
           "changelog/chainstack-updates-july-27-2026",
           "changelog/chainstack-updates-july-23-2026",
           "changelog/chainstack-updates-july-22-2026",


### PR DESCRIPTION
## What

Cloud release notes for August 20, 2026 — World Chain Mainnet and Stable Mainnet are now available as Chainstack Global Nodes.

## Changes

- `changelog/chainstack-updates-august-20-2026.mdx` — new standalone changelog entry
- `changelog.mdx` — new `<Update>` block inserted at the top
- `docs.json` — new entry added after `"changelog"` in the nav list

## Local validation

- `python3 -m json.tool docs.json` — valid
- `mintlify broken-links` — no new broken links introduced (pre-existing broken links in old entries are unrelated)