### PR TITLE
docs: add OpenChainBench benchmark to Robinhood Chain tooling

### DIFF
--- a/docs/robinhood-tooling.mdx
+++ b/docs/robinhood-tooling.mdx
@@ -185,3 +185,7 @@ To make Remix IDE interact with Robinhood Chain through a Chainstack node:
 2. In Remix IDE, navigate to the **Deploy & run transactions** tab. Select **Injected Provider - MetaMask** in **Environment**.
 
 This engages MetaMask and makes Remix IDE interact with Robinhood Chain through a Chainstack node.
+
+## Benchmarks
+
+Independent latency and reliability measurements for Chainstack's Robinhood Chain RPC endpoints are available at [OpenChainBench: Robinhood Chain keyed RPC benchmark](https://openchainbench.com/benchmarks/keyed-rpc-robinhood).


### PR DESCRIPTION
Adds an OpenChainBench benchmark reference to the Robinhood Chain tooling page.