### PR TITLE
Document how node type changes RU billing

### DIFF
--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -18,19 +18,17 @@ See current service pricing on the [pricing page](https://chainstack.com/pricing
 
 ## How your node type affects this
 
-The classification rules on this page decide the cost of each request individually — but only on node types that meter requests that way. Your node type decides whether they apply at all.
+Node type decides whether requests are classified one by one or billed at a fixed class. Global Nodes classify each request; Trader Nodes bill every request according to the node's mode; Dedicated Nodes and the Unlimited Node add-on do not meter requests.
 
-| Node type | How requests are billed |
+| Node type | Billing |
 | --- | --- |
-| [Global Node](/docs/global-elastic-node) | Each request is classified on its own by the rules below — full is 1 RU, archive is 2 RUs |
-| [Trader Node](/docs/trader-node), full mode | Everything the node serves is a full request, so every request is 1 RU |
-| [Trader Node](/docs/trader-node), archive mode | **Every request is billed as archive, 2 RUs**, whatever the method or the block age. The per-request rules below do not apply |
-| [Dedicated Node](/docs/dedicated-node) | Not metered per request — you pay for the node's compute and storage monthly |
-| [Unlimited Node](/docs/unlimited-node) add-on | Not metered per request — a flat monthly fee tied to an RPS tier |
+| [Global Node](/docs/global-elastic-node) | Each request is classified on its own. Full requests are 1 RU and archive requests are 2 RUs, by the per-protocol rules on this page. Debug and trace requests are 2 RUs. |
+| [Trader Node](/docs/trader-node), full mode | Every request is 1 RU, including debug and trace methods where the node offers them. Archive requests are not served: a state query for a block outside the node's retained window returns `-32000` with the message `missing trie node`. See [EVM node returns "Missing trie node"](/docs/evm-node-returns-missing-trie-node). |
+| [Trader Node](/docs/trader-node), archive mode | Every request is 2 RUs, including requests for the latest block, requests with no block parameter, and each WebSocket subscription notification. The per-protocol full-versus-archive rules do not apply. |
+| [Dedicated Node](/docs/dedicated-node) | Not metered per request. Billed monthly for the node's compute and storage. |
+| [Unlimited Node](/docs/unlimited-node) add-on | Not metered per request. A flat monthly fee tied to an RPS tier. |
 
-The archive Trader Node case is the one that surprises people. On an archive Trader Node, `eth_blockNumber` and a `latest` block query cost 2 RUs each, the same as a call reaching back to genesis, because the node is archive rather than because the request is.
-
-A full-mode Trader Node cannot serve an archive request at all. A state query for a block outside the node's window returns `-32000` with `missing trie node` — see [EVM node returns "Missing trie node"](/docs/evm-node-returns-missing-trie-node).
+The archive Trader Node rule applies on every protocol that offers Trader Nodes in archive mode, including protocols with their own full-versus-archive boundaries such as Aptos. Which regions offer each mode is listed in [Available clouds, regions, and locations](/docs/nodes-clouds-regions-and-locations).
 
 ## Full vs archive by protocol
 
@@ -49,7 +47,7 @@ For each protocol, here's what counts as a **full request (1 RU)** and what coun
 
 ## Always 2 RUs
 
-These EVM methods are billed at 2 RUs regardless of block age:
+On Global Nodes and archive Trader Nodes, these EVM methods are billed at 2 RUs regardless of block age. On a full Trader Node every request is 1 RU, including these methods.
 
 - All `debug_*`, `trace_*`, and `arbtrace_*` methods — including `debug_traceTransaction`, `debug_traceBlockByNumber`, and `trace_block`.
 - `eth_callMany`

--- a/docs/request-units.mdx
+++ b/docs/request-units.mdx
@@ -5,7 +5,7 @@ description: How Chainstack bills full and archive requests across all supported
 
 ## What an RU is
 
-A request unit (RU) is the metric Chainstack uses to measure each request against our request-based services. Different requests consume different resources, so pricing is tied to RUs rather than raw call counts.
+A request unit (RU) is the metric Chainstack uses to measure each request against our request-based services. Different requests consume different resources, so pricing is tied to RUs rather than raw call counts. What counts as a full or an archive request depends on your node type as well as the request itself — see [How your node type affects this](#how-your-node-type-affects-this).
 
 See current service pricing on the [pricing page](https://chainstack.com/pricing/).
 
@@ -15,6 +15,22 @@ See current service pricing on the [pricing page](https://chainstack.com/pricing
 | --- | --- |
 | Full | 1 RU |
 | Archive | 2 RUs |
+
+## How your node type affects this
+
+The classification rules on this page decide the cost of each request individually — but only on node types that meter requests that way. Your node type decides whether they apply at all.
+
+| Node type | How requests are billed |
+| --- | --- |
+| [Global Node](/docs/global-elastic-node) | Each request is classified on its own by the rules below — full is 1 RU, archive is 2 RUs |
+| [Trader Node](/docs/trader-node), full mode | Everything the node serves is a full request, so every request is 1 RU |
+| [Trader Node](/docs/trader-node), archive mode | **Every request is billed as archive, 2 RUs**, whatever the method or the block age. The per-request rules below do not apply |
+| [Dedicated Node](/docs/dedicated-node) | Not metered per request — you pay for the node's compute and storage monthly |
+| [Unlimited Node](/docs/unlimited-node) add-on | Not metered per request — a flat monthly fee tied to an RPS tier |
+
+The archive Trader Node case is the one that surprises people. On an archive Trader Node, `eth_blockNumber` and a `latest` block query cost 2 RUs each, the same as a call reaching back to genesis, because the node is archive rather than because the request is.
+
+A full-mode Trader Node cannot serve an archive request at all. A state query for a block outside the node's window returns `-32000` with `missing trie node` — see [EVM node returns "Missing trie node"](/docs/evm-node-returns-missing-trie-node).
 
 ## Full vs archive by protocol
 

--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -20,7 +20,7 @@ For Trader Nodes deployed on the most of public chains, Chainstack supports the 
 * Full — a node that stores full blockchain data. However, it has limitations to how many blocks are available for querying.
 * Archive — a node that stores full blockchain data and an archive of historical states, which makes it possible to query any block since the chain genesis.
 
-The mode you pick also decides how the node bills. On a full-mode Trader Node every request is a full request at 1 RU. On an archive-mode Trader Node **every request is billed as archive at 2 RUs**, regardless of the method or how recent the block is — unlike a [Global Node](/docs/global-elastic-node), where each request is classified on its own. See [How your node type affects this](/docs/request-units#how-your-node-type-affects-this).
+The mode also sets the billing class for every request on the node. A full-mode Trader Node bills every request at 1 RU. An archive-mode Trader Node bills every request at 2 RUs, regardless of the method or the block requested, including each WebSocket subscription notification. See [How your node type affects this](/docs/request-units#how-your-node-type-affects-this).
 
 ## Mode and mempool availability by region
 

--- a/docs/trader-node.mdx
+++ b/docs/trader-node.mdx
@@ -20,6 +20,8 @@ For Trader Nodes deployed on the most of public chains, Chainstack supports the 
 * Full — a node that stores full blockchain data. However, it has limitations to how many blocks are available for querying.
 * Archive — a node that stores full blockchain data and an archive of historical states, which makes it possible to query any block since the chain genesis.
 
+The mode you pick also decides how the node bills. On a full-mode Trader Node every request is a full request at 1 RU. On an archive-mode Trader Node **every request is billed as archive at 2 RUs**, regardless of the method or how recent the block is — unlike a [Global Node](/docs/global-elastic-node), where each request is classified on its own. See [How your node type affects this](/docs/request-units#how-your-node-type-affects-this).
+
 ## Mode and mempool availability by region
 
 Trader Nodes are bound to a single region, and the modes on offer differ from region to region. Because the `txpool_*` methods need the archive mode, a region that offers only the full mode gives you no pool inspection — though subscribing to pending transactions still works there. On Ethereum Mainnet, for example, Trader Nodes are archive in London (lon1) and Ashburn (ash1), and full mode only in Singapore (sgp1).


### PR DESCRIPTION
`request-units` classified every request individually and never mentioned node type. That is correct for Global Nodes and wrong for Trader Nodes, where the node's mode sets the billing class for every request.

This came up when a user asked why every request on an archive Ethereum Trader Node bills 2 RUs, including non-archival ones. An answer generated from this page said that was not expected, because the page did not contain the rule.

## The rules

- **Global Node** — each request is classified on its own: full 1 RU, archive 2 RUs, debug and trace 2 RUs.
- **Trader Node, full mode** — every request is 1 RU, including debug and trace methods where offered. Archive requests are not served: a state query outside the retained window returns `-32000` with `missing trie node`.
- **Trader Node, archive mode** — every request is 2 RUs, including latest-block requests, requests with no block parameter, and each WebSocket subscription notification. This holds on every protocol that offers archive Trader Nodes, Aptos included.
- **Dedicated Node** and the **Unlimited Node** add-on — not metered per request.

Each rule was verified against the request classification and billing implementation and against the deployment configuration of every Trader Node region, rather than taken from discussion.

## Changes

- `request-units.mdx` — new **How your node type affects this** section with the table above, placed before the per-protocol classification it qualifies, plus a pointer in the opening paragraph. The debug and trace section is scoped to Global Nodes and archive Trader Nodes.
- `trader-node.mdx` — the billing consequence stated under **Modes**, where the choice between full and archive is made.
