### PR TITLE
Correct Stellar node options to match the launch

### DIFF
--- a/changelog/llms.txt
+++ b/changelog/llms.txt
@@ -4,6 +4,7 @@
 
 ## Pages
 - [Chainstack Cloud release notes and product updates](/changelog.md)
+- [Chainstack updates: August 20, 2026](/changelog/chainstack-updates-august-20-2026.md)
 - [Chainstack updates: August 7, 2026](/changelog/chainstack-updates-august-7-2026.md)
 - [Chainstack updates: August 4, 2026](/changelog/chainstack-updates-august-4-2026.md)
 - [Chainstack updates: July 27, 2026](/changelog/chainstack-updates-july-27-2026.md)

--- a/docs/nodes-clouds-regions-and-locations.mdx
+++ b/docs/nodes-clouds-regions-and-locations.mdx
@@ -345,6 +345,13 @@ description: Browse the cloud providers, regions, and geographic locations avail
 | Mainnet | Chainstack Global Network | global1 | Worldwide | Archive | Available     |
 | Testnet | Chainstack Global Network | global1 | Worldwide | Full    | Available     |
 
+## Stellar
+
+| Network | Cloud                     | Region  | Location  | Mode |
+| ------- | ------------------------- | ------- | --------- | ---- |
+| Mainnet | Chainstack Global Network | global1 | Worldwide | Full |
+| Testnet | Chainstack Global Network | global1 | Worldwide | Full |
+
 ## XRP Ledger
 
 | Network | Cloud                     | Region  | Location  | Mode |

--- a/docs/protocols-networks.mdx
+++ b/docs/protocols-networks.mdx
@@ -86,7 +86,7 @@ description: Browse all supported blockchain networks on Chainstack including Et
 | Sonic | Global Node, Dedicated | Full, Archive | Full, Archive | Blaze Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Stable | Global Node, Dedicated | Full, Archive | - | - | Yes | [Deploy through platform](https://console.chainstack.com) |
 | Starknet | Global Node, Dedicated | Full, Archive | Full, Archive | Sepolia Testnet | Yes | [Deploy through platform](https://console.chainstack.com) |
-| Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
+| Stellar | Global Node, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Sui (see note below) | Global Node, Dedicated | Full | Full | Testnet | No | [Deploy through platform](https://console.chainstack.com) |
 | Superseed | Dedicated | - | - | - | Yes | [Request deployment](https://chainstack.com/dedicated-nodes/) |
 | TAC | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -29,7 +29,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 | Starknet | Most requests are **full**. Trace methods are always **2 RUs**; block-scoped methods are **archive** when the requested block is more than 128 behind the tip. See [Starknet method scope](#starknet-method-scope) below. |
 | Polkadot | Most requests are **full**. Sidecar trace endpoints are always **2 RUs**; `chain_getBlockHash` and block-scoped Sidecar endpoints are **archive** when the requested block is more than 128 behind the tip. See [Polkadot method scope](#polkadot-method-scope) below. |
 | Sui | Full nodes carrying up to about 6 months of historical state. No archive split — every request is billed as **full** |
-| Bitcoin, TRON, opBNB, Harmony, XRP Ledger | No archive split — every request is billed as full |
+| Bitcoin, TRON, opBNB, Harmony, XRP Ledger, Stellar | No archive split — every request is billed as full |
 
 ## Always 2 RUs
 

--- a/node-options-master-list.json
+++ b/node-options-master-list.json
@@ -3637,20 +3637,54 @@
     "Stellar": {
       "protocol_name": "Stellar",
       "supported_modes": [
-        "N/A"
+        "Full"
       ],
       "full_mode_query_limit": "N/A",
       "archive_mode_available": false,
       "debug_trace_available": false,
       "warp_transactions_available": false,
-      "dedicated_node_availability": "Contact us",
+      "dedicated_node_availability": "Platform",
       "mainnet": {
-        "network_name": "N/A",
+        "network_name": "Mainnet",
         "faucet_url": "N/A",
-        "locations": []
+        "locations": [
+          {
+            "cloud": "Chainstack Global Network",
+            "node_type": "Global Node",
+            "region": "global1",
+            "location": "Worldwide",
+            "deployment_options": [
+              {
+                "mode": "Full",
+                "debug_trace": false,
+                "warp_transactions": false
+              }
+            ]
+          }
+        ]
       },
-      "testnets": [],
-      "additional_notes": "Dedicated nodes only"
+      "testnets": [
+        {
+          "network_name": "Testnet",
+          "faucet_url": "https://lab.stellar.org/account/fund",
+          "locations": [
+            {
+              "cloud": "Chainstack Global Network",
+              "node_type": "Global Node",
+              "region": "global1",
+              "location": "Worldwide",
+              "deployment_options": [
+                {
+                  "mode": "Full",
+                  "debug_trace": false,
+                  "warp_transactions": false
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "additional_notes": "N/A"
     },
     "XRP Ledger": {
       "protocol_name": "XRP Ledger",


### PR DESCRIPTION
The Aug 20 release notes announced Stellar on Global Nodes and Dedicated Nodes for Mainnet and Testnet. `node-options-master-list.json` was never updated, so the generated tables still carried the pre-launch state and contradicted the announcement on the live site.

Before, at `docs/protocols-networks.mdx`:

```
| Stellar | Dedicated | - | - | - | No | [Request deployment](https://chainstack.com/dedicated-nodes/) |
```

Support read **Dedicated** only, with no modes and no networks, and it pointed readers at a deployment request instead of the console. `docs/nodes-clouds-regions-and-locations.mdx` had no Stellar section at all, because the entry's `locations` array was empty.

## Source of truth

`get_deployment_options` returns, for both networks:

| Network | Blockchain | Cloud | Region | Tier | Modes |
| --- | --- | --- | --- | --- | --- |
| `stellar-mainnet` | `BC-000-000-125` | `CC-0016` | `global1` | Global | `full` |
| `stellar-testnet` | `BC-000-000-126` | `CC-0016` | `global1` | Global | `full` |

Structurally identical to XRP Ledger, so the entry is modelled on it: `supported_modes: ["Full"]`, no archive, no debug and trace, Global Node on Chainstack Global Network `global1` Worldwide for both networks.

`dedicated_node_availability` is set to `Platform`, matching XRP Ledger. The API never exposes a Dedicated tier for any protocol — only `Global` and `Trader` — so it cannot confirm or deny Dedicated on its own; XRP Ledger returns the same `Global`-only shape and is documented as `Platform`.

## Changes

- `node-options-master-list.json` — Stellar entry rebuilt from the pre-launch placeholder
- `docs/protocols-networks.mdx` — row now reads `Global Node, Dedicated | Full | Full | Testnet`, deploying through the platform
- `docs/nodes-clouds-regions-and-locations.mdx` — new Stellar section, placed before XRP Ledger to follow master-list order
- `docs/request-units.mdx` — Stellar joins the no-archive-split row with Bitcoin, TRON, opBNB, Harmony, and XRP Ledger, since it is Full-only
- `changelog/llms.txt` — picks up the Aug 20 entry, which the release-notes PR left unsynced

The testnet `faucet_url` points at `lab.stellar.org/account/fund` rather than `friendbot.stellar.org`, which returns 400 without query parameters and is not a user-facing page.

`debug-and-trace-apis.mdx` and `faucets.mdx` are deliberately untouched: Stellar is not EVM, so it does not belong in the debug and trace matrix, matching XRP Ledger, and the Chainstack faucet does not serve Stellar.
