### PR TITLE
CORE-16085 self-hosted release notes v2.62.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4006,6 +4006,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-62-0-august-25-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-43-0-august-18-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-62-0-august-25-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-62-0-august-25-2026.mdx
@@ -1,0 +1,18 @@
+---
+title: "Chainstack Self-Hosted v2.62.0: August 25, 2026"
+description: "Stellar joins the deployment catalog on mainnet and testnet."
+---
+
+## Stellar support
+
+Stellar is now available in the new-node flow, on both mainnet and testnet, running on the stellar-core and stellar-rpc clients. See [Supported clients and protocols](/docs/self-hosted/supported-clients-and-protocols) for the full deployment catalog.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.13.0 |
+| cp-deployments-api | v1.42.0 |
+| cp-workflows | v3.45.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.13.0 |

--- a/docs/self-hosted/deploying-nodes.mdx
+++ b/docs/self-hosted/deploying-nodes.mdx
@@ -7,7 +7,7 @@ This guide explains how to deploy blockchain nodes using Chainstack Self-Hosted.
 
 ## Supported deployments
 
-For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin, with more protocols on the roadmap.
+For the full catalog of protocols, networks, clients, client versions, and resource requirements, see [Supported deployments](/docs/self-hosted/supported-clients-and-protocols). It covers Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, Stellar, and Bitcoin, with more protocols on the roadmap.
 
 ## Resource requirements
 

--- a/docs/self-hosted/faq.mdx
+++ b/docs/self-hosted/faq.mdx
@@ -11,7 +11,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 
 ### Is Chainstack Self-Hosted ready for production?
 
-Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
+Yes. Chainstack Self-Hosted is generally available and supports production deployments across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, Stellar, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog.
 
 ## Features and roadmap
 

--- a/docs/self-hosted/introduction.mdx
+++ b/docs/self-hosted/introduction.mdx
@@ -14,7 +14,7 @@ Chainstack Self-Hosted brings the power of Chainstack's blockchain infrastructur
 - Full infrastructure control — run blockchain nodes on your own servers, whether on premises, in a private cloud, or on dedicated servers
 - Simplified deployment — deploy blockchain nodes through an intuitive web interface without complex manual configuration
 - Enterprise-grade architecture — built on Kubernetes for reliability, scalability, and ease of operations
-- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
+- Multi-protocol support — deploy full nodes across Ethereum, Optimism, Base, Unichain, Zora, World Chain, Blast, Mantle, opBNB, Arbitrum, Robinhood Chain, Polygon, Avalanche, Arc, Sonic, Stable, Berachain, Cronos, BNB Smart Chain, Kaia, Ronin, Hyperliquid, Starknet, TRON, Sui, Tempo, Plasma, Solana, Stellar, and Bitcoin. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for the full catalog
 
 To see what you need to try it, see [Evaluation setup](/docs/self-hosted/evaluation-setup).
 

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.62.0: August 25, 2026" description="">
+
+This release adds Stellar Mainnet and Testnet to the deployment catalog, running on the stellar-core and stellar-rpc clients.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-62-0-august-25-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.59.0: August 24, 2026" description="">
 
 This release adds Solana Mainnet and Devnet to the deployment catalog, running on the agave client, and includes reliability fixes for OP-Stack transaction pool admission and Ronin Saigon peer connectivity.

--- a/docs/self-hosted/requirements.mdx
+++ b/docs/self-hosted/requirements.mdx
@@ -91,6 +91,7 @@ The table below summarizes the standard preset totals by architecture family. Us
 | Ronin | Ronin Saigon | 7 | 28 GiB | 220 GB |
 | Hyperliquid | Hyperliquid Testnet, Mainnet | 4–8 | 16–32 GiB | 250–300 GB |
 | Solana | Solana Mainnet, Devnet | 8–16 | 64–256 GiB | ~2.2–3.5 TB |
+| Stellar | Stellar Mainnet, Testnet | 4 | 16 GiB | 64–400 GB |
 
 <Note>
 vCPU and RAM are split across the clients in multi-client families. Ethereum networks also ship a Light preset at half the CPU and RAM with the same storage. See [Supported deployments](/docs/self-hosted/supported-clients-and-protocols) for per-network figures.

--- a/docs/self-hosted/supported-clients-and-protocols.mdx
+++ b/docs/self-hosted/supported-clients-and-protocols.mdx
@@ -67,6 +67,8 @@ This page is the canonical catalog of every deployment available in Chainstack S
 | Hyperliquid | Testnet | hyperliquid testnet-full | 4 | 16 GiB | 300 GB |
 | Solana | Mainnet | Agave v4.2.0 | 16 | 256 GiB | ~3.5 TB |
 | Solana | Devnet | Agave v4.2.0 | 8 | 64 GiB | ~2.2 TB |
+| Stellar | Mainnet | Stellar-RPC v28.0.0 | 4 | 16 GiB | 400 GB |
+| Stellar | Testnet | Stellar-RPC v28.0.0 | 4 | 16 GiB | 64 GB |
 
 <Note>
 vCPU and RAM figures are the standard preset totals. Ethereum networks also ship a **Light** preset that uses half the CPU and RAM with the same storage — see [EVM Layer 1](#evm-layer-1-execution-consensus) below.
@@ -584,3 +586,24 @@ Both networks bootstrap from a pre-built snapshot (plan for ~2× storage during 
 |--------|------|----------|---------|
 | Agave | 8899 | TCP | HTTP JSON-RPC |
 | Agave | 8900 | TCP | WS JSON-RPC |
+
+## Stellar
+
+Runs a single stellar-rpc node, which manages a Captive Core process internally for ledger sync and validation. The client version is the same across networks — see the [Available deployments](#available-deployments) table above.
+
+| Network | Block explorer |
+|---------|----------------|
+| Stellar Mainnet | [stellar.expert](https://stellar.expert/explorer/public) |
+| Stellar Testnet | [stellar.expert](https://stellar.expert/explorer/testnet) |
+
+<Note>
+Stellar Mainnet needs considerably more storage than Testnet — 400 GB against 64 GB — because Mainnet carries far more ledger history.
+</Note>
+
+### Exposed ports
+
+| Client | Port | Protocol | Purpose |
+|--------|------|----------|---------|
+| Stellar-RPC | 8000 | TCP | HTTP JSON-RPC |
+
+Captive Core's internal HTTP and peer ports are used only for the node's own subprocess and are not exposed.

--- a/self-hosted-deployments.json
+++ b/self-hosted-deployments.json
@@ -340,6 +340,13 @@
         { "port": 4001, "proto": "TCP", "purpose": "Gossip", "exposed": false },
         { "port": 4002, "proto": "TCP", "purpose": "Gossip", "exposed": false }
       ]
+    },
+    "stellar-rpc": {
+      "label": "Stellar RPC (stellar-rpc)",
+      "role": "full",
+      "ports": [
+        { "port": 8000, "proto": "TCP", "purpose": "HTTP JSON-RPC", "exposed": true }
+      ]
     }
   },
   "families": {
@@ -509,6 +516,13 @@
       "notes": [
         "Runs a single full node client that serves the EVM HTTP JSON-RPC. There is no separate WebSocket listener.",
         "The node prunes its logs on a rolling 48-hour window, so steady-state disk use stays flat over long runs."
+      ]
+    },
+    "stellar": {
+      "label": "Stellar",
+      "notes": [
+        "Runs a single stellar-rpc node, which manages a Captive Core process internally for ledger sync and validation.",
+        "Client version is the same across networks; Mainnet needs considerably more storage than Testnet."
       ]
     }
   },
@@ -1140,6 +1154,26 @@
         { "client": "agave", "version": "v4.2.0", "cpu": 8, "ramGi": 64, "storageGi": 2200 }
       ],
       "totals": { "cpu": 8, "ramGi": 64, "storageGi": 2200 }
+    },
+    {
+      "protocol": "Stellar", "network": "Mainnet", "chainId": null,
+      "explorer": "https://stellar.expert/explorer/public",
+      "family": "stellar", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "stellar-rpc", "version": "28.0.0", "cpu": 4, "ramGi": 16, "storageGi": 400 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 400 }
+    },
+    {
+      "protocol": "Stellar", "network": "Testnet", "chainId": null,
+      "explorer": "https://stellar.expert/explorer/testnet",
+      "family": "stellar", "status": "available", "snapshotBootstrap": false,
+      "presets": ["standard"],
+      "clients": [
+        { "client": "stellar-rpc", "version": "28.0.0", "cpu": 4, "ramGi": 16, "storageGi": 64 }
+      ],
+      "totals": { "cpu": 4, "ramGi": 16, "storageGi": 64 }
     }
   ]
 }


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.62.0 release note.
Adds Stellar Mainnet and Testnet to the supported-deployments catalog.