### PR TITLE
docs(changelog): TON Toncenter API v4 on TON nodes (September 4, 2026)

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,13 @@ rss: true
 
 import { Button } from '/snippets/button.mdx';
 
+<Update label="Chainstack updates: September 4, 2026" description=" by Ake">
+
+**Protocols**. Chainstack TON nodes now serve the Toncenter API v4 — REST and WebSocket — alongside v2 and v3 on the same endpoint and API key, on Mainnet and Testnet. v4 adds richer typed responses, block-pinned cacheable URLs, and real-time block and account subscriptions over WebSocket.
+
+<Button href="/changelog/chainstack-updates-september-4-2026">Read more</Button>
+</Update>
+
 <Update label="Chainstack updates: September 2, 2026" description=" by Ake">
 
 **Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.24.0](https://github.com/equilibriumco/pathfinder/releases/tag/v0.24.0), which adds support for Starknet 0.14.4. Pathfinder 0.24.0 upstream requires WebSocket clients to answer server-initiated pings, but on Chainstack this needs no action from you — your endpoint keeps the connection alive on your behalf. The fallback path used by `starknet_traceTransaction` and `starknet_traceBlockTransactions` is now bounded at 30 seconds.

--- a/changelog/chainstack-updates-september-4-2026.mdx
+++ b/changelog/chainstack-updates-september-4-2026.mdx
@@ -1,0 +1,6 @@
+---
+title: "Chainstack updates: September 4, 2026"
+description: "Chainstack TON nodes now serve the Toncenter API v4 — REST and WebSocket — alongside v2 and v3 on the same endpoint and API key, on Mainnet and Testnet."
+---
+
+**Protocols**. Chainstack TON nodes now serve the Toncenter API v4 — REST and WebSocket — alongside v2 and v3 on the same endpoint and API key, on Mainnet and Testnet. v4 adds richer typed responses, block-pinned cacheable URLs, and real-time block and account subscriptions over WebSocket.

--- a/docs.json
+++ b/docs.json
@@ -3746,6 +3746,7 @@
             "tab": "Release notes",
             "pages": [
               "changelog",
+              "changelog/chainstack-updates-september-4-2026",
               "changelog/chainstack-updates-september-2-2026",
               "changelog/chainstack-updates-august-20-2026",
               "changelog/chainstack-updates-august-7-2026",


### PR DESCRIPTION
## What

Adds the **September 4, 2026** Cloud release note announcing **Toncenter API v4** on Chainstack TON nodes.

> **Protocols**. Chainstack TON nodes now serve the Toncenter API v4 — REST and WebSocket — alongside v2 and v3 on the same endpoint and API key, on Mainnet and Testnet. v4 adds richer typed responses, block-pinned cacheable URLs, and real-time block and account subscriptions over WebSocket.

TON v4 is served on the same node, hostname, and API key as the existing v2 and v3 endpoints; v2/v3 are unchanged. Live-verified on both Mainnet and Testnet.

## Changes

- `changelog.mdx` — new `<Update>` entry at the top.
- `changelog/chainstack-updates-september-4-2026.mdx` — standalone release note page.
- `docs.json` — page added to the Release notes tab.

## Local validation

- `docs.json` — valid JSON.
- `mintlify broken-links` — no new broken links.