### PR TITLE
Date the Starknet Pathfinder 0.24.0 release note to the actual rollout day

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -13,11 +13,11 @@ import { Button } from '/snippets/button.mdx';
 <Button href="/changelog/chainstack-updates-september-4-2026">Read more</Button>
 </Update>
 
-<Update label="Chainstack updates: September 2, 2026" description=" by Ake">
+<Update label="Chainstack updates: September 3, 2026" description=" by Ake">
 
-**Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.24.0](https://github.com/equilibriumco/pathfinder/releases/tag/v0.24.0), which adds support for Starknet 0.14.4. Pathfinder 0.24.0 upstream requires WebSocket clients to answer server-initiated pings, but on Chainstack this needs no action from you — your endpoint keeps the connection alive on your behalf. The fallback path used by `starknet_traceTransaction` and `starknet_traceBlockTransactions` is now bounded at 30 seconds.
+**Starknet**. Chainstack upgraded Starknet nodes to [Pathfinder v0.24.0](https://github.com/equilibriumco/pathfinder/releases/tag/v0.24.0), which adds support for Starknet 0.14.4. Pathfinder 0.24.0 upstream requires WebSocket clients to answer server-initiated pings, but on Chainstack this needs no action from you — your endpoint keeps the connection alive on your behalf. The fallback path used by `starknet_traceTransaction` and `starknet_traceBlockTransactions` is now bounded at 30 seconds.
 
-<Button href="/changelog/chainstack-updates-september-2-2026">Read more</Button>
+<Button href="/changelog/chainstack-updates-september-3-2026">Read more</Button>
 </Update>
 
 <Update label="Chainstack updates: August 20, 2026" description=" by Ake">
@@ -68,7 +68,7 @@ import { Button } from '/snippets/button.mdx';
 
 <Update label="Chainstack updates: July 21, 2026" description=" by Ake">
 
-**Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — a breaking change to JSON-RPC API version support: versions 0.6, 0.7, and 0.8 are removed, and the default `/` endpoint now serves version 0.9. Pin `/rpc/v0_9` or `/rpc/v0_10` before the upgrade reaches your node.
+**Starknet**. Chainstack upgraded Starknet nodes to [Pathfinder v0.23.0](https://github.com/eqlabs/pathfinder/releases/tag/v0.23.0) — a breaking change to JSON-RPC API version support: versions 0.6, 0.7, and 0.8 are removed, and the default `/` endpoint now serves version 0.9. Pin `/rpc/v0_9` or `/rpc/v0_10` before the upgrade reaches your node.
 
 <Button href="/changelog/chainstack-updates-july-21-2026">Read more</Button>
 </Update>

--- a/changelog/chainstack-updates-september-3-2026.mdx
+++ b/changelog/chainstack-updates-september-3-2026.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Chainstack updates: September 2, 2026"
-description: "Starknet nodes are upgrading to Pathfinder v0.24.0, adding Starknet 0.14.4 support. WebSocket clients need no changes."
+title: "Chainstack updates: September 3, 2026"
+description: "Starknet nodes are upgraded to Pathfinder v0.24.0, adding Starknet 0.14.4 support. WebSocket clients need no changes."
 ---
 
-**Starknet**. Chainstack is upgrading Starknet nodes to [Pathfinder v0.24.0](https://github.com/equilibriumco/pathfinder/releases/tag/v0.24.0), which adds support for Starknet 0.14.4.
+**Starknet**. Chainstack upgraded Starknet nodes to [Pathfinder v0.24.0](https://github.com/equilibriumco/pathfinder/releases/tag/v0.24.0), which adds support for Starknet 0.14.4. The upgrade is rolled out on Mainnet and Sepolia.
 
 Pathfinder 0.24.0 upstream requires WebSocket clients to answer server-initiated pings. **On Chainstack this needs no action from you.** Your endpoint keeps the WebSocket connection alive on your behalf, so the upstream change does not reach your client and your existing subscriptions are unaffected.
 

--- a/changelog/llms.txt
+++ b/changelog/llms.txt
@@ -4,7 +4,8 @@
 
 ## Pages
 - [Chainstack Cloud release notes and product updates](/changelog.md)
-- [Chainstack updates: September 2, 2026](/changelog/chainstack-updates-september-2-2026.md)
+- [Chainstack updates: September 4, 2026](/changelog/chainstack-updates-september-4-2026.md)
+- [Chainstack updates: September 3, 2026](/changelog/chainstack-updates-september-3-2026.md)
 - [Chainstack updates: August 20, 2026](/changelog/chainstack-updates-august-20-2026.md)
 - [Chainstack updates: August 7, 2026](/changelog/chainstack-updates-august-7-2026.md)
 - [Chainstack updates: August 4, 2026](/changelog/chainstack-updates-august-4-2026.md)

--- a/docs.json
+++ b/docs.json
@@ -599,6 +599,11 @@
       "source": "/docs/etherlink-introduction",
       "destination": "/docs/protocols-networks",
       "permanent": true
+    },
+    {
+      "source": "/changelog/chainstack-updates-september-2-2026",
+      "destination": "/changelog/chainstack-updates-september-3-2026",
+      "permanent": true
     }
   ],
   "api": {
@@ -3747,7 +3752,7 @@
             "pages": [
               "changelog",
               "changelog/chainstack-updates-september-4-2026",
-              "changelog/chainstack-updates-september-2-2026",
+              "changelog/chainstack-updates-september-3-2026",
               "changelog/chainstack-updates-august-20-2026",
               "changelog/chainstack-updates-august-7-2026",
               "changelog/chainstack-updates-august-4-2026",


### PR DESCRIPTION
The Pathfinder 0.24.0 upgrade rolled out on September 3, but the release note was dated September 2 and written as "Chainstack is upgrading" — the docs were prepared ahead of the rollout and the date was a placeholder for it.

The rollout is confirmed complete on Mainnet and Sepolia: `pathfinder_version` returns `v0.24.0` where it previously returned `v0.23.1`, and the served spec versions are unchanged at 0.9.0 on the default path and 0.10.3-rc.0 on `/rpc/v0_10`, as the note states.

- Entry renamed to `chainstack-updates-september-3-2026`, with the title, description, and body moved to past tense and a line naming the networks.
- `changelog.mdx` label, body, and Read more button updated to match.
- `docs.json` navigation entry updated, plus a permanent redirect from the September 2 URL, which was live for two days.
- `changelog/llms.txt` regenerated.