### PR TITLE
CORE-16126 self-hosted release notes v2.63.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4010,6 +4010,7 @@
             "tab": "Release notes",
             "pages": [
               "docs/self-hosted/release-notes",
+              "docs/self-hosted/changelog/chainstack-self-hosted-v2-63-0-august-31-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-62-0-august-25-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-59-0-august-24-2026",
               "docs/self-hosted/changelog/chainstack-self-hosted-v2-53-0-august-20-2026",

--- a/docs/self-hosted/changelog/chainstack-self-hosted-v2-63-0-august-31-2026.mdx
+++ b/docs/self-hosted/changelog/chainstack-self-hosted-v2-63-0-august-31-2026.mdx
@@ -1,0 +1,23 @@
+---
+title: "Chainstack Self-Hosted v2.63.0: August 31, 2026"
+description: "Updates blockchain client images across Sui, Arc, Polygon, Tempo, and Stellar deployments for protocol compatibility, upcoming hardfork readiness, and reliability."
+---
+
+Updates blockchain client images across Sui, Arc, Polygon, Tempo, and Stellar deployments for protocol compatibility, upcoming hardfork readiness, and reliability.
+
+## Improvements and fixes
+
+- Updates the Sui Mainnet and Sui Testnet node images to support the current on-chain protocol version.
+- Updates the Arc Testnet execution and consensus node images ahead of the Zero8 hardfork on September 3, 2026.
+- Updates the Polygon (Mainnet and Amoy) and Tempo (Mainnet and Testnet) node images for reliability and bug fixes.
+- Updates the Stellar RPC node image on Mainnet and Testnet.
+
+## Component versions
+
+| Component | Version |
+|---|---|
+| cp-ui | v3.13.0 |
+| cp-deployments-api | v1.43.0 |
+| cp-workflows | v3.45.0 |
+| cp-auth | v0.5.1 |
+| cp-bolt | v1.13.0 |

--- a/docs/self-hosted/release-notes.mdx
+++ b/docs/self-hosted/release-notes.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack Self-Hosted v2.63.0: August 31, 2026" description="">
+
+Updates blockchain client images across Sui, Arc, Polygon, Tempo, and Stellar deployments for protocol compatibility, upcoming hardfork readiness, and reliability.
+
+<Button href="/docs/self-hosted/changelog/chainstack-self-hosted-v2-63-0-august-31-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack Self-Hosted v2.62.0: August 25, 2026" description="">
 
 This release adds Stellar Mainnet and Testnet to the deployment catalog, running on the stellar-core and stellar-rpc clients.


### PR DESCRIPTION
Publishes the Chainstack Self-Hosted v2.63.0 release note.