### PR TITLE
Document the Yellowstone Geyser gRPC endpoint form across every surface

### DIFF
--- a/docs/authentication-methods-for-different-scenarios.mdx
+++ b/docs/authentication-methods-for-different-scenarios.mdx
@@ -152,7 +152,7 @@ For protocols that support gRPC endpoints (such as [TRON](/docs/tron-tooling#grp
 
 Your gRPC credentials in the Chainstack console include:
 
-- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`. For Solana Geyser this is a dedicated endpoint on the node's **Add-ons** tab, not the node's RPC endpoint
+- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`. For Solana Geyser it is the separate endpoint shown under **Yellowstone gRPC** in the node's **Access and credentials** view, for example `yellowstone-solana-mainnet.core.chainstack.com`, which the console lists without a port
 - **x-token** — your authentication token
 
 Some clients want the scheme and some reject it: `@triton-one/yellowstone-grpc` (TypeScript) and the Rust Yellowstone client take `https://HOST:443`, while the Python `grpc` package, Go, and `grpcurl` take `HOST:443`. Check your client before assuming either form.

--- a/docs/authentication-methods-for-different-scenarios.mdx
+++ b/docs/authentication-methods-for-different-scenarios.mdx
@@ -152,8 +152,10 @@ For protocols that support gRPC endpoints (such as [TRON](/docs/tron-tooling#grp
 
 Your gRPC credentials in the Chainstack console include:
 
-- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`
+- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`. For Solana Geyser this is a dedicated endpoint on the node's **Add-ons** tab, not the node's RPC endpoint
 - **x-token** — your authentication token
+
+Some clients want the scheme and some reject it: `@triton-one/yellowstone-grpc` (TypeScript) and the Rust Yellowstone client take `https://HOST:443`, while the Python `grpc` package, Go, and `grpcurl` take `HOST:443`. Check your client before assuming either form.
 
 To authenticate gRPC requests, pass the x-token as metadata in your gRPC client:
 

--- a/docs/authentication-methods-for-different-scenarios.mdx
+++ b/docs/authentication-methods-for-different-scenarios.mdx
@@ -152,8 +152,8 @@ For protocols that support gRPC endpoints (such as [TRON](/docs/tron-tooling#grp
 
 Your gRPC credentials in the Chainstack console include:
 
-- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`. For Solana Geyser it is the separate endpoint shown under **Yellowstone gRPC** in the node's **Access and credentials** view, for example `yellowstone-solana-mainnet.core.chainstack.com`, which the console lists without a port
-- **x-token** — your authentication token
+- **gRPC endpoint** — the host and port, e.g., `tron-mainnet.core.chainstack.com:443` or `sui-mainnet.core.chainstack.com:443`. For Solana Geyser it is a separate endpoint listed under **Yellowstone gRPC**, and the console gives it as a bare hostname — append `:443` yourself, as in `yellowstone-solana-mainnet.core.chainstack.com:443`
+- **x-token** — your authentication token. This is the same value as the node's auth token, the one that appears as the last path segment of the HTTPS endpoint, so if you already have the RPC endpoint working you already have the x-token
 
 Some clients want the scheme and some reject it: `@triton-one/yellowstone-grpc` (TypeScript) and the Rust Yellowstone client take `https://HOST:443`, while the Python `grpc` package, Go, and `grpcurl` take `HOST:443`. Check your client before assuming either form.
 

--- a/docs/migrating-from-syndica-to-chainstack.mdx
+++ b/docs/migrating-from-syndica-to-chainstack.mdx
@@ -318,7 +318,7 @@ For more Yellowstone gRPC examples, see:
 ```javascript Node.js
 import Client, { CommitmentLevel } from "@triton-one/yellowstone-grpc";
 
-const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const ENDPOINT = "https://yellowstone-solana-mainnet.core.chainstack.com:443"; // From Access and credentials > Yellowstone gRPC; this client needs the https:// scheme
 const TOKEN = "YOUR_X_TOKEN";
 
 async function main() {

--- a/docs/migrating-from-syndica-to-chainstack.mdx
+++ b/docs/migrating-from-syndica-to-chainstack.mdx
@@ -318,8 +318,8 @@ For more Yellowstone gRPC examples, see:
 ```javascript Node.js
 import Client, { CommitmentLevel } from "@triton-one/yellowstone-grpc";
 
-const ENDPOINT = "CHAINSTACK_GEYSER_URL";
-const TOKEN = "CHAINSTACK_GEYSER_TOKEN";
+const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const TOKEN = "YOUR_X_TOKEN";
 
 async function main() {
   const client = new Client(ENDPOINT, TOKEN);

--- a/docs/solana-indexing-subscription-events-geyser.mdx
+++ b/docs/solana-indexing-subscription-events-geyser.mdx
@@ -202,7 +202,7 @@ import geyser_pb2
 import geyser_pb2_grpc
 from events import PROGRAM_ID, decode_event
 
-GRPC_ENDPOINT = "YOUR_NODE.core.chainstack.com:443"
+GRPC_ENDPOINT = "YOUR_GEYSER_HOSTNAME:443"  # From the node's Add-ons tab; grpc takes host:port with no scheme
 X_TOKEN = "YOUR_X_TOKEN"
 PROGRAM_ID_BYTES = bytes(Pubkey.from_string(PROGRAM_ID))
 

--- a/docs/solana-indexing-subscription-events-geyser.mdx
+++ b/docs/solana-indexing-subscription-events-geyser.mdx
@@ -202,7 +202,7 @@ import geyser_pb2
 import geyser_pb2_grpc
 from events import PROGRAM_ID, decode_event
 
-GRPC_ENDPOINT = "YOUR_GEYSER_HOSTNAME:443"  # From the node's Add-ons tab; grpc takes host:port with no scheme
+GRPC_ENDPOINT = "yellowstone-solana-mainnet.core.chainstack.com:443"  # From Access and credentials > Yellowstone gRPC; grpc takes host:port with no scheme
 X_TOKEN = "YOUR_X_TOKEN"
 PROGRAM_ID_BYTES = bytes(Pubkey.from_string(PROGRAM_ID))
 

--- a/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js.mdx
+++ b/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js.mdx
@@ -27,8 +27,8 @@ Once you have the Chainstack Yellowstone gRPC Geyser endpoint and the authentica
 ```js
 const { default: Client } = require("@triton-one/yellowstone-grpc");
 
-const ENDPOINT = "CHAINSTACK_GEYSER_URL"; // Replace with your actual endpoint
-const TOKEN = "CHAINSTACK_GEYSER_TOKEN"; // Replace with your actual token
+const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const TOKEN = "YOUR_X_TOKEN"; // The x-token from the same tab
 
 (async () => {
     const client = new Client(ENDPOINT, TOKEN);
@@ -47,8 +47,8 @@ Note the use of ping every 10 seconds to keep the connection alive as specified 
 const { default: Client } = require("@triton-one/yellowstone-grpc");
 const Base58 = require('bs58');
 
-const ENDPOINT = "CHAINSTACK_GEYSER_URL"; // Replace with your actual endpoint
-const TOKEN = "CHAINSTACK_GEYSER_TOKEN"; // Replace with your actual token
+const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const TOKEN = "YOUR_X_TOKEN"; // The x-token from the same tab
 const PING_INTERVAL_MILLISECONDS = 10000; // Send ping every 10 seconds
 
 // DEX Program IDs to watch

--- a/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js.mdx
+++ b/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js.mdx
@@ -27,7 +27,7 @@ Once you have the Chainstack Yellowstone gRPC Geyser endpoint and the authentica
 ```js
 const { default: Client } = require("@triton-one/yellowstone-grpc");
 
-const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const ENDPOINT = "https://yellowstone-solana-mainnet.core.chainstack.com:443"; // From Access and credentials > Yellowstone gRPC; this client needs the https:// scheme
 const TOKEN = "YOUR_X_TOKEN"; // The x-token from the same tab
 
 (async () => {
@@ -47,7 +47,7 @@ Note the use of ping every 10 seconds to keep the connection alive as specified 
 const { default: Client } = require("@triton-one/yellowstone-grpc");
 const Base58 = require('bs58');
 
-const ENDPOINT = "https://YOUR_GEYSER_HOSTNAME:443"; // From your node's Add-ons tab; this client needs the https:// scheme
+const ENDPOINT = "https://yellowstone-solana-mainnet.core.chainstack.com:443"; // From Access and credentials > Yellowstone gRPC; this client needs the https:// scheme
 const TOKEN = "YOUR_X_TOKEN"; // The x-token from the same tab
 const PING_INTERVAL_MILLISECONDS = 10000; // Send ping every 10 seconds
 

--- a/docs/solana-listening-to-pumpfun-token-mint-using-geyser.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-geyser.mdx
@@ -28,8 +28,8 @@ To switch to Geyser in the pump.fun V2 repo:
 
 1. Set `LISTENER_TYPE="geyser"` in `src/config.py`
 2. Add the following to your .env file:
-   - `GEYSER_ENDPOINT`
-   - `GEYSER_API_TOKEN`
+   - `GEYSER_ENDPOINT` — the Geyser endpoint from your node's **Add-ons** tab, as `YOUR_GEYSER_HOSTNAME:443`. The bot uses the Python `grpc` package, which takes the host and port with no scheme
+   - `GEYSER_API_TOKEN` — the x-token from the same tab
 
 <Signup />
 

--- a/docs/solana-listening-to-pumpfun-token-mint-using-geyser.mdx
+++ b/docs/solana-listening-to-pumpfun-token-mint-using-geyser.mdx
@@ -28,7 +28,7 @@ To switch to Geyser in the pump.fun V2 repo:
 
 1. Set `LISTENER_TYPE="geyser"` in `src/config.py`
 2. Add the following to your .env file:
-   - `GEYSER_ENDPOINT` — the Geyser endpoint from your node's **Add-ons** tab, as `YOUR_GEYSER_HOSTNAME:443`. The bot uses the Python `grpc` package, which takes the host and port with no scheme
+   - `GEYSER_ENDPOINT` — the gRPC endpoint from **Access and credentials** > **Yellowstone gRPC**, with the port added, as `yellowstone-solana-mainnet.core.chainstack.com:443`. The bot uses the Python `grpc` package, which takes the host and port with no scheme
    - `GEYSER_API_TOKEN` — the x-token from the same tab
 
 <Signup />

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -72,9 +72,9 @@ where `YOUR_CHAINSTACK_ENDPOINT` is your node HTTPS endpoint. See [node access d
 
 ## gRPC: Yellowstone Geyser
 
-Real-time streaming runs over gRPC through the [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin), a paid add-on you install on the node. Its endpoint is separate from the node's RPC endpoint, listens on port `443` with TLS, and authenticates with the token in the `x-token` metadata header rather than in the URL.
+Real-time streaming runs over gRPC through the [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin), a paid add-on you install on the node. Its endpoint appears under **Yellowstone gRPC** in the node's **Access and credentials** view, separate from the HTTPS and WSS endpoints. The console lists it as a bare hostname; it listens on port `443` with TLS and authenticates with the token in the `x-token` metadata header rather than in the URL.
 
-The endpoint form depends on the client: `@triton-one/yellowstone-grpc` (TypeScript) and `yellowstone-grpc-client` (Rust) need the scheme, as in `https://YOUR_GEYSER_HOSTNAME:443`, while the Python `grpc` package, Go, and `grpcurl` take `YOUR_GEYSER_HOSTNAME:443` with no scheme. See [Connect to your endpoint](/docs/yellowstone-grpc-geyser-plugin#connect-to-your-endpoint) for per-client examples, and [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token) for the authentication details.
+The endpoint form depends on the client: `@triton-one/yellowstone-grpc` (TypeScript) and `yellowstone-grpc-client` (Rust) need the scheme, as in `https://yellowstone-solana-mainnet.core.chainstack.com:443`, while the Python `grpc` package, Go, and `grpcurl` take `yellowstone-solana-mainnet.core.chainstack.com:443` with no scheme. See [Connect to your endpoint](/docs/yellowstone-grpc-geyser-plugin#connect-to-your-endpoint) for per-client examples, and [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token) for the authentication details.
 
 ## JavaScript and TypeScript: @solana/kit
 

--- a/docs/solana-tooling.mdx
+++ b/docs/solana-tooling.mdx
@@ -70,6 +70,12 @@ curl -H "Content-Type: application/json" \
 
 where `YOUR_CHAINSTACK_ENDPOINT` is your node HTTPS endpoint. See [node access details](/docs/manage-your-node#view-node-access-and-credentials).
 
+## gRPC: Yellowstone Geyser
+
+Real-time streaming runs over gRPC through the [Yellowstone gRPC Geyser plugin](/docs/yellowstone-grpc-geyser-plugin), a paid add-on you install on the node. Its endpoint is separate from the node's RPC endpoint, listens on port `443` with TLS, and authenticates with the token in the `x-token` metadata header rather than in the URL.
+
+The endpoint form depends on the client: `@triton-one/yellowstone-grpc` (TypeScript) and `yellowstone-grpc-client` (Rust) need the scheme, as in `https://YOUR_GEYSER_HOSTNAME:443`, while the Python `grpc` package, Go, and `grpcurl` take `YOUR_GEYSER_HOSTNAME:443` with no scheme. See [Connect to your endpoint](/docs/yellowstone-grpc-geyser-plugin#connect-to-your-endpoint) for per-client examples, and [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token) for the authentication details.
+
 ## JavaScript and TypeScript: @solana/kit
 
 [`@solana/kit`](https://github.com/anza-xyz/kit) is the modern Solana JavaScript SDK — a tree-shakeable, functional API that replaces the class-based `@solana/web3.js` v1. It is the direct successor to what briefly shipped as `@solana/web3.js@2.x`.

--- a/docs/yellowstone-grpc-geyser-plugin.mdx
+++ b/docs/yellowstone-grpc-geyser-plugin.mdx
@@ -57,14 +57,14 @@ For arbitrary historical data beyond the buffer, use the standard JSON-RPC metho
 
 ## Connect to your endpoint
 
-Once the add-on is installed, the node's **Add-ons** tab shows two values: the Geyser endpoint host and the x-token. The endpoint is separate from the node's regular RPC endpoint, and the token is passed as metadata rather than in the URL — see [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token).
+Once the add-on is installed, the node's **Access and credentials** view gains a **Yellowstone gRPC** section with the gRPC endpoint and the x-token. This endpoint is separate from the node's HTTPS and WSS endpoints, and the token travels in request metadata rather than in the URL — see [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token).
 
-The Geyser endpoint listens on port **443** with TLS. How you write it depends on your client:
+The console shows the endpoint as a bare hostname, for example `yellowstone-solana-mainnet.core.chainstack.com`. Add the port yourself: Geyser listens on **443** with TLS. Whether you also add a scheme depends on your client:
 
 | Client | Endpoint form |
 | --- | --- |
-| `@triton-one/yellowstone-grpc` (TypeScript), `yellowstone-grpc-client` (Rust) | `https://YOUR_GEYSER_HOSTNAME:443` — the scheme is required |
-| `grpc` (Python), `grpc-go` (Go), `grpcurl` | `YOUR_GEYSER_HOSTNAME:443` — host and port only, no scheme |
+| `@triton-one/yellowstone-grpc` (TypeScript), `yellowstone-grpc-client` (Rust) | `https://yellowstone-solana-mainnet.core.chainstack.com:443` — the scheme is required |
+| `grpc` (Python), `grpc-go` (Go), `grpcurl` | `yellowstone-solana-mainnet.core.chainstack.com:443` — host and port only, no scheme |
 
 The two forms are not interchangeable. A TypeScript or Rust client given a bare host fails to connect, and a Python or Go client given a scheme fails to resolve it.
 
@@ -72,7 +72,7 @@ The two forms are not interchangeable. A TypeScript or Rust client given a bare 
 ```js Node.js
 const { default: Client } = require("@triton-one/yellowstone-grpc");
 
-const client = new Client("https://YOUR_GEYSER_HOSTNAME:443", "YOUR_X_TOKEN");
+const client = new Client("https://yellowstone-solana-mainnet.core.chainstack.com:443", "YOUR_X_TOKEN");
 console.log(await client.getVersion());
 ```
 
@@ -83,7 +83,7 @@ auth = grpc.metadata_call_credentials(
     lambda ctx, cb: cb((("x-token", "YOUR_X_TOKEN"),), None)
 )
 creds = grpc.composite_channel_credentials(grpc.ssl_channel_credentials(), auth)
-channel = grpc.aio.secure_channel("YOUR_GEYSER_HOSTNAME:443", creds)
+channel = grpc.aio.secure_channel("yellowstone-solana-mainnet.core.chainstack.com:443", creds)
 ```
 </CodeGroup>
 

--- a/docs/yellowstone-grpc-geyser-plugin.mdx
+++ b/docs/yellowstone-grpc-geyser-plugin.mdx
@@ -55,6 +55,40 @@ For arbitrary historical data beyond the buffer, use the standard JSON-RPC metho
 
 3. Click **Add-ons** > **Yellowstone gRPC Geyser Plugin** > **Install**.
 
+## Connect to your endpoint
+
+Once the add-on is installed, the node's **Add-ons** tab shows two values: the Geyser endpoint host and the x-token. The endpoint is separate from the node's regular RPC endpoint, and the token is passed as metadata rather than in the URL — see [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token).
+
+The Geyser endpoint listens on port **443** with TLS. How you write it depends on your client:
+
+| Client | Endpoint form |
+| --- | --- |
+| `@triton-one/yellowstone-grpc` (TypeScript), `yellowstone-grpc-client` (Rust) | `https://YOUR_GEYSER_HOSTNAME:443` — the scheme is required |
+| `grpc` (Python), `grpc-go` (Go), `grpcurl` | `YOUR_GEYSER_HOSTNAME:443` — host and port only, no scheme |
+
+The two forms are not interchangeable. A TypeScript or Rust client given a bare host fails to connect, and a Python or Go client given a scheme fails to resolve it.
+
+<CodeGroup>
+```js Node.js
+const { default: Client } = require("@triton-one/yellowstone-grpc");
+
+const client = new Client("https://YOUR_GEYSER_HOSTNAME:443", "YOUR_X_TOKEN");
+console.log(await client.getVersion());
+```
+
+```python Python
+import grpc
+
+auth = grpc.metadata_call_credentials(
+    lambda ctx, cb: cb((("x-token", "YOUR_X_TOKEN"),), None)
+)
+creds = grpc.composite_channel_credentials(grpc.ssl_channel_credentials(), auth)
+channel = grpc.aio.secure_channel("YOUR_GEYSER_HOSTNAME:443", creds)
+```
+</CodeGroup>
+
+For full working examples, see [Listening to programs using Geyser and Yellowstone gRPC (Node.js)](/docs/solana-listening-to-programs-using-geyser-and-yellowstone-grpc-node-js) and [Solana: transactions and block time with Yellowstone gRPC](/docs/solana-transactions-block-time-yellowstone-grpc).
+
 ## Limits
 
 $49/month:

--- a/docs/yellowstone-grpc-geyser-plugin.mdx
+++ b/docs/yellowstone-grpc-geyser-plugin.mdx
@@ -57,7 +57,7 @@ For arbitrary historical data beyond the buffer, use the standard JSON-RPC metho
 
 ## Connect to your endpoint
 
-Once the add-on is installed, the node's **Access and credentials** view gains a **Yellowstone gRPC** section with the gRPC endpoint and the x-token. This endpoint is separate from the node's HTTPS and WSS endpoints, and the token travels in request metadata rather than in the URL — see [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token).
+Once the add-on is installed, the node's **Access and credentials** view gains a **Yellowstone gRPC** section with the gRPC endpoint and the x-token. This endpoint is separate from the node's HTTPS and WSS endpoints, and the token travels in request metadata rather than in the URL — see [gRPC access via x-token](/docs/authentication-methods-for-different-scenarios#grpc-access-via-x-token). The x-token is the same value as the node's auth token, so if your RPC endpoint already works you already have it.
 
 The console shows the endpoint as a bare hostname, for example `yellowstone-solana-mainnet.core.chainstack.com`. Add the port yourself: Geyser listens on **443** with TLS. Whether you also add a scheme depends on your client:
 


### PR DESCRIPTION
A user on the Yellowstone gRPC add-on reported that the console shows the endpoint as a bare hostname with no scheme or port, and that they could not find a complete example URL in the docs — so they guessed `https://` and `:443`. This makes the endpoint form explicit everywhere it is relevant.

## What was actually missing

Some of this was documented, but not where anyone would find it and not in every form:

- `yellowstone-grpc-geyser-plugin.mdx`, the page you land on for the add-on, ended its setup at **Install** with nothing about connecting, and linked to neither the authentication page nor the tutorial that carries a real endpoint.
- The `https://HOST:443` form appeared nowhere. Every published example was a bare `HOST:443`, which is correct for Python, Go, and grpcurl — and fails with `@triton-one/yellowstone-grpc` and the Rust client, which require the scheme. The TypeScript client's own default endpoint is `http://localhost:10000` and upstream examples pass `https://api.rpcpool.com`, so the scheme is not optional there.
- Two Node.js samples used an opaque `CHAINSTACK_GEYSER_URL` placeholder, exactly where a reader needs the shape.
- The port was never stated alongside the hostname the console gives you, which is the specific step the user had to guess.

## Changes

- **`yellowstone-grpc-geyser-plugin.mdx`** — new **Connect to your endpoint** section: the endpoint and x-token live under **Yellowstone gRPC** in the node's **Access and credentials** view, the endpoint is separate from the node's HTTPS and WSS endpoints, the console lists it without a port, Geyser listens on 443 with TLS, a per-client table of the two endpoint forms with a note that they are not interchangeable, Node.js and Python snippets, and links to the authentication page and the working tutorials.
- **`solana-tooling.mdx`** — new **gRPC: Yellowstone Geyser** section, following how `sui-tooling.mdx` states its gRPC endpoint and auth inline.
- **`authentication-methods-for-different-scenarios.mdx`** — the gRPC endpoint bullet now covers the Solana Geyser case and states which clients want the scheme and which reject it.
- **Node.js Geyser tutorial** and **Syndica migration guide** — `CHAINSTACK_GEYSER_URL` replaced with the complete `https://HOST:443` endpoint and a comment on where it comes from.
- **pump.fun Geyser tutorial** — `GEYSER_ENDPOINT` and `GEYSER_API_TOKEN` now say what shape each takes and where they come from.
- **Python indexing tutorial** — `YOUR_NODE.core.chainstack.com:443` replaced with the real Geyser host, because the old placeholder implied the Geyser host is derived from the node's RPC host.

Examples use `yellowstone-solana-mainnet.core.chainstack.com`, the shared per-network host the console shows, so they are copy-pasteable with only the x-token to fill in.

All touched pages were checked in a local build; both new cross-link anchors resolve.
