### PR TITLE
docs: add OpenChainBench benchmark link to Robinhood Chain tooling page

### DIFF
--- a/docs/robinhood-tooling.mdx
+++ b/docs/robinhood-tooling.mdx
@@ -185,3 +185,7 @@ To make Remix IDE interact with Robinhood Chain through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy & run transactions** tab. Select **Injected Provider - MetaMask** in **Environment**.
 
 This engages MetaMask and makes Remix IDE interact with Robinhood Chain through a Chainstack node.
+
+## Benchmark
+
+Independent latency and reliability measurements for Chainstack's Robinhood Chain RPC endpoints are available at [OpenChainBench — Robinhood Chain keyed RPC benchmark](https://openchainbench.com/benchmarks/keyed-rpc-robinhood).


### PR DESCRIPTION
Adds a short **Benchmark** section at the end of the Robinhood Chain tooling page pointing to OpenChainBench's independent, continuously updated latency and reliability measurements for Chainstack's Robinhood Chain RPC endpoints.

The benchmark probes Chainstack's keyed endpoint every 60 seconds from 3 regions (US-East, EU-West, Singapore) and publishes p50/p90/p99 latency alongside success rate — useful context for developers choosing or evaluating an RPC provider.

Link: https://openchainbench.com/benchmarks/keyed-rpc-robinhood