### PR TITLE
CORE-16065 self-hosted release notes v2.59.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3556,6 +3556,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026.mdx
@@ -1,0 +1,23 @@
+---
+title: "Chainstack Self-Hosted v2.59.0: August 24, 2026"
+description: "Solana joins the deployment catalog on mainnet and devnet, alongside reliability fixes for OP-Stack and Ronin Saigon nodes."
+---
+
+## Solana support
+
+Solana is now available in the new-node flow, on both mainnet and devnet, running on the agave client. See [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the full deployment catalog.
+
+## Reliability fixes
+
+- OP-Stack execution clients — transaction pool admission no longer depends on the sequencer HTTP endpoint being reachable
+- Ronin Saigon — the execution client now gets a trusted peer, removing a source of sync stalls
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.13.0 |
+| cp-deployments-api | v1.39.0 |
+| cp-workflows | v3.43.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.13.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,7 +11,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.59.0: August 24, 2026" description="">
+
+This release adds Solana Mainnet and Devnet to the deployment catalog, running on the agave client, and includes reliability fixes for OP-Stack transaction pool admission and Ronin Saigon peer connectivity.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.53.0: August 20, 2026" description="">
 
 This release adds ten new networks to the deployment catalog — Base Sepolia, Optimism Sepolia, Zora Sepolia, Unichain Sepolia, Polygon Amoy, Starknet Sepolia, TRON Nile, Bitcoin Signet, Bitcoin Testnet4, and Hyperliquid Mainnet. Snapshot-based bootstrapping now also accepts an already-unpacked archive as a data source.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -90,6 +90,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Kaia | Kaia Mainnet, Kairos | 4–8 | 16–32 GiB | ~1.2–2.75 TB |
 | Ronin | Ronin Saigon | 7 | 28 GiB | 220 GB |
 | Hyperliquid | Hyperliquid Testnet, Mainnet | 4–8 | 16–32 GiB | 250–300 GB |
+| Solana | Solana Mainnet, Devnet | 8–16 | 64–256 GiB | ~2.2–3.5 TB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.
@@ -98,7 +99,7 @@ vCPU and RAM are split across the clients in multi-client families. Ethereum net
 ### Snapshot bootstrap and storage headroom
 
 <Warning>
-Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism (both networks), Base Sepolia, Unichain Sepolia, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Polygon Amoy, Starknet Sepolia, Bitcoin Signet, Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), and BNB Smart Chain (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
+Deployments that bootstrap from a pre-built snapshot — currently Ethereum (all networks), Optimism (both networks), Base Sepolia, Unichain Sepolia, World Chain (both networks), Blast Mainnet, Mantle (both networks), opBNB (both networks), Arbitrum (both networks), Robinhood Chain (both networks), Polygon Amoy, Starknet Sepolia, Bitcoin Signet, Sui (both networks), Avalanche Mainnet, Arc Testnet, Sonic Mainnet, Stable (both networks), Berachain (both networks), Cronos (both networks), BNB Smart Chain (both networks), and Solana (both networks) — temporarily require about **2× the steady-state storage**. The node downloads the snapshot archive and then extracts it into the chain data directory, so both copies coexist on disk until extraction completes. Provision the node's persistent volume at this peak; you can keep it sized for headroom afterward. Deployments that sync without a snapshot do not have this peak.
 </Warning>
 
 Tempo (both networks) also bootstraps from a snapshot, but its client downloads and extracts the archive within the storage figures already listed in the catalog, so it needs no extra headroom for the bootstrap.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -65,6 +65,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Ronin | Saigon | Conduit-Reth v2.1.2 + OP-Node v1.19.0 + EigenDA-Proxy 2.7.0 | 7 | 28 GiB | 220 GB |
 | Hyperliquid | Mainnet | hyperliquid mainnet-full | 8 | 32 GiB | 250 GB |
 | Hyperliquid | Testnet | hyperliquid testnet-full | 4 | 16 GiB | 300 GB |
+| Solana | Mainnet | Agave v4.2.0 | 16 | 256 GiB | ~3.5 TB |
+| Solana | Devnet | Agave v4.2.0 | 8 | 64 GiB | ~2.2 TB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -565,10 +567,20 @@ The node prunes its logs on a rolling 48-hour window, so steady-state disk use s
 
 The single HTTP listener carries the EVM JSON-RPC. There is no separate WebSocket listener on this deployment. The gossip ports (4001 and 4002) are internal.
 
-## Coming soon
+## Solana
 
-| Protocol | Network | Client |
-|----------|---------|--------|
-| Solana | Mainnet, Devnet | Agave |
+Runs a single full node (validator in RPC mode) on the Agave client. The client version is the same across networks — see the [Available deployments](#available-deployments) table above.
 
-See the [FAQ](/docs/self-hosted/faq) for the roadmap.
+| Network | Block explorer |
+|---------|-----------------|
+| Solana Mainnet | [explorer.solana.com](https://explorer.solana.com/?cluster=mainnet-beta) |
+| Solana Devnet | [explorer.solana.com](https://explorer.solana.com/?cluster=devnet) |
+
+Both networks bootstrap from a pre-built snapshot (plan for ~2× storage during deploy).
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Agave | 8899 | TCP | HTTP JSON-RPC |
+| Agave | 8900 | TCP | WS JSON-RPC |

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -1123,13 +1123,23 @@
     },
     {
       "protocol": "Solana", "network": "Mainnet", "chainId": null,
-      "explorer": "https://solscan.io",
-      "family": "solana", "status": "coming-soon", "snapshotBootstrap": null,
-      "presets": [],
+      "explorer": "https://explorer.solana.com/?cluster=mainnet-beta",
+      "family": "solana", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
       "clients": [
-        { "client": "agave", "version": null, "cpu": null, "ramGi": null, "storageGi": null }
+        { "client": "agave", "version": "v4.2.0", "cpu": 16, "ramGi": 256, "storageGi": 3500 }
       ],
-      "totals": { "cpu": null, "ramGi": null, "storageGi": null }
+      "totals": { "cpu": 16, "ramGi": 256, "storageGi": 3500 }
+    },
+    {
+      "protocol": "Solana", "network": "Devnet", "chainId": null,
+      "explorer": "https://explorer.solana.com/?cluster=devnet",
+      "family": "solana", "status": "available", "snapshotBootstrap": true,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "agave", "version": "v4.2.0", "cpu": 8, "ramGi": 64, "storageGi": 2200 }
+      ],
+      "totals": { "cpu": 8, "ramGi": 64, "storageGi": 2200 }
     }
   ]
 }


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.59.0 release note. Adds Solana Mainnet and Devnet to the supported-deployments catalog.