### PR TITLE
Rewrite the docs landing page

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -386,6 +386,7 @@
 - [FAQ](/docs/self-hosted/faq.md)
 - [Support and feedback](/docs/self-hosted/support.md)
 - [Chainstack Self-Hosted release notes and version history](/docs/self-hosted/release-notes.md)
+- [Chainstack Self-Hosted v2.59.0: August 24, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026.md)
 - [Chainstack Self-Hosted v2.53.0: August 20, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026.md)
 - [Chainstack Self-Hosted v2.43.0: August 18, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026.md)
 - [Chainstack Self-Hosted v2.37.0: August 13, 2026](/docs/self-hosted/changelog/chainstack-self-hosted-v2-37-0-august-13-2026.md)

--- a/docs/platform-introduction.mdx
+++ b/docs/platform-introduction.mdx
@@ -3,19 +3,57 @@ title: "Chainstack platform overview: nodes, APIs, and billing"
 description: Get started with Chainstack, the blockchain infrastructure platform supporting 70+ networks with managed RPC nodes, APIs, and self-hosted deployment.
 ---
 
-Topping up with crypto is also an option at [Billing](https://console.chainstack.com/user/settings/billing). We support topping up with [150+ cryptocurrencies](https://nowpayments.io/supported-coins) .
+Chainstack gives you RPC access to 70+ blockchain networks. Deploy a node, get an endpoint, and call it — or run the same infrastructure on hardware you control.
 
-To submit a request for a new product capability, protocol support, or other improvements, visit our [ideas portal](https://ideas.chainstack.com/).
+There are two products, and they have separate documentation:
 
-For assistance, reach out to [Chainstack support](https://support.chainstack.com).
+- Cloud — managed nodes that Chainstack runs for you. Deploy one from the [Chainstack console](https://console.chainstack.com/) and get an endpoint in seconds.
+- Chainstack Self-Hosted — the same node stack deployed on your own Kubernetes cluster, managed through the Control Panel.
 
-## Chainstack faucets
+## Start here
 
-<CardGroup>
- <Card title="Available here" href="https://faucet.chainstack.com/" icon="angle-right" iconType="solid" horizontal/>
- <Card title="Via the Chainstack MCP server" href="/docs/chainstack-mcp-server" icon="angle-right" iconType="solid" horizontal/>
- </CardGroup>
+<CardGroup cols={2}>
+  <Card title="Node types" href="/docs/global-elastic-node" icon="server" iconType="solid" horizontal />
 
-## Supported regions, locations, chains.
+  <Card title="Pricing and request units" href="/docs/pricing-introduction" icon="tag" iconType="solid" horizontal />
 
-See also [Available clouds, regions, and locations](/docs/nodes-clouds-regions-and-locations).
+  <Card title="Supported protocols and networks" href="/docs/protocols-networks" icon="diagram-project" iconType="solid" horizontal />
+
+  <Card title="Clouds, regions, and locations" href="/docs/nodes-clouds-regions-and-locations" icon="globe" iconType="solid" horizontal />
+</CardGroup>
+
+## Build
+
+- [Blockchain APIs](/reference/blockchain-apis) — the RPC method reference for every supported protocol
+- [Web3 libraries](/reference/web3-libraries) — connecting web3.js, ethers.js, web3.py, and others to your endpoint
+- [Authentication methods](/docs/authentication-methods-for-different-scenarios) — auth tokens, basic auth, and when to use each
+- [Chainstack MCP server](/docs/chainstack-mcp-server) — deploy and manage nodes from an AI agent
+
+## Run it yourself
+
+- [Chainstack Self-Hosted](/docs/self-hosted/introduction) — run the node stack on your own Kubernetes cluster
+- [Quick start](/docs/self-hosted/quick-start) — a first Self-Hosted deployment end to end
+
+## Move an existing workload
+
+Coming from another provider? See [Migrate to Chainstack with AI](/docs/migrate-to-chainstack-with-ai), which walks an agent through swapping your endpoints, along with the provider-specific guides alongside it.
+
+## Testnet tokens
+
+Request testnet funds from the [Chainstack faucet](https://faucet.chainstack.com/), or through the [Chainstack MCP server](/docs/chainstack-mcp-server) if you would rather stay in your editor. See [Faucet](/docs/faucets) for the supported networks.
+
+## Use these docs from an agent
+
+Every page is available as plain text: append `.md` to any documentation URL to get its markdown source, or use one of the whole-portal endpoints.
+
+- [llms.txt](https://docs.chainstack.com/llms.txt) — a compact index of every section, to discover what exists before fetching pages
+- [llms-full.txt](https://docs.chainstack.com/llms-full.txt) — the entire portal in a single file
+- [skill.md](https://docs.chainstack.com/skill.md) — the portal packaged as an agent skill
+
+The [Chainstack MCP server](/docs/chainstack-mcp-server) at `https://mcp.chainstack.com/mcp` searches these docs as well, alongside deploying and managing nodes.
+
+## Billing and support
+
+Pay by card, or top up with crypto at [Billing](https://console.chainstack.com/user/settings/billing) — 150+ cryptocurrencies are supported. For plan comparisons and quotas, see [Pricing](/docs/pricing-introduction).
+
+To request a protocol, a capability, or any other improvement, use the [ideas portal](https://ideas.chainstack.com/). For anything else, [Chainstack support](https://support.chainstack.com) can help.


### PR DESCRIPTION
`docs/platform-introduction.mdx` is the page every visitor to docs.chainstack.com lands on — the root redirects to it — and it was 20 lines of orphaned fragments.

It opened with **"Topping up with crypto is also an option at Billing"** — "also," with nothing before it. Then two unrelated one-liners, a faucet card group, and `## Supported regions, locations, chains.` with a trailing period that house style forbids. No overview, no orientation, no path into anything, despite a title of "Chainstack platform overview: nodes, APIs, and billing" and a description promising "Get started with Chainstack."

## Why it was like that

Not a regression to revert. The orphan clause is present in the **first commit** of this file (`6460cc11`, 2025-03-24, "Added Mintlify preview"), where the description read literally `"Access the Chainstack platform at ."` — it arrived broken from the readme.io migration. A 28-protocol card grid was later bolted on, then removed in June 2025, correctly, because it was hand-maintained and we now support 95 protocols. Nothing replaced it. The page has sat near 1KB ever since, and every commit since is SEO frontmatter or link fixes.

## Traffic this affects

Last 30 days:

| Path | Views |
| --- | --- |
| `/docs/platform-introduction` | 5,977 — **rank 1 of 11,505 paths** |
| `/` (redirects here) | 5,301 |
| `/docs/platform-introduction.md` | 2,776 |

The `.md` figure matters: `llms.txt` points agents at this page first, so it is effectively the table of contents an agent reads before deciding where to go.

## What the page does now

A router, not an essay. Opening paragraph on what Chainstack is, then the Cloud and Self-Hosted split, which the old page never mentioned despite `docs.json` being organized around it. Then sections routing to destinations that already exist: **Start here**, **Build**, **Run it yourself**, **Move an existing workload**, **Testnet tokens**, **Use these docs from an agent**, **Billing and support**.

Deliberate choices:

- **No protocol grid.** That is what rotted last time. `protocols-networks` is generated from the master list and always current, so one link there beats 95 hand-listed cards.
- **Cards only in Start here.** `<Card>` components pass through into the `.md` representation as raw JSX — a 21-card page yields 21 raw `<Card … />` lines — so the other sections use markdown lists, which also let each destination carry a one-line description. This keeps the agent-facing output readable while retaining a visual anchor for the rendered page.
- **Nothing restated.** Plans link to `/docs/pricing-introduction`, faucet networks to `/docs/faucets`, regions to `/docs/nodes-clouds-regions-and-locations`.
- **Frontmatter untouched**, so the URL and SEO metadata are preserved on our highest-traffic page.

## Checks

All 12 internal links resolve to files in the repo, no heading ends in a period, no unescaped `$`.

`docs/llms.txt` picks up the Self-Hosted v2.59.0 release note, which landed on `main` unsynced and is unrelated to this change.
