### PR TITLE
Add the Pro tab to billing thresholds and correct Developer

### DIFF
--- a/docs/billing-thresholds.mdx
+++ b/docs/billing-thresholds.mdx
@@ -25,13 +25,14 @@ Each subscription plan has progressive billing thresholds. Once you reach a thre
   <Tab title="Developer">
     | Step | Threshold amount |
     |------|-----------------|
-    | 1    | $10            |
-    | 2    | $25            |
-    | 3    | $50            |
-    | 4    | $100           |
-    | 5    | $400           |
-    | 6    | $600           |
-    | 7    | $1,000         |
+    | 1    | $5             |
+    | 2    | $10            |
+    | 3    | $25            |
+    | 4    | $50            |
+    | 5    | $100           |
+    | 6    | $400           |
+    | 7    | $600           |
+    | 8    | $1,000         |
   </Tab>
   
   <Tab title="Growth">
@@ -42,6 +43,15 @@ Each subscription plan has progressive billing thresholds. Once you reach a thre
     | 3    | $400           |
     | 4    | $600           |
     | 5    | $1,000         |
+  </Tab>
+  
+  <Tab title="Pro">
+    | Step | Threshold amount |
+    |------|-----------------|
+    | 1    | $100           |
+    | 2    | $400           |
+    | 3    | $600           |
+    | 4    | $1,000         |
   </Tab>
   
   <Tab title="Business">
@@ -72,7 +82,7 @@ The thresholds work progressively:
 3. **Final threshold** — once you reach the highest threshold for your plan, subsequent charges occur each time you accumulate that same amount again
 
 <Note>
-On the Developer plan, you'll be charged at `$10`, then at `$25` (additional `$15` from the first threshold), then at `$50` (additional `$25`), and so on. Once you reach the `$1,000` threshold, you'll be charged every time you accumulate another `$1,000` in usage.
+On the Developer plan, you'll be charged at `$5`, then at `$10` (additional `$5` from the first threshold), then at `$25` (additional `$15`), and so on. Once you reach the `$1,000` threshold, you'll be charged every time you accumulate another `$1,000` in usage.
 </Note>
 
 ## Payment processing


### PR DESCRIPTION
Reported from a customer conversation: the billing thresholds page has no tab for the Pro plan. It doesn't — and while checking, Developer turned out to be wrong too.

## Why Pro was missing

The page's numbers trace to a 2020 spec that defined thresholds for Developer, Growth, Business, and Enterprise. Pro launched in Feb 2025, so it was never in that source, and the page has carried the same four tabs since.

## Verified against the live billing configuration

Rather than infer Pro's values, every plan's threshold group was read from the platform's billing configuration:

| Plan | Configured thresholds | Page before |
| --- | --- | --- |
| Developer | 5, 10, 25, 50, 100, 400, 600, 1000 | 10, 25, 50, 100, 400, 600, 1000 — **missing the first step** |
| Growth | 50, 100, 400, 600, 1000 | matched |
| **Pro** | **100, 400, 600, 1000** | **absent** |
| Business | 100, 400, 600, 1000 | matched |
| Enterprise | 100, 400, 600, 1000 | matched |

Pro's values are identical to Business, which matches the intent recorded when the plan was introduced.

The Developer discrepancy was found by validating the extraction against a plan the page already documented, before trusting any of the numbers. That control is what surfaced it — the page understates the first Developer charge, which is a live billing figure on a customer-facing page.

## Changes

- **Pro tab added**, placed between Growth and Business to match plan order
- **Developer corrected** to eight steps beginning at \$5
- **Worked example updated** — it walked through "charged at \$10, then at \$25 (additional \$15)", which no longer described the first two steps. Now reads \$5, then \$10 (additional \$5), then \$25 (additional \$15)

## Not changed

A Pay-as-you-go threshold group also exists with the same values as Business, and Pay-as-you-go is a live plan. It is left off deliberately: whether it belongs on this page is a product-content decision, and "pay-as-you-go" was renamed to "extra usage" in the docs earlier this year, so adding a tab under either name needs a call on terminology first.

New rows follow the file's existing convention of unescaped `$` inside table cells, which renders correctly — the published Markdown escapes them on export. Mixing conventions within the table would be worse than matching it.

`generate_llms_txt.py --check` clean.
