### PR TITLE
Add Stellar tooling page

### DIFF
--- a/changelog/llms.txt
+++ b/changelog/llms.txt
@@ -4,6 +4,7 @@
 
 ## Pages
 - [Chainstack Cloud release notes and product updates](/changelog.md)
+- [Chainstack updates: August 20, 2026](/changelog/chainstack-updates-august-20-2026.md)
 - [Chainstack updates: August 7, 2026](/changelog/chainstack-updates-august-7-2026.md)
 - [Chainstack updates: August 4, 2026](/changelog/chainstack-updates-august-4-2026.md)
 - [Chainstack updates: July 27, 2026](/changelog/chainstack-updates-july-27-2026.md)

--- a/docs.json
+++ b/docs.json
@@ -1502,6 +1502,7 @@
               "docs/worldchain-tooling",
               "docs/stable-tooling",
               "docs/xrpl-tooling",
+              "docs/stellar-tooling",
               "docs/near-tooling"
             ]
           }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -365,6 +365,7 @@
 - [World Chain tooling](/docs/worldchain-tooling.md)
 - [Stable tooling](/docs/stable-tooling.md)
 - [XRP Ledger tooling](/docs/xrpl-tooling.md)
+- [Stellar tooling](/docs/stellar-tooling.md)
 - [NEAR tooling](/docs/near-tooling.md)
 - [Introduction to Chainstack Self-Hosted](/docs/self-hosted/introduction.md)
 - [Evaluation setup](/docs/self-hosted/evaluation-setup.md)

--- a/docs/stellar-tooling.mdx
+++ b/docs/stellar-tooling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Stellar tooling"
-description: "Connect to your Chainstack Stellar node over the Stellar RPC JSON-RPC API with curl, the JavaScript SDK, and the Python SDK, including how much ledger history your node holds."
+description: "Connect to your Chainstack Stellar node over the Stellar RPC JSON-RPC API with curl, the JavaScript SDK, and the Python SDK, and check the ledger history your node holds."
 ---
 
 Your Chainstack Stellar node serves the [Stellar RPC API](https://developers.stellar.org/docs/data/apis/rpc) — the JSON-RPC interface that stellar-rpc exposes for reading ledger data, simulating contract calls, and submitting transactions. Horizon is a separate service with its own REST interface and is not served on this endpoint.
@@ -38,41 +38,17 @@ Every call is an HTTP POST with a `method` and, for methods that take arguments,
 
 Replace `YOUR_CHAINSTACK_ENDPOINT` with your node's HTTPS endpoint. For the credential in that endpoint and the other ways to authenticate, see [Authentication methods for different scenarios](/docs/authentication-methods-for-different-scenarios).
 
-## How much ledger history your node holds
+## Historical data availability
 
-Stellar nodes on Chainstack keep a rolling window of recent ledgers rather than full history, and `getHealth` reports that window directly — no guesswork needed. Read three fields:
+Stellar nodes on Chainstack run in full mode and keep a rolling window of recent ledgers rather than history from genesis. Billing is independent of the window — every Stellar request is billed as full, at 1 RU; see [Request units](/docs/request-units).
 
-| Field | Meaning |
-| --- | --- |
-| `ledgerRetentionWindow` | The configured window, in ledgers |
-| `oldestLedger` | The oldest ledger actually available right now |
-| `latestLedger` | The current tip |
+Your node reports its own window in `getHealth`:
 
-The configured window is the ceiling; `oldestLedger` is what you can actually query. A node that has not been running long enough to fill its window holds less than the configured amount, so always work from `oldestLedger` rather than assuming the full window is present.
+- `ledgerRetentionWindow` — the configured size of the window, in ledgers
+- `oldestLedger` — the oldest ledger the node can serve right now
+- `latestLedger` — the current tip
 
-Measured on Aug 22, 2026, both networks configured at 1,036,800 ledgers:
-
-| Network | Ledgers available | Window | Close rate |
-| --- | --- | --- | --- |
-| Mainnet | 1,036,799 | 68.4 days | 5.70 s/ledger |
-| Testnet | 43,079 | 2.5 days | 5.01 s/ledger |
-
-Mainnet is at steady state — it holds essentially its whole configured window. Testnet held far less at the time of measurement because it had not yet accumulated that much history.
-
-Requesting a ledger outside the window returns `-32600`, and the message names the range the node can serve:
-
-<CodeGroup>
-  ```json Response
-  {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "error": {
-      "code": -32600,
-      "message": "start ledger (1) must be between the oldest ledger: 4225023 and the latest ledger: 4268124 for this rpc instance"
-    }
-  }
-  ```
-</CodeGroup>
+Work from `oldestLedger`, not from `ledgerRetentionWindow`. The configured size is the ceiling, and a node that has not been running long enough to fill its window holds less than that. A request for a ledger outside the window returns `-32600` with a message naming the range the node can serve.
 
 ## JavaScript
 

--- a/docs/stellar-tooling.mdx
+++ b/docs/stellar-tooling.mdx
@@ -1,0 +1,162 @@
+---
+title: "Stellar tooling"
+description: "Connect to your Chainstack Stellar node over the Stellar RPC JSON-RPC API with curl, the JavaScript SDK, and the Python SDK, including how much ledger history your node holds."
+---
+
+Your Chainstack Stellar node serves the [Stellar RPC API](https://developers.stellar.org/docs/data/apis/rpc) — the JSON-RPC interface that stellar-rpc exposes for reading ledger data, simulating contract calls, and submitting transactions. Horizon is a separate service with its own REST interface and is not served on this endpoint.
+
+## JSON-RPC over HTTPS
+
+Every call is an HTTP POST with a `method` and, for methods that take arguments, a `params` object. The endpoint is HTTPS only — Stellar nodes on Chainstack do not expose a WebSocket endpoint.
+
+<CodeGroup>
+  ```bash cURL
+  curl YOUR_CHAINSTACK_ENDPOINT \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}'
+  ```
+</CodeGroup>
+
+`getHealth` is the fastest way to confirm the endpoint works and to see the ledger range the node holds:
+
+<CodeGroup>
+  ```json Response
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "status": "healthy",
+      "latestLedger": 64065198,
+      "latestLedgerCloseTime": "1787363249",
+      "oldestLedger": 63028399,
+      "oldestLedgerCloseTime": "1781453141",
+      "ledgerRetentionWindow": 1036800
+    }
+  }
+  ```
+</CodeGroup>
+
+Replace `YOUR_CHAINSTACK_ENDPOINT` with your node's HTTPS endpoint. For the credential in that endpoint and the other ways to authenticate, see [Authentication methods for different scenarios](/docs/authentication-methods-for-different-scenarios).
+
+## How much ledger history your node holds
+
+Stellar nodes on Chainstack keep a rolling window of recent ledgers rather than full history, and `getHealth` reports that window directly — no guesswork needed. Read three fields:
+
+| Field | Meaning |
+| --- | --- |
+| `ledgerRetentionWindow` | The configured window, in ledgers |
+| `oldestLedger` | The oldest ledger actually available right now |
+| `latestLedger` | The current tip |
+
+The configured window is the ceiling; `oldestLedger` is what you can actually query. A node that has not been running long enough to fill its window holds less than the configured amount, so always work from `oldestLedger` rather than assuming the full window is present.
+
+Measured on Aug 22, 2026, both networks configured at 1,036,800 ledgers:
+
+| Network | Ledgers available | Window | Close rate |
+| --- | --- | --- | --- |
+| Mainnet | 1,036,799 | 68.4 days | 5.70 s/ledger |
+| Testnet | 43,079 | 2.5 days | 5.01 s/ledger |
+
+Mainnet is at steady state — it holds essentially its whole configured window. Testnet held far less at the time of measurement because it had not yet accumulated that much history.
+
+Requesting a ledger outside the window returns `-32600`, and the message names the range the node can serve:
+
+<CodeGroup>
+  ```json Response
+  {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": {
+      "code": -32600,
+      "message": "start ledger (1) must be between the oldest ledger: 4225023 and the latest ledger: 4268124 for this rpc instance"
+    }
+  }
+  ```
+</CodeGroup>
+
+## JavaScript
+
+Use the official [`@stellar/stellar-sdk`](https://github.com/stellar/js-stellar-sdk) and point `rpc.Server` at your endpoint.
+
+<CodeGroup>
+  ```javascript JavaScript
+  // npm install @stellar/stellar-sdk
+  import { rpc } from "@stellar/stellar-sdk";
+
+  const server = new rpc.Server("YOUR_CHAINSTACK_ENDPOINT");
+
+  const health = await server.getHealth();
+  console.log("getHealth:", health.status, "| latest", health.latestLedger, "| oldest", health.oldestLedger);
+
+  const network = await server.getNetwork();
+  console.log("getNetwork:", network.passphrase);
+
+  const ledger = await server.getLatestLedger();
+  console.log("getLatestLedger: sequence", ledger.sequence, "protocol", ledger.protocolVersion);
+  ```
+</CodeGroup>
+
+<CodeGroup>
+  ```text Output
+  getHealth: healthy | latest 64065193 | oldest 63028394
+  getNetwork: Public Global Stellar Network ; September 2015
+  getLatestLedger: sequence 64065193 protocol 27
+  ```
+</CodeGroup>
+
+### Read recent ledgers
+
+`getLedgers` takes a single request object with `startLedger` and a `pagination` block, rather than positional arguments:
+
+<CodeGroup>
+  ```javascript JavaScript
+  const { latestLedger } = await server.getHealth();
+
+  const { ledgers } = await server.getLedgers({
+    startLedger: latestLedger - 2,
+    pagination: { limit: 3 },
+  });
+
+  for (const l of ledgers) {
+    console.log(`ledger ${l.sequence} closed at ${new Date(l.ledgerCloseTime * 1000).toISOString()}`);
+  }
+  ```
+</CodeGroup>
+
+<CodeGroup>
+  ```text Output
+  ledger 64065203 closed at 2026-08-22T01:47:57.000Z
+  ledger 64065204 closed at 2026-08-22T01:48:03.000Z
+  ledger 64065205 closed at 2026-08-22T01:48:08.000Z
+  ```
+</CodeGroup>
+
+## Python
+
+Use the official [`stellar-sdk`](https://github.com/StellarCN/py-stellar-base) and its `SorobanServer`, which speaks the Stellar RPC API.
+
+<CodeGroup>
+  ```python Python
+  # pip install stellar-sdk
+  from stellar_sdk import SorobanServer
+
+  server = SorobanServer("YOUR_CHAINSTACK_ENDPOINT")
+
+  health = server.get_health()
+  print("get_health:", health.status, "| latest", health.latest_ledger, "| oldest", health.oldest_ledger)
+
+  network = server.get_network()
+  print("get_network:", network.passphrase, "| protocol", network.protocol_version)
+
+  ledger = server.get_latest_ledger()
+  print("get_latest_ledger: sequence", ledger.sequence)
+  ```
+</CodeGroup>
+
+<CodeGroup>
+  ```text Output
+  get_health: healthy | latest 64065195 | oldest 63028396
+  get_network: Public Global Stellar Network ; September 2015 | protocol 27
+  get_latest_ledger: sequence 64065195
+  ```
+</CodeGroup>


### PR DESCRIPTION
Stellar shipped on Aug 20 with no dedicated page. It is also the case where a tooling page earns the most: its API is neither Horizon's REST interface nor the Ethereum `eth_*` set, so a reader arrives with nothing to carry over.

## What the node actually serves

Verified against live mainnet and testnet Global Nodes:

- **Stellar RPC (JSON-RPC over HTTPS)**, `stellar-rpc 27.1.1`, captive core `stellar-core 27.1.0`, protocol 27. Horizon is not served on this endpoint.
- **No WebSocket endpoint at all** — `get_node` returns no `wss_endpoint` for Stellar, and `api_namespaces` is `["stellar"]`. The page says HTTPS only rather than leaving readers to discover it.
- `GET /` returns `-32600 Invalid json request`; the endpoint is POST JSON-RPC only.

## Historical data availability

`getHealth` self-reports the window, so nothing here is inferred: it returns `ledgerRetentionWindow` (the configured size), `oldestLedger`, and `latestLedger`. The configured size is a ceiling — a node that has not filled its window holds less — so the page tells readers to work from `oldestLedger`. Out-of-range requests return `-32600` with a message naming the servable range.

Measured while writing, for reference rather than for the page: mainnet held 1,036,799 ledgers against a 1,036,800 configured window, testnet 43,079. Deliberately kept out of the page — a dated measurement goes stale and this is a docs page, not a report.

## Verified snippets

Every snippet was run as written and the outputs on the page are real captures.

- curl `getHealth`
- `@stellar/stellar-sdk` 17.0.0 via `rpc.Server` — `getHealth`, `getNetwork`, `getLatestLedger`
- `getLedgers`, which takes a single request object with `startLedger` and `pagination`; passing positional arguments returns `-32600 parameters must be array or object`, so the page shows the object form
- `stellar-sdk` 15.0.0 (Python) via `SorobanServer` — `get_health`, `get_network`, `get_latest_ledger`

Both official SDKs work against the endpoint without special handling.

## Notes

The page opens straight into what the node serves rather than with the usual "Get started with a reliable X RPC endpoint" line, because `chainstack.com/build-better-with-stellar/` does not exist yet and I would rather not ship a 404. Worth picking up with marketing — the XRP Ledger equivalent exists.

Method availability is deliberately out of scope here; a tooling page is not the place for it.

`changelog/llms.txt` picks up the Aug 20 changelog entry. #665 carries the same one-line addition, since that page is already on `main` and both branches regenerate against it.

Probe nodes were deleted after the sweep.

