### PR TITLE
docs: add Stellar release notes (August 20, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: August 20, 2026" description=" by Ake">
+
+**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.
+
+<Button href="/changelog/chainstack-updates-august-20-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: August 7, 2026" description=" by Ake">
 
 **Protocols**. Chainstack now supports XRP Ledger — a payments-focused L1 with its own JSON-RPC and WebSocket API rather than the Ethereum `eth_*` interface. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for XRP Ledger Mainnet and Testnet, in Full mode.

--- a/changelog/chainstack-updates-august-20-2026.mdx
+++ b/changelog/chainstack-updates-august-20-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: August 20, 2026"
+description: "Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization — is now supported on Chainstack across Global Nodes and Dedicated Nodes."
+---
+
+**Protocols**. Chainstack now supports Stellar — a public blockchain for fast, low-cost cross-border payments and asset tokenization. You can deploy [Global Nodes](/docs/global-elastic-node) and [Dedicated Nodes](/docs/dedicated-node) for Stellar Mainnet and Testnet.

--- a/docs.json
+++ b/docs.json
@@ -3291,6 +3291,7 @@
         "tab": "Release notes",
         "pages": [
           "changelog",
+          "changelog/chainstack-updates-august-20-2026",
           "changelog/chainstack-updates-august-7-2026",
           "changelog/chainstack-updates-august-4-2026",
           "changelog/chainstack-updates-july-27-2026",


### PR DESCRIPTION
## What

Cloud release notes for August 20, 2026 — Stellar is now available as Chainstack Global Nodes and Dedicated Nodes for Mainnet and Testnet.

## Changes

- `changelog/chainstack-updates-august-20-2026.mdx` — new standalone changelog entry
- `changelog.mdx` — new `<Update>` block inserted at the top
- `docs.json` — new entry added after `"changelog"` in the nav list

## Local validation

- `python3 -m json.tool docs.json` — valid
- No new broken links introduced